### PR TITLE
add length property for function objects

### DIFF
--- a/src/jsvar.c
+++ b/src/jsvar.c
@@ -1497,6 +1497,27 @@ JsVar *jsvArrayBufferGetFromName(JsVar *name) {
   return value;
 }
 
+
+JsVar *jsvGetFunctionArgumentLength(JsVar *functionScope) {
+  JsVar *args = jsvNewWithFlags(JSV_ARRAY);
+  if (!args) return 0; // out of memory
+
+  JsvObjectIterator it;
+  jsvObjectIteratorNew(&it, functionScope);
+  while (jsvObjectIteratorHasValue(&it)) {
+    JsVar *idx = jsvObjectIteratorGetKey(&it);
+    if (jsvIsFunctionParameter(idx)) {
+      JsVar *val = jsvSkipOneName(idx);
+      jsvArrayPushAndUnLock(args, val);
+    }
+    jsvUnLock(idx);
+    jsvObjectIteratorNext(&it);
+  }
+  jsvObjectIteratorFree(&it);
+
+  return args;
+}
+
 /** If a is a name skip it and go to what it points to - and so on.
  * ALWAYS locks - so must unlock what it returns. It MAY
  * return 0. */

--- a/src/jsvar.h
+++ b/src/jsvar.h
@@ -435,6 +435,8 @@ bool jsvGetBoolAndUnLock(JsVar *v);
 long long jsvGetLongIntegerAndUnLock(JsVar *v);
 
 
+
+
 /** Get the item at the given location in the array buffer and return the result */
 size_t jsvGetArrayBufferLength(JsVar *arrayBuffer);
 /** Get the String the contains the data for this arrayBuffer */
@@ -445,6 +447,9 @@ JsVar *jsvArrayBufferGet(JsVar *arrayBuffer, size_t index);
 void jsvArrayBufferSet(JsVar *arrayBuffer, size_t index, JsVar *value);
 /** Given an integer name that points to an arraybuffer or an arraybufferview, evaluate it and return the result */
 JsVar *jsvArrayBufferGetFromName(JsVar *name);
+
+/** Get the number of arguments for a given function */
+JsVar *jsvGetFunctionArgumentLength(JsVar *scope);
 
 /** If a is a name skip it and go to what it points to - and so on.
  * ALWAYS locks - so must unlock what it returns. It MAY

--- a/src/jswrap_functions.c
+++ b/src/jswrap_functions.c
@@ -37,24 +37,9 @@ JsVar *jswrap_arguments() {
     return 0;
   }
 
-  JsVar *args = jsvNewWithFlags(JSV_ARRAY);
-  if (!args) return 0; // out of memory
-
-  JsvObjectIterator it;
-  jsvObjectIteratorNew(&it, scope);
-  while (jsvObjectIteratorHasValue(&it)) {
-    JsVar *idx = jsvObjectIteratorGetKey(&it);
-    if (jsvIsFunctionParameter(idx)) {
-      JsVar *val = jsvSkipOneName(idx);
-      jsvArrayPushAndUnLock(args, val);
-    }
-    jsvUnLock(idx);
-    jsvObjectIteratorNext(&it);
-  }
-  jsvObjectIteratorFree(&it);
-
-  return args;
+  return jsvGetFunctionArgumentLength(scope);
 }
+
 
 
 /*JSON{

--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -57,9 +57,11 @@ JsVar *jswrap_object_length(JsVar *parent) {
   if (jsvIsArray(parent)) {
     return jsvNewFromInteger(jsvGetArrayLength(parent));
   } else if (jsvIsArrayBuffer(parent)) {
-      return jsvNewFromInteger((JsVarInt)jsvGetArrayBufferLength(parent));
+    return jsvNewFromInteger((JsVarInt)jsvGetArrayBufferLength(parent));
   } else if (jsvIsString(parent)) {
     return jsvNewFromInteger((JsVarInt)jsvGetStringLength(parent));
+  } else if (jsvIsFunction(parent)) {
+    return jswrap_object_length(jsvGetFunctionArgumentLength(parent));
   }
   return 0;
 }


### PR DESCRIPTION
Currently this does not work:

```js
var fx = function(a,b,c){};
console.log(fx.length);
```

It seems to be standard since [JavaScript 1.1](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length).

This path adds support for function.length with the result of
```js
console.log(function(){}.length);
console.log(function(a){}.length);
console.log(function(a,b){}.length);
//prints 
//0
//1
//2
```