### PR TITLE
Terminal cleanup on running multiple tests

### DIFF
--- a/targets/linux/jshardware.c
+++ b/targets/linux/jshardware.c
@@ -115,6 +115,7 @@ IOEventFlags pinToEVEXTI(Pin pin) {
 // ----------------------------------------------------------------------------
 // for non-blocking IO
 struct termios orig_termios;
+static int terminal_set;
 
 void reset_terminal_mode()
 {
@@ -157,16 +158,19 @@ int getch()
 }
 
 void jshInit() {
-  struct termios new_termios;
+  if (!terminal_set) {
+    struct termios new_termios;
 
-  /* take two copies - one for now, one for later */
-  tcgetattr(0, &orig_termios);
-  memcpy(&new_termios, &orig_termios, sizeof(new_termios));
+    /* take two copies - one for now, one for later */
+    tcgetattr(0, &orig_termios);
+    memcpy(&new_termios, &orig_termios, sizeof(new_termios));
 
-  /* register cleanup handler, and set the new terminal mode */
-  atexit(reset_terminal_mode);
-  cfmakeraw(&new_termios);
-  tcsetattr(0, TCSANOW, &new_termios);
+    /* register cleanup handler, and set the new terminal mode */
+    atexit(reset_terminal_mode);
+    cfmakeraw(&new_termios);
+    tcsetattr(0, TCSANOW, &new_termios);
+    terminal_set = 1;
+  }
 
 #ifdef SYSFS_GPIO_DIR
   int i;


### PR DESCRIPTION
A minor annoyance. When running all tests, the terminal original settings are overridden.
