### PR TITLE
add Dockerfile to provide a clean build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get install -y software-properties-common && apt-get update \
+ && add-apt-repository ppa:terry.guo/gcc-arm-embedded \
+ && apt-get update \ 
+ && apt-get install -y git gcc-arm-none-eabi build-essential python
+
+RUN git clone https://github.com/espruino/Espruino espruino
+WORKDIR /espruino
+
+# If compiling for a non-linux target that has internet support, use WIZnet support, not TI CC3000
+ENV WIZNET=1
+# If compiling for a non-linux target that has internet support, use ESP8266 support, not TI CC3000
+#ENV ESP8266 1
+
+ENV RELEASE 1
+ENV PICO_1V3 1
+
+RUN make

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ RUN git clone https://github.com/espruino/Espruino espruino
 WORKDIR /espruino
 
 # If compiling for a non-linux target that has internet support, use WIZnet support, not TI CC3000
-ENV WIZNET=1
+#ENV WIZNET=1
 # If compiling for a non-linux target that has internet support, use ESP8266 support, not TI CC3000
 #ENV ESP8266 1
 
 ENV RELEASE 1
-ENV PICO_1V3 1
+#ENV PICO_1V3 1
 
-RUN make
+CMD ["make"]


### PR DESCRIPTION
as advertised:

* provide a build environment like described in the README.
* allows to set the build parameters/environment when running the Docker container
* build artifacts can be copied from the container using `docker cp ...`
* an example Docker image will be available as gesellix/espruino, but you might provide your official repo.
