### PR TITLE
Use 'signed' prints only for base 10 values

### DIFF
--- a/src/jsutils.c
+++ b/src/jsutils.c
@@ -389,7 +389,7 @@ char itoch(int val) {
 void itostr(JsVarInt vals,char *str,unsigned int base) {
   JsVarIntUnsigned val;
   // handle negative numbers
-  if (vals<0) {
+  if (base == 10 && vals<0) {
     *(str++)='-';
     val = (JsVarIntUnsigned)(-vals);
   } else {


### PR DESCRIPTION
Signed (negative) printouts are relevant for base 10. Exclude them from other bases. This allows for example 0xffffffff to printed instead of -1.

Seems like a handy thing for printing out registers and such.
Does not change build output.
Does not change tests output.
