### PR TITLE
make vagrant up pull arm-none-eabi-gcc v4.8.4 and set it to PATH

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -2,8 +2,26 @@
 #
 # This script is run by Vagrant when a new machine is provisioned.
 #
+ 
+sudo apt-get -y install git
+# add support for 64 bit (which vagrant is set to configure)
+sudo apt-get -y install lib32z1 lib32ncurses5 lib32bz2-1.0
+sudo apt-get -y install lib32ncurses5
+sudo apt-get -y install ia32-libs
+ 
+# download known working version of arm-none-eabi-gcc
+sudo mkdir ~/gcc-temp
+cd ~/gcc-temp
+sudo wget https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q3-update/+download/gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2
+cd /usr/local
+sudo tar xjf ~/gcc-temp/gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2
+ 
+# apply setup config to add compiler to PATH
+# from stackoverflow i.e http://stackoverflow.com/a/28279205
+echo "source /vagrant/scripts/vagrant_setup.sh" >> /home/vagrant/.bashrc
 
-sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded
-sudo apt-get update
-sudo apt-get install -y gcc-arm-none-eabi git
 
+# for reference, this is what _should_ work
+#sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded #<- sadly wrong version
+#sudo apt-get update
+#sudo apt-get install -y gcc-arm-none-eabi git

--- a/scripts/vagrant_setup.sh
+++ b/scripts/vagrant_setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# This is sourced from /home/vagrant/.bashrc, triggered by vagrant ssh
+#
+export PATH="$PATH:/usr/local/gcc-arm-none-eabi-4_8-2014q3/bin/"


### PR DESCRIPTION
this will make it possible to do

`vagrant up && vagrant ssh && scripts/create_espruino_image_1v3.sh` and it chooses the correct compiler