### PR TITLE
Constructors fix - explicit value casting of boolean value

### DIFF
--- a/src/jsparse.c
+++ b/src/jsparse.c
@@ -934,7 +934,7 @@ JsVar *jspeFactorFunctionCall() {
   JsVar *parent = 0, *a;
 
   a = jspeFactorNew();
-  bool isConstruct = execInfo.execute & EXEC_CONSTRUCT;
+  bool isConstruct = (execInfo.execute & EXEC_CONSTRUCT) ? true : false;
   execInfo.execute &= (JsExecFlags)~EXEC_CONSTRUCT;
 
   while (execInfo.lex->tk=='(') {


### PR DESCRIPTION
This should address issue #97.

I expected bool to provide true/false casting... but bool is wicked :) (https://lkml.org/lkml/2013/8/31/138)
