### PR TITLE
Fix gh-177. OctalIntegerLiteral support

### DIFF
--- a/src/jslex.c
+++ b/src/jslex.c
@@ -134,8 +134,10 @@ void jslGetNextToken(JsLex *lex) {
         jslTokenAppendChar(lex, lex->currCh);
         jslGetNextCh(lex);
       }
+
       if ((lex->currCh=='x' || lex->currCh=='X') ||
-          (lex->currCh=='b' || lex->currCh=='B')) {
+          (lex->currCh=='b' || lex->currCh=='B') ||
+          (lex->currCh=='o' || lex->currCh=='O')) {
         canBeFloating = false;
         jslTokenAppendChar(lex, lex->currCh); jslGetNextCh(lex);
       }

--- a/src/jsutils.c
+++ b/src/jsutils.c
@@ -78,9 +78,18 @@ JsVarInt stringToIntWithRadix(const char *s, int forceRadix, bool *hasError) {
   if (*s == '0') {
     radix = 8;
     s++;
-    if (*s == 'x' || *s == 'X') {
+
+    // OctalIntegerLiteral: 0o01, 0O01
+    if (*s == 'o' || *s == 'O') {
+      radix = 8;
+      s++;
+
+    // HexIntegerLiteral: 0x01, 0X01
+    } else if (*s == 'x' || *s == 'X') {
       radix = 16;
       s++;
+
+    // BinaryIntegerLiteral: 0b01, 0B01
     } else if (*s == 'b' || *s == 'B') {
       radix = 2;
       s++;

--- a/tests/test_integer_literals.js
+++ b/tests/test_integer_literals.js
@@ -3,3 +3,6 @@ console.log( 0X01 === 1);
 
 console.log( 0b01 === 1);
 console.log( 0B01 === 1);
+
+console.log( 0o01 === 1);
+console.log( 0O01 === 1);


### PR DESCRIPTION
This may be better fixed by including ctype.h and using tolower(ch)

Signed-off-by: Rick Waldron waldron.rick@gmail.com
