### PR TITLE
Added some details to take in account STM32F411 properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ If you are a board manufacturer interested in getting your board officially supp
 * MBed platforms - have not worked for a while - full hardware wrapper still required
 * ARDUINOMEGA2560 - compiles, but has never worked. Almost certainly due to ints being 16 bits.
 * LC-TECH STM32F103RBT6 - WORKING, but with some issues (LED inverted logic, BTN needs pullup to work)
-* ST NUCLEO-F401RE - early alpha status
-
+* ST NUCLEO-F401RE - beta status
+* ST NUCLEO-F411RE - early alpha status
 
 Building under Linux
 ------------------
@@ -243,4 +243,3 @@ However if you're planning on selling the Espruino software on your own board, p
 * You won't be able to call your board an 'Espruino' board unless it's agreed with us (we own the trademark)
 * You must explain clearly in your documentation that your device uses Espruino internally
 * If you're profiting from our hard work without contributing anything back, we're not going to very motivated to support you (or your users)
-

--- a/boards/NUCLEOF411RE.py
+++ b/boards/NUCLEOF411RE.py
@@ -22,7 +22,7 @@ info = {
   'default_console' : "EV_SERIAL2", # USART2 by default, the Nucleo's USB is actually running on this too
   'default_console_tx' : "A2", # USART2_TX on PA2,
   'default_console_rx' : "A3", # USART2_RX on PA3
-  'variables' :  7423 # (128-12)*1024/16-1
+  'variables' :  7423, # (128-12)*1024/16-1
   'binary_name' : 'espruino_%v_nucleof411re.bin',
 };
 chip = {

--- a/scripts/build_board_json.py
+++ b/scripts/build_board_json.py
@@ -22,7 +22,7 @@ import string;
 
 
 scriptdir = os.path.dirname(os.path.realpath(__file__))
-basedir = scriptdir+"/../"
+basedir = os.path.normalize(scriptdir+"/../")
 sys.path.append(basedir+"scripts");
 sys.path.append(basedir+"boards");
 
@@ -105,4 +105,3 @@ boarddata = {
 jsonFile = open(jsonFilename, 'w')
 jsonFile.write(json.dumps(boarddata, indent=1));
 jsonFile.close();
-

--- a/scripts/build_platform_config.py
+++ b/scripts/build_platform_config.py
@@ -206,7 +206,7 @@ codeOut("""
 """);
 
 if board.chip["class"]=="STM32":
-  if board.chip["part"][:9]=="STM32F401":
+  if (board.chip["part"][:9]=="STM32F401") | (board.chip["part"][:9]=="STM32F411"):
 # FIXME - need to remove TIM5 from jspininfo
    codeOut("""
 // Used by various pins, but always with other options


### PR DESCRIPTION
1. Updated README.md to integrate NUCLEOF411RE
2. Updated NUCLEOF411RE.py to correct some syntax and really get it build
3. Updated build_board_json.py to normalize path and get sys.append to work on ubuntu 14.04 LTS
4. Updated build_platform_config.py to setup the timer used with STM32F411 boards, so far it is now the same as for STM32F401RE
5. Stopped the auto removal of ending whites spaces but true on ending lines of files. (:
