### PR TITLE
Optional BLE interface to communicate with Espruino

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 INCLUDE=-I$(ROOT) -I$(ROOT)/targets -I$(ROOT)/src -I$(ROOT)/gen
 LIBS=
 DEFINES=
-CFLAGS=#-Wall -Wextra -Wconversion -Werror=implicit-function-declaration
+CFLAGS=-Wall -Wextra -Wconversion -Werror=implicit-function-declaration
 LDFLAGS=-Winline
 OPTIMIZEFLAGS=
 #-fdiagnostics-show-option - shows which flags can be used with -Werror

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 INCLUDE=-I$(ROOT) -I$(ROOT)/targets -I$(ROOT)/src -I$(ROOT)/gen
 LIBS=
 DEFINES=
-CFLAGS=-Wall -Wextra -Wconversion -Werror=implicit-function-declaration
+CFLAGS=#-Wall -Wextra -Wconversion -Werror=implicit-function-declaration
 LDFLAGS=-Winline
 OPTIMIZEFLAGS=
 #-fdiagnostics-show-option - shows which flags can be used with -Werror
@@ -998,47 +998,108 @@ ifeq ($(FAMILY), NRF52)
 
 	# ARCHFLAGS are shared by both CFLAGS and LDFLAGS.
 	ARCHFLAGS = -mthumb -mabi=aapcs -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
-	DEFINES += -DCONFIG_GPIO_AS_PINRESET -DBOARD_PCA10036 -DNRF52 -DBSP_DEFINES_ONLY
+	
+	ifdef BLE_INTERFACE
+		DEFINES += -DSWI_DISABLE0 -DSOFTDEVICE_PRESENT -DNRF52 -DCONFIG_GPIO_AS_PINRESET -DBOARD_PCA10036 -DS132 -DBLE_STACK_SUPPORT_REQD -DBLE_INTERFACE
+	else
+		DEFINES += -DCONFIG_GPIO_AS_PINRESET -DBOARD_PCA10036 -DNRF52 -DBSP_DEFINES_ONLY
+	endif # BLE_INTERFACE
 
-	# Includes. See NRF52 examples as you add functionality. For example if you are added SPI interface then see Nordic's SPI example. 
-	# In this example you can view the makefile and take INCLUDES and SOURCES directly from it. Just make sure you set path correctly as seen below.
-	INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/uart/config/uart_pca10036
-	INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/uart/config
-	INCLUDE += -I$(NRF52_SDK_PATH)/examples/bsp
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/nrf_soc_nosd
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/device
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/uart
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/hal
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/delay
-	INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/uart
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/util
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/uart
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/common
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/toolchain
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/config
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/fifo
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/toolchain/gcc
+	ifdef BLE_INTERFACE
 
-	# Includes for adding timer peripheral. 
-	INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/timer/config/timer_pca10036
-	INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/timer/config
-	INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/timer
-	INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/timer
+		#includes common to all targets
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/ble_peripheral/ble_app_uart/config
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/config
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/bsp
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/fifo
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/delay
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/softdevice/s132/headers/nrf52
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/util
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/uart
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/ble/common
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/pstorage
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/uart
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/device
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/button
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/timer
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/softdevice/s132/headers
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/gpiote
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/ble/ble_services/ble_nus
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/hal
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/toolchain/gcc
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/toolchain
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/common
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/ble/ble_advertising
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/trace
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/softdevice/common/softdevice_handler
 
-	# Source files used. Add them here as necessary. See makefile examples for guidance in Nordic's SDK for specific projects (i.e uart example project).
-	SOURCES += \
-	$(NRF52_SDK_PATH)/components/toolchain/system_nrf52.c \
-	$(NRF52_SDK_PATH)/components/libraries/util/app_error.c \
-	$(NRF52_SDK_PATH)/components/libraries/fifo/app_fifo.c \
-	$(NRF52_SDK_PATH)/components/libraries/util/app_util_platform.c \
-	$(NRF52_SDK_PATH)/components/libraries/util/nrf_assert.c \
-	$(NRF52_SDK_PATH)/components/libraries/uart/retarget.c \
-	$(NRF52_SDK_PATH)/components/libraries/uart/app_uart_fifo.c \
-	$(NRF52_SDK_PATH)/components/drivers_nrf/delay/nrf_delay.c \
-	$(NRF52_SDK_PATH)/components/drivers_nrf/common/nrf_drv_common.c \
-	$(NRF52_SDK_PATH)/components/drivers_nrf/uart/nrf_drv_uart.c \
-	$(NRF52_SDK_PATH)/components/drivers_nrf/timer/nrf_drv_timer.c # I want to add timer peripheral so add source here (as in timer example makefile from nordic sdk).
+		#source common to all targets
+		SOURCES += \
+		$(NRF52_SDK_PATH)/components/libraries/button/app_button.c \
+		$(NRF52_SDK_PATH)/components/libraries/util/app_error.c \
+		$(NRF52_SDK_PATH)/components/libraries/fifo/app_fifo.c \
+		$(NRF52_SDK_PATH)/components/libraries/timer/app_timer.c \
+		$(NRF52_SDK_PATH)/components/libraries/trace/app_trace.c \
+		$(NRF52_SDK_PATH)/components/libraries/util/nrf_assert.c \
+		$(NRF52_SDK_PATH)/components/libraries/uart/retarget.c \
+		$(NRF52_SDK_PATH)/components/libraries/uart/app_uart_fifo.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/delay/nrf_delay.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/common/nrf_drv_common.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/gpiote/nrf_drv_gpiote.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/uart/nrf_drv_uart.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/pstorage/pstorage.c \
+		$(NRF52_SDK_PATH)/examples/bsp/bsp.c \
+		$(NRF52_SDK_PATH)/examples/bsp/bsp_btn_ble.c \
+		$(NRF52_SDK_PATH)/components/ble/common/ble_advdata.c \
+		$(NRF52_SDK_PATH)/components/ble/ble_advertising/ble_advertising.c \
+		$(NRF52_SDK_PATH)/components/ble/common/ble_conn_params.c \
+		$(NRF52_SDK_PATH)/components/ble/ble_services/ble_nus/ble_nus.c \
+		$(NRF52_SDK_PATH)/components/ble/common/ble_srv_common.c \
+		$(NRF52_SDK_PATH)/components/toolchain/system_nrf52.c \
+		$(NRF52_SDK_PATH)/components/softdevice/common/softdevice_handler/softdevice_handler.c
 
+	else
+
+		# Includes. See NRF52 examples as you add functionality. For example if you are added SPI interface then see Nordic's SPI example. 
+		# In this example you can view the makefile and take INCLUDES and SOURCES directly from it. Just make sure you set path correctly as seen below.
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/uart/config/uart_pca10036
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/uart/config
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/bsp
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/nrf_soc_nosd
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/device
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/uart
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/hal
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/delay
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/uart
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/util
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/uart
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/common
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/toolchain
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/config
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/libraries/fifo
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/toolchain/gcc
+
+		# Includes for adding timer peripheral. 
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/timer/config/timer_pca10036
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/timer/config
+		INCLUDE += -I$(NRF52_SDK_PATH)/components/drivers_nrf/timer
+		INCLUDE += -I$(NRF52_SDK_PATH)/examples/peripheral/timer
+
+		# Source files used. Add them here as necessary. See makefile examples for guidance in Nordic's SDK for specific projects (i.e uart example project).
+		SOURCES += \
+		$(NRF52_SDK_PATH)/components/toolchain/system_nrf52.c \
+		$(NRF52_SDK_PATH)/components/libraries/util/app_error.c \
+		$(NRF52_SDK_PATH)/components/libraries/fifo/app_fifo.c \
+		$(NRF52_SDK_PATH)/components/libraries/util/app_util_platform.c \
+		$(NRF52_SDK_PATH)/components/libraries/util/nrf_assert.c \
+		$(NRF52_SDK_PATH)/components/libraries/uart/retarget.c \
+		$(NRF52_SDK_PATH)/components/libraries/uart/app_uart_fifo.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/delay/nrf_delay.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/common/nrf_drv_common.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/uart/nrf_drv_uart.c \
+		$(NRF52_SDK_PATH)/components/drivers_nrf/timer/nrf_drv_timer.c # I want to add timer peripheral so add source here (as in timer example makefile from nordic sdk).
+
+	endif # BLE_INTERFACE
 
 	#assembly files common to all targets
 	#ASM_SOURCE_FILES  = ../../../../../components/toolchain/gcc/gcc_startup_nrf52.s
@@ -1104,8 +1165,13 @@ endif
 OPTIMIZEFLAGS += -fno-common -fno-exceptions -fdata-sections -ffunction-sections
 
 ifdef NRF52
-	LINKER_FILE = $(NRF52_SDK_PATH)/components/toolchain/gcc/linker_espruino.ld
-endif #NRF52
+	ifdef BLE_INTERFACE
+		LINKER_FILE = $(NRF52_SDK_PATH)/components/toolchain/gcc/linker_ble_interface_espruino.ld
+	else
+		LINKER_FILE = $(NRF52_SDK_PATH)/components/toolchain/gcc/linker_espruino.ld
+	endif # BLE_INTERFACE
+endif # NRF52
+
 # I've no idea why this breaks the bootloader, but it does.
 # Given we've left 10k for it, there's no real reason to enable LTO anyway.
 ifndef BOOTLOADER
@@ -1156,10 +1222,20 @@ endif
 endif
 
 ifdef NRF52
-INCLUDE += -I$(ROOT)/targets/nrf52
-SOURCES +=                              \
-targets/nrf52/main.c                    \
-targets/nrf52/jshardware.c              
+
+	INCLUDE += -I$(ROOT)/targets/nrf52
+	SOURCES +=                              \
+	targets/nrf52/main.c                    \
+	targets/nrf52/jshardware.c    
+
+	ifdef BLE_INTERFACE
+		SOURCES +=							\
+		targets/nrf52/ble_interface.c
+	else
+		SOURCES +=							\
+		targets/nrf52/uart_interface.c
+	endif # BLE_INTERFACE
+
 endif # NRF52
 
 ifdef LINUX

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you are a board manufacturer interested in getting your board officially supp
 * STM32F4DISCOVERY - WORKING
 * STM32F401CDISCOVERY - appears WORKING, but very little testing done
 * STM32F429IDISCOVERY - WORKING over serial (A9/A10). No USB and no LCD support
+* NRF52832 Preview Development Kit - WORKING with limited functionality. Able to interface with Espruino over BLE (send commands from smartphone or computer) or serial as normal (send commands from chrome IDE or terminal).
 * HY STM32 2.4" - WORKING
 * HY STM32 2.8" - WORKING - limited memory so some features removed
 * HY STM32 3.2" - WORKING
@@ -113,6 +114,18 @@ It may complain that there isn't enough space on the chip. This isn't an issue u
 * Try different compilers. `codesourcery-2013.05-23-arm-none-eabi` provides low binary size for `-O3`
 
 **Note:** Espruino boards contain a special bootloader at `0x08000000` (the default address), with the Espruino binary moved on 10240 bytes to `0x08002800`. To load the Espruino binary onto a board at the correct address, use `ESPRUINO_1V3=1 RELEASE=1 make serialflash`. If you want to make a binary that contains the bootloader as well as Espruino (like the ones that the Espruino Web IDE expects to use) use the script `scripts/create_espruino_image_1v3.sh` which will compile the bootloader *and* Espruino, and then join them together.
+
+### Building for Nordic Semiconductor's NRF52832 Preview Development Kit.
+
+The (previously suggested) CodeSourcery GCC compiler is no longer available. We'd suggest you use [gcc-arm-none-eabi](https://launchpad.net/gcc-arm-embedded/+download).
+
+Download the compiler, set up your path so you have access to it, and run:
+
+```NRF52832DK=1 BLE_INTERFACE=1 RELEASE=1 make```
+
+Note: If you want to communicate with espruino through wired USB connection remove 'BLE_INTERFACE=1'. This will run Espruino so that you can program it from the chrome IDE as you normally would instead of over BLE.
+
+Also note that you must program the soft device provided by Nordic before programming Espruino. I am working on getting rid of this step. Get the soft device 132 from Nordic's newest SDK for the NRF52 platform. Program both the softdevice and Espruino with nRFGo studio which can be found on nordicsemi.com.
 
 ### Building for Linux
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ If you are a board manufacturer interested in getting your board officially supp
 * STM32F4DISCOVERY - WORKING
 * STM32F401CDISCOVERY - appears WORKING, but very little testing done
 * STM32F429IDISCOVERY - WORKING over serial (A9/A10). No USB and no LCD support
-* NRF52832 Preview Development Kit - WORKING with limited functionality. Able to interface with Espruino over BLE (send commands from smartphone or computer) or serial as normal (send commands from chrome IDE or terminal).
 * HY STM32 2.4" - WORKING
 * HY STM32 2.8" - WORKING - limited memory so some features removed
 * HY STM32 3.2" - WORKING
@@ -114,18 +113,6 @@ It may complain that there isn't enough space on the chip. This isn't an issue u
 * Try different compilers. `codesourcery-2013.05-23-arm-none-eabi` provides low binary size for `-O3`
 
 **Note:** Espruino boards contain a special bootloader at `0x08000000` (the default address), with the Espruino binary moved on 10240 bytes to `0x08002800`. To load the Espruino binary onto a board at the correct address, use `ESPRUINO_1V3=1 RELEASE=1 make serialflash`. If you want to make a binary that contains the bootloader as well as Espruino (like the ones that the Espruino Web IDE expects to use) use the script `scripts/create_espruino_image_1v3.sh` which will compile the bootloader *and* Espruino, and then join them together.
-
-### Building for Nordic Semiconductor's NRF52832 Preview Development Kit.
-
-The (previously suggested) CodeSourcery GCC compiler is no longer available. We'd suggest you use [gcc-arm-none-eabi](https://launchpad.net/gcc-arm-embedded/+download).
-
-Download the compiler, set up your path so you have access to it, and run:
-
-```NRF52832DK=1 BLE_INTERFACE=1 RELEASE=1 make```
-
-Note: If you want to communicate with espruino through wired USB connection remove 'BLE_INTERFACE=1'. This will run Espruino so that you can program it from the chrome IDE as you normally would instead of over BLE.
-
-Also note that you must program the soft device provided by Nordic before programming Espruino. I am working on getting rid of this step. Get the soft device 132 from Nordic's newest SDK for the NRF52 platform. Program both the softdevice and Espruino with nRFGo studio which can be found on nordicsemi.com.
 
 ### Building for Linux
 

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/ble/ble_advertising/ble_advertising.c
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/ble/ble_advertising/ble_advertising.c
@@ -142,8 +142,10 @@ uint32_t ble_advertising_init(ble_advdata_t const                 * p_advdata,
         m_advdata.p_manuf_specific_data->company_identifier =
         p_advdata->p_manuf_specific_data->company_identifier;
         m_advdata.p_manuf_specific_data->data.size = p_advdata->p_manuf_specific_data->data.size;
+
+        uint32_t i;
         
-        for(uint32_t i = 0; i < m_advdata.p_manuf_specific_data->data.size; i++)
+        for(i = 0; i < m_advdata.p_manuf_specific_data->data.size; i++)
         {
             m_manuf_data_array[i] = p_advdata->p_manuf_specific_data->data.p_data[i];
         }
@@ -157,7 +159,9 @@ uint32_t ble_advertising_init(ble_advdata_t const                 * p_advdata,
         m_advdata.p_service_data_array->data.size    = p_advdata->p_service_data_array->data.size;
         m_advdata.p_service_data_array->service_uuid = p_advdata->p_service_data_array->service_uuid;
 
-        for(uint32_t i = 0; i < m_advdata.p_service_data_array->data.size; i++)
+        uint32_t i;
+
+        for(i = 0; i < m_advdata.p_service_data_array->data.size; i++)
         {
             m_service_data_array[i] = p_advdata->p_service_data_array->data.p_data[i];
         }
@@ -498,7 +502,9 @@ uint32_t ble_advertising_peer_addr_reply(ble_gap_addr_t * p_peer_address)
 
     m_peer_address.addr_type = p_peer_address->addr_type;
 
-    for (int i = 0; i < BLE_GAP_ADDR_LEN; i++)
+    int i;
+
+    for (i = 0; i < BLE_GAP_ADDR_LEN; i++)
     {
         m_peer_address.addr[i] = p_peer_address->addr[i];
     }

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/ble/ble_services/ble_nus/ble_nus.c
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/ble/ble_services/ble_nus/ble_nus.c
@@ -162,7 +162,7 @@ static uint32_t tx_char_add(ble_nus_t * p_nus, const ble_nus_init_t * p_nus_init
 
     memset(&char_md, 0, sizeof(char_md));
 
-    char_md.char_props.write         = 1;
+    char_md.char_props.write         = 0; // nRF Toolbox UART app requires this to write properly...
     char_md.char_props.write_wo_resp = 1;
     char_md.p_char_user_desc         = NULL;
     char_md.p_char_pf                = NULL;

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/drivers_nrf/pstorage/pstorage.c
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/drivers_nrf/pstorage/pstorage.c
@@ -609,7 +609,9 @@ static void cmd_queue_init(void)
     m_cmd_queue.rp    = 0;
     m_cmd_queue.count = 0;
 
-    for (uint32_t cmd_index = 0; cmd_index < PSTORAGE_CMD_QUEUE_SIZE; ++cmd_index)
+    uint32_t cmd_index;
+
+    for (cmd_index = 0; cmd_index < PSTORAGE_CMD_QUEUE_SIZE; ++cmd_index)
     {
         cmd_queue_element_init(cmd_index);
     }
@@ -1289,8 +1291,10 @@ uint32_t pstorage_init(void)
     m_next_app_instance = 0;
     m_next_page_addr    = PSTORAGE_DATA_START_ADDR;
     m_current_page_id   = 0;
+
+    uint32_t index;
     
-    for (uint32_t index = 0; index < PSTORAGE_NUM_OF_PAGES; index++)
+    for (index = 0; index < PSTORAGE_NUM_OF_PAGES; index++)
     {
         m_app_table[index].cb           = NULL;
         m_app_table[index].block_size   = 0;

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/libraries/trace/app_trace.c
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/libraries/trace/app_trace.c
@@ -68,7 +68,10 @@ void app_trace_init(void)
 void app_trace_dump(uint8_t * p_buffer, uint32_t len)
 {
     app_trace_log("\r\n");
-    for (uint32_t index = 0; index <  len; index++)
+
+    uint32_t index;
+
+    for (index = 0; index <  len; index++)
     {
         app_trace_log("0x%02X ", p_buffer[index]);
     }

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/gcc_startup_nrf52.s
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/gcc_startup_nrf52.s
@@ -56,7 +56,7 @@ __StackTop:
 #ifdef __HEAP_SIZE
     .equ    Heap_Size, __HEAP_SIZE
 #else
-    .equ    Heap_Size, 8192
+    .equ    Heap_Size, 0
 #endif
     .globl    __HeapBase
     .globl    __HeapLimit

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_ble_interface_espruino.ld
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_ble_interface_espruino.ld
@@ -1,12 +1,12 @@
 /* Linker script to configure memory regions. */
 
-  SEARCH_DIR(.)
-  GROUP(-lgcc -lc -lnosys)
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
 
-  MEMORY
-  {
-    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x80000
-    RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x08000
-  }
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x1f000, LENGTH = 0x61000
+  RAM (rwx) :  ORIGIN = 0x20002800, LENGTH = 0x5800
+}
 
 INCLUDE "/home/michael/Documents/Espruino/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_common_espruino.ld"

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_ble_interface_espruino.ld
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_ble_interface_espruino.ld
@@ -9,4 +9,177 @@ MEMORY
   RAM (rwx) :  ORIGIN = 0x20002800, LENGTH = 0x5800
 }
 
-INCLUDE "/home/michael/Documents/Espruino/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_common_espruino.ld"
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.Vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    *(.eh_frame*)
+    . = ALIGN(4);
+  } > FLASH
+    
+
+  .ARM.extab : 
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(4);
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    . = ALIGN(4);
+  } > FLASH
+  __exidx_end = .;
+
+  __etext = .;
+  _etext = .;
+  _sidata = .;
+    
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    _sdata = .;
+    *(vtable)
+    *(.data*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    *(.preinit_array)
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    *(SORT(.init_array.*))
+    *(.init_array)
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    *(SORT(.fini_array.*))
+    *(.fini_array)
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    *(.jcr)
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+    _edata = .;
+
+  } > RAM
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    _sbss = .;
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    _ebss = .;
+  } > RAM
+  
+  .heap (COPY):
+  {
+    __end__ = .;
+    end = __end__;
+    *(.heap*)
+    __HeapLimit = .;
+  } > RAM
+
+  PROVIDE ( _end = end );
+
+  /* .stack_dummy section doesn't contains any symbols. It is only
+   * used for linker to calculate size of stack sections, and assign
+   * values to stack symbols later */
+  .stack_dummy (COPY):
+  {
+    *(.stack*)
+  } > RAM
+
+  /* Set stack top to end of RAM, and stack limit move down by
+   * size of stack_dummy section */
+  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+  _estack = __StackTop;
+  __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+  PROVIDE(__stack = __StackTop);
+  
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_common_espruino.ld
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_common_espruino.ld
@@ -1,0 +1,174 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.Vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    *(.eh_frame*)
+    . = ALIGN(4);
+  } > FLASH
+    
+
+  .ARM.extab : 
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(4);
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    . = ALIGN(4);
+  } > FLASH
+  __exidx_end = .;
+
+  __etext = .;
+  _etext = .;
+  _sidata = .;
+    
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    _sdata = .;
+    *(vtable)
+    *(.data*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    *(.preinit_array)
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    *(SORT(.init_array.*))
+    *(.init_array)
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    *(SORT(.fini_array.*))
+    *(.fini_array)
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    *(.jcr)
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+    _edata = .;
+
+  } > RAM
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    _sbss = .;
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    _ebss = .;
+  } > RAM
+  
+  .heap (COPY):
+  {
+    __end__ = .;
+    end = __end__;
+    *(.heap*)
+    __HeapLimit = .;
+  } > RAM
+
+  PROVIDE ( _end = end );
+
+  /* .stack_dummy section doesn't contains any symbols. It is only
+   * used for linker to calculate size of stack sections, and assign
+   * values to stack symbols later */
+  .stack_dummy (COPY):
+  {
+    *(.stack*)
+  } > RAM
+
+  /* Set stack top to end of RAM, and stack limit move down by
+   * size of stack_dummy section */
+  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+  _estack = __StackTop;
+  __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+  PROVIDE(__stack = __StackTop);
+  
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_espruino.ld
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_espruino.ld
@@ -1,12 +1,185 @@
 /* Linker script to configure memory regions. */
 
-  SEARCH_DIR(.)
-  GROUP(-lgcc -lc -lnosys)
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
 
-  MEMORY
+MEMORY
+{
+FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x80000
+RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x08000
+}
+
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
   {
-    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x80000
-    RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x08000
-  }
+    KEEP(*(.Vectors))
+    *(.text*)
 
-INCLUDE "/home/michael/Documents/Espruino/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/components/toolchain/gcc/linker_common_espruino.ld"
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    *(.eh_frame*)
+    . = ALIGN(4);
+  } > FLASH
+    
+
+  .ARM.extab : 
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(4);
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    . = ALIGN(4);
+  } > FLASH
+  __exidx_end = .;
+
+  __etext = .;
+  _etext = .;
+  _sidata = .;
+    
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    _sdata = .;
+    *(vtable)
+    *(.data*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    *(.preinit_array)
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    *(SORT(.init_array.*))
+    *(.init_array)
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    *(SORT(.fini_array.*))
+    *(.fini_array)
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    *(.jcr)
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+    _edata = .;
+
+  } > RAM
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    _sbss = .;
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    _ebss = .;
+  } > RAM
+  
+  .heap (COPY):
+  {
+    __end__ = .;
+    end = __end__;
+    *(.heap*)
+    __HeapLimit = .;
+  } > RAM
+
+  PROVIDE ( _end = end );
+
+  /* .stack_dummy section doesn't contains any symbols. It is only
+   * used for linker to calculate size of stack sections, and assign
+   * values to stack symbols later */
+  .stack_dummy (COPY):
+  {
+    *(.stack*)
+  } > RAM
+
+  /* Set stack top to end of RAM, and stack limit move down by
+   * size of stack_dummy section */
+  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+  _estack = __StackTop;
+  __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+  PROVIDE(__stack = __StackTop);
+  
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/examples/bsp/bsp.c
+++ b/targetlibs/nrf52/nRF52_SDK_0.9.1_3639cc9/examples/bsp/bsp.c
@@ -650,7 +650,10 @@ uint32_t bsp_buttons_disable()
 uint32_t bsp_wakeup_buttons_set(uint32_t wakeup_buttons)
 {
 #if (BUTTONS_NUMBER > 0) && !defined(BSP_SIMPLE)
-    for (uint32_t i = 0; i < BUTTONS_NUMBER; i++)
+
+    uint32_t i;
+
+    for (i = 0; i < BUTTONS_NUMBER; i++)
     {
         uint32_t new_cnf = NRF_GPIO->PIN_CNF[m_buttons_list[i]];
         uint32_t new_sense = ((1 << i) & wakeup_buttons) ? GPIO_PIN_CNF_SENSE_Low : GPIO_PIN_CNF_SENSE_Disabled;

--- a/targets/nrf52/ble_interface.c
+++ b/targets/nrf52/ble_interface.c
@@ -1,0 +1,462 @@
+/* Copyright (c) 2012 Nordic Semiconductor. All Rights Reserved.
+ *
+ * The information contained herein is property of Nordic Semiconductor ASA.
+ * Terms and conditions of usage are described in detail in NORDIC
+ * SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
+ *
+ * Licensees are granted free, non-transferable use of the information. NO
+ * WARRANTY of ANY KIND is provided. This heading must NOT be removed from
+ * the file.
+ *
+ */
+
+#include "ble_interface.h"
+
+#include "jsdevices.h"
+
+static ble_nus_t                        m_nus;                                      /**< Structure to identify the Nordic UART Service. */
+static uint16_t                         m_conn_handle = BLE_CONN_HANDLE_INVALID;    /**< Handle of the current connection. */
+
+static ble_uuid_t                       m_adv_uuids[] = {{BLE_UUID_NUS_SERVICE, NUS_SERVICE_UUID_TYPE}};  /**< Universally unique service identifier. */
+
+uint32_t ble_nus_string_send_wrapper(uint8_t * p_string, uint16_t length)
+{
+  ble_nus_string_send(&m_nus, p_string, length); // No error code here right now...
+}
+/**@brief Function for assert macro callback.
+*
+* @details This function will be called in case of an assert in the SoftDevice.
+*
+* @warning This handler is an example only and does not fit a final product. You need to analyse 
+*          how your product is supposed to react in case of Assert.
+* @warning On assert from the SoftDevice, the system can only recover on reset.
+*
+* @param[in] line_num    Line number of the failing ASSERT call.
+* @param[in] p_file_name File name of the failing ASSERT call.
+*/
+void assert_nrf_callback(uint16_t line_num, const uint8_t * p_file_name)
+{
+  app_error_handler(DEAD_BEEF, line_num, p_file_name);
+}
+
+
+/**@brief Function for the GAP initialization.
+*
+* @details This function will set up all the necessary GAP (Generic Access Profile) parameters of 
+*          the device. It also sets the permissions and appearance.
+*/
+void gap_params_init(void)
+{
+  uint32_t                err_code;
+  ble_gap_conn_params_t   gap_conn_params;
+  ble_gap_conn_sec_mode_t sec_mode;
+
+  BLE_GAP_CONN_SEC_MODE_SET_OPEN(&sec_mode);
+  
+  err_code = sd_ble_gap_device_name_set(&sec_mode,
+                                        (const uint8_t *) DEVICE_NAME,
+                                        strlen(DEVICE_NAME));
+  APP_ERROR_CHECK(err_code);
+
+  memset(&gap_conn_params, 0, sizeof(gap_conn_params));
+
+  gap_conn_params.min_conn_interval = MIN_CONN_INTERVAL;
+  gap_conn_params.max_conn_interval = MAX_CONN_INTERVAL;
+  gap_conn_params.slave_latency     = SLAVE_LATENCY;
+  gap_conn_params.conn_sup_timeout  = CONN_SUP_TIMEOUT;
+
+  err_code = sd_ble_gap_ppcp_set(&gap_conn_params);
+  APP_ERROR_CHECK(err_code);
+}
+
+
+/**@brief Function for handling the data from the Nordic UART Service.
+*
+* @details This function will process the data received from the Nordic UART BLE Service and send
+*          it to the UART module.
+*
+* @param[in] p_nus    Nordic UART Service structure.
+* @param[in] p_data   Data to be send to UART module.
+* @param[in] length   Length of the data.
+*/
+/**@snippet [Handling the data received over BLE] */
+void nus_data_handler(ble_nus_t * p_nus, uint8_t * p_data, uint16_t length)
+{
+  uint32_t i;
+
+  for (i = 0; i < length; i++)
+  {
+    jshPushIOCharEvent(EV_SERIAL1, (char) p_data[i]);
+  }
+}
+/**@snippet [Handling the data received over BLE] */
+
+
+/**@brief Function for initializing services that will be used by the application.
+*/
+void services_init(void)
+{
+  uint32_t       err_code;
+  ble_nus_init_t nus_init;
+  
+  memset(&nus_init, 0, sizeof(nus_init));
+
+  nus_init.data_handler = nus_data_handler;
+  
+  err_code = ble_nus_init(&m_nus, &nus_init);
+  APP_ERROR_CHECK(err_code);
+}
+
+
+/**@brief Function for handling an event from the Connection Parameters Module.
+*
+* @details This function will be called for all events in the Connection Parameters Module
+*          which are passed to the application.
+*
+* @note All this function does is to disconnect. This could have been done by simply setting
+*       the disconnect_on_fail config parameter, but instead we use the event handler
+*       mechanism to demonstrate its use.
+*
+* @param[in] p_evt  Event received from the Connection Parameters Module.
+*/
+void on_conn_params_evt(ble_conn_params_evt_t * p_evt)
+{
+  uint32_t err_code;
+  
+  if(p_evt->evt_type == BLE_CONN_PARAMS_EVT_FAILED)
+  {
+      err_code = sd_ble_gap_disconnect(m_conn_handle, BLE_HCI_CONN_INTERVAL_UNACCEPTABLE);
+      APP_ERROR_CHECK(err_code);
+  }
+}
+
+
+/**@brief Function for handling errors from the Connection Parameters module.
+*
+* @param[in] nrf_error  Error code containing information about what went wrong.
+*/
+void conn_params_error_handler(uint32_t nrf_error)
+{
+  APP_ERROR_HANDLER(nrf_error);
+}
+
+
+/**@brief Function for initializing the Connection Parameters module.
+*/
+void conn_params_init(void)
+{
+  uint32_t               err_code;
+  ble_conn_params_init_t cp_init;
+  
+  memset(&cp_init, 0, sizeof(cp_init));
+
+  cp_init.p_conn_params                  = NULL;
+  cp_init.first_conn_params_update_delay = FIRST_CONN_PARAMS_UPDATE_DELAY;
+  cp_init.next_conn_params_update_delay  = NEXT_CONN_PARAMS_UPDATE_DELAY;
+  cp_init.max_conn_params_update_count   = MAX_CONN_PARAMS_UPDATE_COUNT;
+  cp_init.start_on_notify_cccd_handle    = BLE_GATT_HANDLE_INVALID;
+  cp_init.disconnect_on_fail             = false;
+  cp_init.evt_handler                    = on_conn_params_evt;
+  cp_init.error_handler                  = conn_params_error_handler;
+  
+  err_code = ble_conn_params_init(&cp_init);
+  APP_ERROR_CHECK(err_code);
+}
+
+
+/**@brief Function for putting the chip into sleep mode.
+*
+* @note This function will not return.
+*/
+void sleep_mode_enter(void)
+{
+  uint32_t err_code = bsp_indication_set(BSP_INDICATE_IDLE);
+  APP_ERROR_CHECK(err_code);
+
+  // Prepare wakeup buttons.
+  err_code = bsp_btn_ble_sleep_mode_prepare();
+  APP_ERROR_CHECK(err_code);
+
+  // Go to system-off mode (this function will not return; wakeup will cause a reset).
+  err_code = sd_power_system_off();
+  APP_ERROR_CHECK(err_code);
+}
+
+
+/**@brief Function for handling advertising events.
+*
+* @details This function will be called for advertising events which are passed to the application.
+*
+* @param[in] ble_adv_evt  Advertising event.
+*/
+void on_adv_evt(ble_adv_evt_t ble_adv_evt)
+{
+  uint32_t err_code;
+
+  switch (ble_adv_evt)
+  {
+      case BLE_ADV_EVT_FAST:
+          err_code = bsp_indication_set(BSP_INDICATE_ADVERTISING);
+          APP_ERROR_CHECK(err_code);
+          break;
+      case BLE_ADV_EVT_IDLE:
+          sleep_mode_enter();
+          break;
+      default:
+          break;
+  }
+}
+
+
+/**@brief Function for the Application's S110 SoftDevice event handler.
+*
+* @param[in] p_ble_evt S110 SoftDevice event.
+*/
+void on_ble_evt(ble_evt_t * p_ble_evt)
+{
+  uint32_t                         err_code;
+  
+  switch (p_ble_evt->header.evt_id)
+  {
+      case BLE_GAP_EVT_CONNECTED:
+          err_code = bsp_indication_set(BSP_INDICATE_CONNECTED);
+          APP_ERROR_CHECK(err_code);
+          m_conn_handle = p_ble_evt->evt.gap_evt.conn_handle;
+          break;
+          
+      case BLE_GAP_EVT_DISCONNECTED:
+          err_code = bsp_indication_set(BSP_INDICATE_IDLE);
+          APP_ERROR_CHECK(err_code);
+          m_conn_handle = BLE_CONN_HANDLE_INVALID;
+          break;
+
+      case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
+          // Pairing not supported
+          err_code = sd_ble_gap_sec_params_reply(m_conn_handle, BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL, NULL);
+          APP_ERROR_CHECK(err_code);
+          break;
+
+      case BLE_GATTS_EVT_SYS_ATTR_MISSING:
+          // No system attributes have been stored.
+          err_code = sd_ble_gatts_sys_attr_set(m_conn_handle, NULL, 0, 0);
+          APP_ERROR_CHECK(err_code);
+          break;
+
+      default:
+          // No implementation needed.
+          break;
+  }
+}
+
+
+/**@brief Function for dispatching a S110 SoftDevice event to all modules with a S110 SoftDevice 
+*        event handler.
+*
+* @details This function is called from the S110 SoftDevice event interrupt handler after a S110 
+*          SoftDevice event has been received.
+*
+* @param[in] p_ble_evt  S110 SoftDevice event.
+*/
+void ble_evt_dispatch(ble_evt_t * p_ble_evt)
+{
+  ble_conn_params_on_ble_evt(p_ble_evt);
+  ble_nus_on_ble_evt(&m_nus, p_ble_evt);
+  on_ble_evt(p_ble_evt);
+  ble_advertising_on_ble_evt(p_ble_evt);
+  bsp_btn_ble_on_ble_evt(p_ble_evt);
+  
+}
+
+
+/**@brief Function for the S110 SoftDevice initialization.
+*
+* @details This function initializes the S110 SoftDevice and the BLE event interrupt.
+*/
+void ble_stack_init(void)
+{
+  uint32_t err_code;
+  
+  // Initialize SoftDevice.
+  SOFTDEVICE_HANDLER_INIT(NRF_CLOCK_LFCLKSRC_XTAL_20_PPM, NULL);
+
+  // Enable BLE stack.
+  ble_enable_params_t ble_enable_params;
+  memset(&ble_enable_params, 0, sizeof(ble_enable_params));
+#if (defined(S130) || defined(S132))
+  ble_enable_params.gatts_enable_params.attr_tab_size   = BLE_GATTS_ATTR_TAB_SIZE_DEFAULT;
+#endif
+  ble_enable_params.gatts_enable_params.service_changed = IS_SRVC_CHANGED_CHARACT_PRESENT;
+  err_code = sd_ble_enable(&ble_enable_params);
+  APP_ERROR_CHECK(err_code);
+  
+  // Subscribe for BLE events.
+  err_code = softdevice_ble_evt_handler_set(ble_evt_dispatch);
+  APP_ERROR_CHECK(err_code);
+}
+
+
+/**@brief Function for handling events from the BSP module.
+*
+* @param[in]   event   Event generated by button press.
+*/
+void bsp_event_handler(bsp_event_t event)
+{
+  uint32_t err_code;
+  switch (event)
+  {
+      case BSP_EVENT_SLEEP:
+          sleep_mode_enter();
+          break;
+
+      case BSP_EVENT_DISCONNECT:
+          err_code = sd_ble_gap_disconnect(m_conn_handle, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+          if (err_code != NRF_ERROR_INVALID_STATE)
+          {
+              APP_ERROR_CHECK(err_code);
+          }
+          break;
+
+      case BSP_EVENT_WHITELIST_OFF:
+          err_code = ble_advertising_restart_without_whitelist();
+          if (err_code != NRF_ERROR_INVALID_STATE)
+          {
+              APP_ERROR_CHECK(err_code);
+          }
+          break;
+
+      default:
+          break;
+  }
+}
+
+
+/**@brief   Function for handling app_uart events.
+*
+* @details This function will receive a single character from the app_uart module and append it to 
+*          a string. The string will be be sent over BLE when the last character received was a 
+*          'new line' i.e '\n' (hex 0x0D) or if the string has reached a length of 
+*          @ref NUS_MAX_DATA_LENGTH.
+*/
+/**@snippet [Handling the data received over UART] */
+void uart_event_handle(app_uart_evt_t * p_event)
+{
+  static uint8_t data_array[BLE_NUS_MAX_DATA_LEN];
+  static uint8_t index = 0;
+  uint32_t       err_code;
+
+  switch (p_event->evt_type)
+  {
+      case APP_UART_DATA_READY:
+          UNUSED_VARIABLE(app_uart_get(&data_array[index]));
+          index++;
+
+          if ((data_array[index - 1] == '\n') || (index >= (BLE_NUS_MAX_DATA_LEN)))
+          {
+              err_code = ble_nus_string_send(&m_nus, data_array, index);
+              if (err_code != NRF_ERROR_INVALID_STATE)
+              {
+                  APP_ERROR_CHECK(err_code);
+              }
+              
+              index = 0;
+          }
+          break;
+
+      case APP_UART_COMMUNICATION_ERROR:
+          APP_ERROR_HANDLER(p_event->data.error_communication);
+          break;
+
+      case APP_UART_FIFO_ERROR:
+          APP_ERROR_HANDLER(p_event->data.error_code);
+          break;
+
+      default:
+          break;
+  }
+}
+/**@snippet [Handling the data received over UART] */
+
+
+/**@brief  Function for initializing the UART module.
+*/
+/**@snippet [UART Initialization] */
+void uart_init(void)
+{
+  uint32_t                     err_code;
+  const app_uart_comm_params_t comm_params =
+  {
+      RX_PIN_NUMBER,
+      TX_PIN_NUMBER,
+      RTS_PIN_NUMBER,
+      CTS_PIN_NUMBER,
+      APP_UART_FLOW_CONTROL_ENABLED,
+      false,
+      UART_BAUDRATE_BAUDRATE_Baud38400
+  };
+
+  APP_UART_FIFO_INIT( &comm_params,
+                     UART_RX_BUF_SIZE,
+                     UART_TX_BUF_SIZE,
+                     uart_event_handle,
+                     APP_IRQ_PRIORITY_LOW,
+                     err_code);
+  APP_ERROR_CHECK(err_code);
+}
+/**@snippet [UART Initialization] */
+
+
+/**@brief Function for initializing the Advertising functionality.
+*/
+void advertising_init(void)
+{
+  uint32_t      err_code;
+  ble_advdata_t advdata;
+  ble_advdata_t scanrsp;
+
+  // Build advertising data struct to pass into @ref ble_advertising_init.
+  memset(&advdata, 0, sizeof(advdata));
+  advdata.name_type          = BLE_ADVDATA_FULL_NAME;
+  advdata.include_appearance = false;
+  advdata.flags              = BLE_GAP_ADV_FLAGS_LE_ONLY_LIMITED_DISC_MODE;
+
+  memset(&scanrsp, 0, sizeof(scanrsp));
+  scanrsp.uuids_complete.uuid_cnt = sizeof(m_adv_uuids) / sizeof(m_adv_uuids[0]);
+  scanrsp.uuids_complete.p_uuids  = m_adv_uuids;
+
+  ble_adv_modes_config_t options = {0};
+  options.ble_adv_fast_enabled  = BLE_ADV_FAST_ENABLED;
+  options.ble_adv_fast_interval = APP_ADV_INTERVAL;
+  options.ble_adv_fast_timeout  = APP_ADV_TIMEOUT_IN_SECONDS;
+
+  err_code = ble_advertising_init(&advdata, &scanrsp, &options, on_adv_evt, NULL);
+  APP_ERROR_CHECK(err_code);
+}
+
+
+/**@brief Function for initializing buttons and leds.
+*
+* @param[out] p_erase_bonds  Will be true if the clear bonding button was pressed to wake the application up.
+*/
+void buttons_leds_init(bool * p_erase_bonds)
+{
+  bsp_event_t startup_event;
+
+  uint32_t err_code = bsp_init(BSP_INIT_LED | BSP_INIT_BUTTONS,
+                               APP_TIMER_TICKS(100, APP_TIMER_PRESCALER), 
+                               bsp_event_handler);
+  APP_ERROR_CHECK(err_code);
+
+  err_code = bsp_btn_ble_init(NULL, &startup_event);
+  APP_ERROR_CHECK(err_code);
+
+  *p_erase_bonds = (startup_event == BSP_EVENT_CLEAR_BONDING_DATA);
+}
+
+
+/**@brief Function for placing the application in low power state while waiting for events.
+*/
+void power_manage(void)
+{
+  uint32_t err_code = sd_app_evt_wait();
+  APP_ERROR_CHECK(err_code);
+}

--- a/targets/nrf52/ble_interface.h
+++ b/targets/nrf52/ble_interface.h
@@ -1,0 +1,230 @@
+/* Copyright (c) 2012 Nordic Semiconductor. All Rights Reserved.
+ *
+ * The information contained herein is property of Nordic Semiconductor ASA.
+ * Terms and conditions of usage are described in detail in NORDIC
+ * SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
+ *
+ * Licensees are granted free, non-transferable use of the information. NO
+ * WARRANTY of ANY KIND is provided. This heading must NOT be removed from
+ * the file.
+ *
+ */
+
+/**@file
+ *
+ * @brief    BLE interface for interacting with Espruino over the air.
+ *
+ * @details Users can send and receive scripts and responses to espruino over BLE. From their smartphone or computer. Uses the nordic UART service. Recoomended to
+ * be done over smartphone using Nordic's nRF Toolbox app which can be found on their webiste nordicsemi.com and source code on their github page.
+ *
+ * @note The application must propagate S110 SoftDevice events to the Nordic UART Service module
+ *       by calling the ble_nus_on_ble_evt() function from the ble_stack_handler callback.
+ */
+
+#ifndef BLE_INTERFACE_H__
+#define BLE_INTERFACE_H__
+
+#include <stdint.h>
+#include <string.h>
+
+#include "nordic_common.h"
+#include "nrf.h"
+#include "ble_hci.h"
+#include "ble_advdata.h"
+#include "ble_advertising.h"
+#include "ble_conn_params.h"
+#include "softdevice_handler.h"
+#include "app_timer.h"
+#include "app_button.h"
+#include "ble_nus.h"
+#include "app_uart.h"
+#include "app_util_platform.h"
+#include "bsp.h"
+#include "bsp_btn_ble.h"
+
+#define IS_SRVC_CHANGED_CHARACT_PRESENT 0                                           /**< Include the service_changed characteristic. If not enabled, the server's database cannot be changed for the lifetime of the device. */
+
+#define DEVICE_NAME                     "Nordic_Espruino"                               /**< Name of device. Will be included in the advertising data. */
+#define NUS_SERVICE_UUID_TYPE           BLE_UUID_TYPE_VENDOR_BEGIN                  /**< UUID type for the Nordic UART Service (vendor specific). */
+
+#define APP_ADV_INTERVAL                64                                          /**< The advertising interval (in units of 0.625 ms. This value corresponds to 40 ms). */
+#define APP_ADV_TIMEOUT_IN_SECONDS      180                                         /**< The advertising timeout (in units of seconds). */
+
+#define APP_TIMER_PRESCALER             0                                           /**< Value of the RTC1 PRESCALER register. */
+#define APP_TIMER_MAX_TIMERS            (2 + BSP_APP_TIMERS_NUMBER)                 /**< Maximum number of simultaneously created timers. */
+#define APP_TIMER_OP_QUEUE_SIZE         4                                           /**< Size of timer operation queues. */
+
+#define MIN_CONN_INTERVAL               MSEC_TO_UNITS(20, UNIT_1_25_MS)             /**< Minimum acceptable connection interval (20 ms), Connection interval uses 1.25 ms units. */
+#define MAX_CONN_INTERVAL               MSEC_TO_UNITS(75, UNIT_1_25_MS)             /**< Maximum acceptable connection interval (75 ms), Connection interval uses 1.25 ms units. */
+#define SLAVE_LATENCY                   0                                           /**< Slave latency. */
+#define CONN_SUP_TIMEOUT                MSEC_TO_UNITS(4000, UNIT_10_MS)             /**< Connection supervisory timeout (4 seconds), Supervision Timeout uses 10 ms units. */
+#define FIRST_CONN_PARAMS_UPDATE_DELAY  APP_TIMER_TICKS(5000, APP_TIMER_PRESCALER)  /**< Time from initiating event (connect or start of notification) to first time sd_ble_gap_conn_param_update is called (5 seconds). */
+#define NEXT_CONN_PARAMS_UPDATE_DELAY   APP_TIMER_TICKS(30000, APP_TIMER_PRESCALER) /**< Time between each call to sd_ble_gap_conn_param_update after the first call (30 seconds). */
+#define MAX_CONN_PARAMS_UPDATE_COUNT    3                                           /**< Number of attempts before giving up the connection parameter negotiation. */
+
+#define DEAD_BEEF                       0xDEADBEEF                                  /**< Value used as error code on stack dump, can be used to identify stack location on stack unwind. */
+
+#define UART_TX_BUF_SIZE                128                                         /**< UART TX buffer size. */
+#define UART_RX_BUF_SIZE                128                                         /**< UART RX buffer size. */
+
+/**@brief Function for sending a string to the peer.
+ *
+ * @details This function sends the input string as an RX characteristic notification to the
+ *          peer.
+ *
+ * @param[in] p_string    String to be sent.
+ * @param[in] length      Length of the string.
+ *
+ * @retval NRF_SUCCESS If the string was sent successfully. Otherwise, an error code is returned.
+ */
+uint32_t ble_nus_string_send_wrapper(uint8_t * p_string, uint16_t length);
+/**@brief Function for assert macro callback.
+ *
+ * @details This function will be called in case of an assert in the SoftDevice.
+ *
+ * @warning This handler is an example only and does not fit a final product. You need to analyse 
+ *          how your product is supposed to react in case of Assert.
+ * @warning On assert from the SoftDevice, the system can only recover on reset.
+ *
+ * @param[in] line_num    Line number of the failing ASSERT call.
+ * @param[in] p_file_name File name of the failing ASSERT call.
+ */
+void assert_nrf_callback(uint16_t line_num, const uint8_t * p_file_name);
+
+
+/**@brief Function for the GAP initialization.
+ *
+ * @details This function will set up all the necessary GAP (Generic Access Profile) parameters of 
+ *          the device. It also sets the permissions and appearance.
+ */
+void gap_params_init(void);
+
+
+/**@brief Function for handling the data from the Nordic UART Service.
+ *
+ * @details This function will process the data received from the Nordic UART BLE Service and send
+ *          it to the UART module.
+ *
+ * @param[in] p_nus    Nordic UART Service structure.
+ * @param[in] p_data   Data to be send to UART module.
+ * @param[in] length   Length of the data.
+ */
+/**@snippet [Handling the data received over BLE] */
+void nus_data_handler(ble_nus_t * p_nus, uint8_t * p_data, uint16_t length);
+/**@snippet [Handling the data received over BLE] */
+
+
+/**@brief Function for initializing services that will be used by the application.
+ */
+void services_init(void);
+
+
+/**@brief Function for handling an event from the Connection Parameters Module.
+ *
+ * @details This function will be called for all events in the Connection Parameters Module
+ *          which are passed to the application.
+ *
+ * @note All this function does is to disconnect. This could have been done by simply setting
+ *       the disconnect_on_fail config parameter, but instead we use the event handler
+ *       mechanism to demonstrate its use.
+ *
+ * @param[in] p_evt  Event received from the Connection Parameters Module.
+ */
+void on_conn_params_evt(ble_conn_params_evt_t * p_evt);
+
+
+/**@brief Function for handling errors from the Connection Parameters module.
+ *
+ * @param[in] nrf_error  Error code containing information about what went wrong.
+ */
+void conn_params_error_handler(uint32_t nrf_error);
+
+
+/**@brief Function for initializing the Connection Parameters module.
+ */
+void conn_params_init(void);
+
+
+/**@brief Function for putting the chip into sleep mode.
+ *
+ * @note This function will not return.
+ */
+void sleep_mode_enter(void);
+
+
+/**@brief Function for handling advertising events.
+ *
+ * @details This function will be called for advertising events which are passed to the application.
+ *
+ * @param[in] ble_adv_evt  Advertising event.
+ */
+void on_adv_evt(ble_adv_evt_t ble_adv_evt);
+
+
+/**@brief Function for the Application's S110 SoftDevice event handler.
+ *
+ * @param[in] p_ble_evt S110 SoftDevice event.
+ */
+void on_ble_evt(ble_evt_t * p_ble_evt);
+
+/**@brief Function for dispatching a S110 SoftDevice event to all modules with a S110 SoftDevice 
+ *        event handler.
+ *
+ * @details This function is called from the S110 SoftDevice event interrupt handler after a S110 
+ *          SoftDevice event has been received.
+ *
+ * @param[in] p_ble_evt  S110 SoftDevice event.
+ */
+void ble_evt_dispatch(ble_evt_t * p_ble_evt);
+
+
+/**@brief Function for the S110 SoftDevice initialization.
+ *
+ * @details This function initializes the S110 SoftDevice and the BLE event interrupt.
+ */
+void ble_stack_init(void);
+
+
+/**@brief Function for handling events from the BSP module.
+ *
+ * @param[in]   event   Event generated by button press.
+ */
+void bsp_event_handler(bsp_event_t event);
+
+
+/**@brief   Function for handling app_uart events.
+ *
+ * @details This function will receive a single character from the app_uart module and append it to 
+ *          a string. The string will be be sent over BLE when the last character received was a 
+ *          'new line' i.e '\n' (hex 0x0D) or if the string has reached a length of 
+ *          @ref NUS_MAX_DATA_LENGTH.
+ */
+/**@snippet [Handling the data received over UART] */
+void uart_event_handle(app_uart_evt_t * p_event);
+
+
+/**@brief  Function for initializing the UART module.
+ */
+/**@snippet [UART Initialization] */
+void uart_init(void);
+
+
+/**@brief Function for initializing the Advertising functionality.
+ */
+void advertising_init(void);
+
+
+/**@brief Function for initializing buttons and leds.
+ *
+ * @param[out] p_erase_bonds  Will be true if the clear bonding button was pressed to wake the application up.
+ */
+void buttons_leds_init(bool * p_erase_bonds);
+
+
+/**@brief Function for placing the application in low power state while waiting for events.
+ */
+void power_manage(void);
+
+#endif // BLE_INTERFACE_H__
+
+/** @} */

--- a/targets/nrf52/main.c
+++ b/targets/nrf52/main.c
@@ -45,7 +45,7 @@ int main() {
   jshInit();
   jsvInit();
   jsiInit(false);
-  debug_all_leds_on();
+  //debug_all_leds_on();
 
   while (1) 
   {

--- a/targets/nrf52/uart_interface.c
+++ b/targets/nrf52/uart_interface.c
@@ -1,0 +1,66 @@
+/* Copyright (c) 2012 Nordic Semiconductor. All Rights Reserved.
+ *
+ * The information contained herein is property of Nordic Semiconductor ASA.
+ * Terms and conditions of usage are described in detail in NORDIC
+ * SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
+ *
+ * Licensees are granted free, non-transferable use of the information. NO
+ * WARRANTY of ANY KIND is provided. This heading must NOT be removed from
+ * the file.
+ *
+ */
+
+#include "uart_interface.h"
+
+#include "jsdevices.h"
+
+// UART callback function. Registered in uart_init(). Allows to asychronously read characters from UART.
+void uart_event_handle(app_uart_evt_t * p_event)
+{
+  if (p_event->evt_type == APP_UART_COMMUNICATION_ERROR)
+  {
+    APP_ERROR_HANDLER(p_event->data.error_communication);
+  }
+  else if (p_event->evt_type == APP_UART_FIFO_ERROR)
+  {
+    APP_ERROR_HANDLER(p_event->data.error_code);
+  }
+  else if (p_event->evt_type == APP_UART_DATA_READY) // There is one byte in the RX FIFO.
+  {
+    uint8_t character;
+    while(app_uart_get(&character) != NRF_SUCCESS); // Non blocking.
+    jshPushIOCharEvent(EV_SERIAL1, (char) character);
+  }
+}
+
+// Initialzes non blocking serial communication with terminal via uart. Returns 0 on success, -1 on an error.
+int uart_init()
+{
+  uint32_t err_code;
+
+  const app_uart_comm_params_t comm_params =
+  {
+      RX_PIN_NUMBER,
+      TX_PIN_NUMBER,
+      UART_PIN_DISCONNECTED,
+      UART_PIN_DISCONNECTED,
+      APP_UART_FLOW_CONTROL_DISABLED,
+      false,
+      UART_BAUDRATE_BAUDRATE_Baud38400
+  };
+
+  APP_UART_FIFO_INIT(&comm_params,
+                     UART_RX_BUF_SIZE,
+                     UART_TX_BUF_SIZE,
+                     uart_event_handle,
+                     APP_IRQ_PRIORITY_LOW,
+                     err_code);
+
+  APP_ERROR_CHECK(err_code);
+
+  if (err_code != NRF_SUCCESS)
+  {
+    return -1;
+  }
+  return 0;
+}

--- a/targets/nrf52/uart_interface.h
+++ b/targets/nrf52/uart_interface.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2012 Nordic Semiconductor. All Rights Reserved.
+ *
+ * The information contained herein is property of Nordic Semiconductor ASA.
+ * Terms and conditions of usage are described in detail in NORDIC
+ * SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
+ *
+ * Licensees are granted free, non-transferable use of the information. NO
+ * WARRANTY of ANY KIND is provided. This heading must NOT be removed from
+ * the file.
+ *
+ */
+
+/**@file
+ *
+ * @brief    Interact with Espruino through simulated USB port over UART. Serial communcitaiton with terminal as with other Espruino devices.
+ *
+ */
+
+#ifndef UART_INTERFACE_H__
+#define UART_INTERFACE_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "app_uart.h"
+#include "app_error.h"
+#include "nrf_delay.h"
+#include "nrf.h"
+#include "bsp.h"
+ 
+#define MAX_TEST_DATA_BYTES (15U)
+#define UART_TX_BUF_SIZE 64                         /**< UART TX buffer size. */
+#define UART_RX_BUF_SIZE 32                         /**< UART RX buffer size. */
+
+// UART callback function. Registered in uart_init(). Allows to asychronously read characters from UART.
+void uart_event_handle(app_uart_evt_t * p_event);
+
+// Initialzes non blocking serial communication with terminal via uart. Returns 0 on success, -1 on an error.
+int uart_init();
+
+#endif // UART_INTERFACE_H__
+
+/** @} */


### PR DESCRIPTION
This implements both a BLE Interface and the standard Serial interface for the nRF52832 Preview Development kit.

Now the user can choose to communicate with Espruino over the air through Bluetooth low energy. This means user can send commands like digitalWrite(18, 1);

to the nRF52 chip with their smartphone (or computer) instead of the Espruino IDE, no wires required.

Recommended to use nRF Toolbox app https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrftoolbox&hl=en and specifically the UART module. Note softdevice must be programmed onto nRF52 before Espruino is programmed but i am working on fixing this.

Also not hex files are programmed to nRF52 using nRFgo Studio https://www.nordicsemi.com/eng/nordic/Products/nRFgo-Studio/nRFgo-Studio-Win64/14964.

Also i will improve instructions.

No features implemented in jshardware.c yet, just communication and write to GPIO.