### PR TITLE
add vagrant setup + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ To cross compile,
 
 This will create a file called ```functions.html```
 
+### Building under Windows/MacOS with a VM (Vagrant)
+
+* Clone this repository.
+* Download and install the correct [VirtualBox](https://www.virtualbox.org/) for your platform. eg. If you have Windows, download 'VirtualBox for Windows Hosts'.
+* Download and install the correct [Vagrant](https://www.vagrantup.com/downloads.html) for your platform.
+  > If running on MacOS, the two previous steps can be accomplished easily with [Homebrew Cask](http://caskroom.io):  `brew cask install virtualbox vagrant` will do it.
+* In your terminal application, navigate to your cloned working copy.
+* Execute `vagrant up`.  This will take a little while while the box is downloaded, and your virtual machine is provisioned.
+* When it is complete, execute `vagrant ssh`, which will open an ssh session into your new VM. 
+* Execute `cd /vagrant && ESPRUINO_1V3=1 make` and wait.
+* Espruino is now built. See the documentation under **Building under Linux** for more examples.
+* To terminate the ssh session, simply execute `exit`.
+* `vagrant suspend` will pause the VM, `vagrant halt` will stop it, and `vagrant up` will bring it back up again.  See Vagrant's ["Getting Started"](http://docs.vagrantup.com/v2/getting-started/index.html) page for further information.
 
 Building under Windows/MacOS with a VM
 ---------------------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,59 @@
+Vagrant.configure(2) do |config|
+
+  # Ubuntu Server
+  config.vm.define "headless", primary: true do |headless|
+    headless.vm.box = "ubuntu/trusty64"
+  end
+
+  ## FOLDER ##
+
+  config.vm.synced_folder ".", "/vagrant"
+
+  ## NETWORK ##
+
+  # your host OS type
+  host = RbConfig::CONFIG['host_os']
+
+  ## VIRTUALBOX ##
+
+  config.vm.provider "virtualbox" do |v|
+    # Give VM 1/4 system memory & access to all cpu cores on the host
+    if host =~ /darwin/
+      cpus = `sysctl -n hw.ncpu`.to_i
+      # sysctl returns Bytes and we need to convert to MB
+      mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
+    elsif host =~ /linux/
+      cpus = `nproc`.to_i
+      # meminfo shows KB and we need to convert to MB
+      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
+    end
+
+    v.memory = mem
+    v.cpus = cpus
+  end
+
+  ## HOST-SPECIFIC ##
+
+  if host =~ /darwin/
+    # macs require NFS for sharing because of performance issues.
+    # NFS comes preinstalled on Macs, so no extra steps are necessary here.
+    config.vm.synced_folder ".", "/vagrant", type: "nfs"
+
+    # NFS requires a private network.  by default, a private network requires a static IP,
+    # but this is a pain to manage if you have many machines up.  the auto_network plugin
+    # will automatically assign a static IP to your box.  to install this plugin, execute
+    # `./scripts/vagrant/setup-host.sh` or `vagrant plugin install vagrant-auto_network`
+    config.vm.network :private_network, :auto_network => true
+  end
+
+  ## PROVISIONING ##
+
+  config.vm.provision "shell", path: "./scripts/provision.sh"
+
+  ## SSH ##
+
+  config.ssh.forward_agent = true
+  config.ssh.forward_x11 = true
+
+end
+

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script is run by Vagrant when a new machine is provisioned.
+#
+
+sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded
+sudo apt-get update
+sudo apt-get install gcc-arm-none-eabi git
+


### PR DESCRIPTION
In the current `README.md`, it's recommended to install Virtual Box and create an Ubuntu VM, etc., if you need to build on a non-Linux system.

The same thing can be accomplished in fewer steps with [Vagrant](http://vagrantup.com).  

In addition, this gives the project the ability to make changes to the provisioning of the virtual machine as necessary.  For example, if another compiler needed to be chosen, or perhaps Ubuntu wasn't cutting it anymore--just modify `Vagrantfile` and `scripts/provision.sh`, and that's that.  You could also go as far as *recommending* that the system be built from within a Vagrant machine, since it's a controlled environment--and you control it.

Anyway, I've built the firmware using this method.  Attaching the Espruino to the Vagrant box can probably be accomplished via the Vagrantfile as well (for flashing), but I haven't tried it--otherwise, you can simply load the VM in the VirtualBox GUI and do it as documented.

If I have any suggestions from here, looking for a smaller box on [Atlas](http://atlas.hashicorp.com) may be a good idea, because it will reduce the download size.