### PR TITLE
Correct and expand test readme

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,38 @@
 Tests
 =====
 
-The tests here are run automatically when you type './espruino test'. Ideally their name would represent what they tested, but this hasn't been done yet.
+The tests here are run automatically when you type
+
+```sh
+./espruino --test-all
+```
+
+Ideally their name would represent what they tested, but this hasn't been done yet.
+
+## Other tests
+
+You can find an overview of all of these by running `./espruino --help`.
+
+### Run a supplied test
+```sh
+./espruino --test test.js
+```
+
+### Run all Exhaustive Memory crash tests
+
+```sh
+./espruino --test-mem-all
+```
+
+### Run the supplied Exhaustive Memory crash test
+
+```sh
+./espruino --test-mem test.js
+```
+
+### Run the supplied Exhaustive Memory crash test with # vars
+
+```sh
+./espruino --test-mem-n test.js #
+```
+


### PR DESCRIPTION
When trying to run the tests, I found the instructions in the tests readme outdated. I found working instructions in `./espruino --help`, and updated the readme with the information I found.
