### PR TITLE
Add definition for HY-TinySTM103T

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,14 @@ STLIB=STM32F10X_MD
 PRECOMPILED_OBJS+=$(ROOT)/targetlibs/stm32f1/lib/startup_stm32f10x_md.o
 OPTIMIZEFLAGS+=-Os # short on program memory
 
+else ifdef HYTINY_STM103T
+EMBEDDED=1
+SAVE_ON_FLASH=1
+BOARD=HYTINY_STM103T
+STLIB=STM32F10X_MD
+PRECOMPILED_OBJS+=$(ROOT)/targetlibs/stm32f1/lib/startup_stm32f10x_md.o
+OPTIMIZEFLAGS+=-Os # short on program memory
+
 else ifdef MAPLERET6_STM32
 EMBEDDED=1
 USE_NET=1

--- a/boards/HYTINY_STM103T.py
+++ b/boards/HYTINY_STM103T.py
@@ -1,0 +1,84 @@
+#!/bin/false
+# This file is part of Espruino, a JavaScript interpreter for Microcontrollers
+#
+# Copyright (C) 2013 Gordon Williams <gw@pur3.co.uk>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# ----------------------------------------------------------------------------------------
+# This file contains information for a specific board - the available pins, and where LEDs,
+# Buttons, and other in-built peripherals are. It is used to build documentation as well
+# as various source and header files for Espruino.
+# ----------------------------------------------------------------------------------------
+
+import pinutils;
+import json;
+info = {
+ 'name' : "Haoyu HY-TinySTM103T",
+ 'link' :  [ "http://www.hotmcu.com/stm32f103tb-arm-cortex-m3-development-board-p-222.html" ],
+ 'variables' : 1020,
+ 'binary_name' : 'espruino_%v_hytiny_stm103t.bin',
+};
+chip = {
+  'part' : "STM32F103TBT6", 
+  'family' : "STM32F1",
+  'package' : "VFQFPN36",
+  'ram' : 20,
+  'flash' : 128,
+  'speed' : 72,
+  'usart' : 2,
+  'spi' : 1,
+  'i2c' : 1,
+  'adc' : 2,
+  'dac' : 0,
+  'saved_code' : {
+    'address' : 0x08000000 + ((128-6)*1024),
+    'page_size' : 1024, # size of pages
+    'pages' : 6, # number of pages we're using
+    'flash_available' : 128-6 # 6 used for code
+  },
+};
+
+devices = {
+# 'OSC' : { 'pin_1' :  'D0',
+#           'pin_2' : 'D1' },
+  'LED1' : { 'pin' : 'A1' },
+  'USB' : { 'pin_disc' : 'A0',
+            'pin_dm' : 'A11',
+            'pin_dp' : 'A12' 
+          },
+};
+
+# left-right, or top-bottom order
+board = {
+  'left' : [ '3V3','A3','A4','A5','A6','A7','B0','B1','B2','A8','A9','A10','A11','A12','GND' ],
+  'right' : [ 'GND','A1','A2','A0','RST','ISP','A14','A13','B7','B6','B5','B4','B3','A15','5V' ],
+};
+board["_css"] = """
+#board {
+  width: 540px;
+  height: 418px;
+  top: 300px;
+  left: 200px;
+  background-image: url(img/HYTINY_STM103T.jpg);
+}
+#boardcontainer {
+  height: 850px;
+}
+left {
+  top: 155px;
+  right: 520px;
+  
+}
+right {
+  top: 155px;
+  left: 520px;
+}
+
+""";
+
+def get_pins():
+  pins = pinutils.scan_pin_file([], 'stm32f103xb.csv', 6, 10, 11)
+  return pinutils.only_from_package(pinutils.fill_gaps_in_pin_list(pins), chip["package"])


### PR DESCRIPTION
This board has an STM32F103TB, i.e. 128K flash, 20K RAM - no file system support enabled, so still a little room left in flash. As with the Olimexino-STM32, this defines 1020 vars.

There's still a quirk with the generated pin file, see #711.