### PR TITLE
Make crypto compile for ESP8266

### DIFF
--- a/libs/crypto/jswrap_crypto.c
+++ b/libs/crypto/jswrap_crypto.c
@@ -88,7 +88,7 @@ JsVar *jswrap_crypto_error_to_jsvar(int err) {
 
 void jswrap_crypto_error(int err) {
   const char *e = jswrap_crypto_error_to_str(err);
-  if (e) jsError(e);
+  if (e) jsError("%s", e);
   else jsError("Unknown error: -0x%x", -err);
 }
 


### PR DESCRIPTION
Before this fix, compiler complained about `invalid initializer`.