### PR TITLE
Implementation of #655

### DIFF
--- a/libs/network/esp8266/jswrap_esp8266.c
+++ b/libs/network/esp8266/jswrap_esp8266.c
@@ -563,10 +563,32 @@ JsVar *jswrap_ESP8266WiFi_getRstInfo() {
 /*JSON{
   "type"     : "staticmethod",
   "class"    : "ESP8266WiFi",
+  "name"     : "logDebug",
+  "generate" : "jswrap_ESP8266WiFi_logDebug",
+  "params"   : [
+    ["enable", "JsVar", "Enable or disable the debug logging."]
+  ]
+}
+ * Enable or disable the logging of debug information.  A value of `true` enables
+ * debug logging while a value of `false` disables debug logging.  Debug output is sent
+ * to UART1.
+ */
+void jswrap_ESP8266WiFi_logDebug(
+    JsVar *jsDebug
+  ) {
+  uint8 enable = (uint8)jsvGetBool(jsDebug);
+  os_printf("> jswrap_ESP8266WiFi_logDebug, enable=%d\n", enable);
+  system_set_os_print((uint8)jsvGetBool(jsDebug));
+  os_printf("< jswrap_ESP8266WiFi_logDebug\n");
+}
+
+/*JSON{
+  "type"     : "staticmethod",
+  "class"    : "ESP8266WiFi",
   "name"     : "updateCPUFreq",
   "generate" : "jswrap_ESP8266WiFi_updateCPUFreq",
   "params"   : [
-    ["freq","JsVar","Desired frequency - either 80 or 160."]
+    ["freq", "JsVar", "Desired frequency - either 80 or 160."]
   ]
 }
  * Update the operating frequency of the ESP8266 processor.

--- a/libs/network/esp8266/jswrap_esp8266.h
+++ b/libs/network/esp8266/jswrap_esp8266.h
@@ -35,6 +35,7 @@ JsVar *jswrap_ESP8266WiFi_getState();
 JsVar *jswrap_ESP8266WiFi_getStationConfig();
 void   jswrap_ESP8266WiFi_init();
 void   jswrap_ESP8266WiFi_kill();
+void   jswrap_ESP8266WiFi_logDebug(JsVar *jsDebug);
 void   jswrap_ESP8266WiFi_mdnsInit();
 void   jswrap_ESP8266WiFi_onWiFiEvent(JsVar *callback);
 void   jswrap_ESP8266WiFi_ping(JsVar *ipAddr, JsVar *pingCallback);

--- a/src/jsvar.c
+++ b/src/jsvar.c
@@ -1386,6 +1386,16 @@ void jsvSetInteger(JsVar *v, JsVarInt value) {
   v->varData.integer  = value;
 }
 
+/**
+ * Get the boolean value of a variable.
+ * From a JavaScript variable, we determine its boolean value.  The rules
+ * are:
+ *
+ * * If integer, true if value is not 0.
+ * * If float, true if value is not 0.0.
+ * * If function, array or object, always true.
+ * * If string, true if length of string is greater than 0.
+ */
 bool jsvGetBool(const JsVar *v) {
   if (jsvIsString(v))
     return jsvGetStringLength((JsVar*)v)!=0;

--- a/targets/esp8266/docs/05-User_Guide.md
+++ b/targets/esp8266/docs/05-User_Guide.md
@@ -367,3 +367,13 @@ Set the operating frequency of the ESP8266 processor.
 `ESP8266WiFi.updateCPUFreq(newFreq)`
 
 * `newFreq` - The new operating frequency of the CPU.  Either 80 (80MHz) or 160 (160MHz).
+
+----
+
+##ESP8266WiFi.logDebug
+
+Enable or disable the logging of debug messages to the UART1 debug log.
+
+`ESP8266WiFi.logDebug(onOff)`
+
+* `onOff` - A boolean.  A value of `true` enables debugging while `false` disables.


### PR DESCRIPTION
Issue #655 adds the ability to disable ESP8266 debugging to UART1.  The new JS level API called `ESP8266WiFi.logDebug(onOff)` has been added.