### PR TITLE
Travis-CI intergration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 before_install:
+ - sudo apt-get update
+ - sudo apt-get install libsdl1.2-dev
 before_script:
 compiler:
   - gcc


### PR DESCRIPTION
CI is obviously useful for validating build / test integrity.
This commit adds integration with travis-ci.org.
Only Linux compilation at this point.

The repository needs to be enabled in travis-ci.org (See http://about.travis-ci.org/docs/user/getting-started/)
