### PR TITLE
fix: typo in sleep pin indicator dump

### DIFF
--- a/src/jsinteractive.c
+++ b/src/jsinteractive.c
@@ -587,7 +587,7 @@ void jsiDumpHardwareInitialisation(vcbprintf_callback user_callback, void *user_
   if (pinBusyIndicator != DEFAULT_BUSY_PIN_INDICATOR) {
     cbprintf(user_callback, user_data, "setBusyIndicator(%p);\n", pinBusyIndicator);
   }
-  if (pinSleepIndicator != DEFAULT_BUSY_PIN_INDICATOR) {
+  if (pinSleepIndicator != DEFAULT_SLEEP_PIN_INDICATOR) {
     cbprintf(user_callback, user_data, "setSleepIndicator(%p);\n", pinSleepIndicator);
   }
   if (jsiStatus&JSIS_ALLOW_DEEP_SLEEP) {


### PR DESCRIPTION
Clear copy-paste bug that lead to error while `save()` if busy pin is set and sleep pin is not.

Also, note `jspin.c:187`. Should we write `UNKNOWN` there? Maybe `undefined` is a better idea? In current state, following scenario is possible:

```
Uncaught ReferenceError: "UNKNOWN" is not defined
 at line 1 col 19
setSleepIndicator(UNKNOWN);
                  ^
>dump()
setSleepIndicator(UNKNOWN);
```

Use of `undefined` instead of `UNKNOWN` would solve the problem.