### PR TITLE
Reduce Advertising Interval to 750ms

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -51,7 +51,7 @@ of beta.  */
 #define DEVICE_NAME                     "Espruino "PC_BOARD_ID                      /**< Name of device. Will be included in the advertising data. */
 #define NUS_SERVICE_UUID_TYPE           BLE_UUID_TYPE_VENDOR_BEGIN                  /**< UUID type for the Nordic UART Service (vendor specific). */
 
-#define APP_ADV_INTERVAL                1600                                        /**< The advertising interval (in units of 0.625 ms. This value corresponds to 1s). */
+#define APP_ADV_INTERVAL                1200                                        /**< The advertising interval (in units of 0.625 ms. This value corresponds to 750ms). */
 #define APP_ADV_TIMEOUT_IN_SECONDS      180                                         /**< The advertising timeout (in units of seconds). */
 
 #define APP_TIMER_PRESCALER             0                                           /**< Value of the RTC1 PRESCALER register. */


### PR DESCRIPTION
As seen in https://code.google.com/p/chromium/issues/detail?id=580548#c4, reducing the Advertising Interval makes it easier to connect to Chrome OS devices.

When Chrome OS 50 reaches stable channel, it might be good to revisit this decision and see if we can reset the Advertising Interval to 1s in order to keep battery's life longer.

R=@gfwilliams