### PR TITLE
fix Array.concat() bug

### DIFF
--- a/tests/test_array_concat.js
+++ b/tests/test_array_concat.js
@@ -1,0 +1,19 @@
+// test for array join
+
+function eq(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+var actual = [1,2].concat([3,4]);
+var expected = [1,2,3,4];
+
+result = eq(actual, expected);


### PR DESCRIPTION
This fixes #288.

I changed it to a do-while loop to make it more explicit that the first iteration always runs on the 'parent' array.  I'm not really experienced with C, so if this doesn't read right for a C programmer, I am happy to change it back.
