### PR TITLE
Method calls and membership evaluation should be done on all factors

### DIFF
--- a/src/jsparse.c
+++ b/src/jsparse.c
@@ -933,7 +933,7 @@ JsVar *jspeFactorIdPostfix(JsVar *a) {
 }
 
 JsVar *jspeFactorId() {
-  return jspeFactorIdPostfix(jspeFactorSingleId());
+  return jspeFactorSingleId();
 }
 
 
@@ -1208,7 +1208,7 @@ JsVar *jspeFactor() {
         return jspeFactorArray();
     } else if (execInfo.lex->tk==LEX_R_FUNCTION) {
       JSP_MATCH(LEX_R_FUNCTION);
-      return jspeFactorIdPostfix(jspeFunctionDefinition());
+      return jspeFunctionDefinition();
     } else  if (execInfo.lex->tk==LEX_R_NEW) {
       return jspeFactorNew();
     } else if (execInfo.lex->tk==LEX_R_TYPEOF) {
@@ -1242,7 +1242,7 @@ __attribute((noinline)) JsVar *__jspePostfix(JsVar *a) {
 }
 
 JsVar *jspePostfix() {
-  return __jspePostfix(jspeFactor());
+  return __jspePostfix(jspeFactorIdPostfix(jspeFactor()));
 }
 
 JsVar *jspeUnary() {


### PR DESCRIPTION
Currently, only Id factors are checked for method calls and de-referenced for members.

Anonymous variables should also be de-referenced. For example, this is entirely legal (and useful):

[1,2,3].map(function(x) { return x + 1; });
"abc".length
