### PR TITLE
set default values for mem & cpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.bin
 *.pyc
 gen/*
+.vagrant/*
 boards/*.html
 boards/*.json
 zipcontents

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,9 @@ Vagrant.configure(2) do |config|
   ## VIRTUALBOX ##
 
   config.vm.provider "virtualbox" do |v|
+    # Give some pessimistic default values, fix errors on Windows
+	mem = 512
+	cpus = 2
     # Give VM 1/4 system memory & access to all cpu cores on the host
     if host =~ /darwin/
       cpus = `sysctl -n hw.ncpu`.to_i


### PR DESCRIPTION
Currently, following https://github.com/espruino/Espruino/blob/master/README_Building.md#building-under-windowsmacos-with-a-vm-vagrant will lead to error on windows
Adding default values for cpus and mem fixes this