### PR TITLE
#define USE_AES to make SHAx functions available on ESP8266

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1001,37 +1001,32 @@ ifeq ($(BOARD),MICROBIT)
 endif
 
 ifdef USE_CRYPTO
+  DEFINES += -DUSE_CRYPTO
   INCLUDE += -I$(ROOT)/libs/crypto
   INCLUDE += -I$(ROOT)/libs/crypto/mbedtls
   INCLUDE += -I$(ROOT)/libs/crypto/mbedtls/include
   WRAPPERSOURCES += libs/crypto/jswrap_crypto.c
+  SOURCES += \
+libs/crypto/mbedtls/library/sha1.c \
+libs/crypto/mbedtls/library/sha256.c \
+libs/crypto/mbedtls/library/sha512.c
 
 ifdef USE_TLS
-  DEFINES += -DUSE_TLS
+  USE_AES=1
+  DEFINES += -DUSE_TLS=1 -DUSE_AES=1
   SOURCES += \
-libs/crypto/mbedtls/library/aes.c \
-libs/crypto/mbedtls/library/asn1parse.c \
 libs/crypto/mbedtls/library/bignum.c \
-libs/crypto/mbedtls/library/cipher.c \
-libs/crypto/mbedtls/library/cipher_wrap.c \
 libs/crypto/mbedtls/library/ctr_drbg.c \
 libs/crypto/mbedtls/library/debug.c \
 libs/crypto/mbedtls/library/ecp.c \
 libs/crypto/mbedtls/library/ecp_curves.c \
 libs/crypto/mbedtls/library/entropy.c \
 libs/crypto/mbedtls/library/entropy_poll.c \
-libs/crypto/mbedtls/library/md.c \
 libs/crypto/mbedtls/library/md5.c \
-libs/crypto/mbedtls/library/md_wrap.c \
-libs/crypto/mbedtls/library/oid.c \
 libs/crypto/mbedtls/library/pk.c \
-libs/crypto/mbedtls/library/pkcs5.c \
 libs/crypto/mbedtls/library/pkparse.c \
 libs/crypto/mbedtls/library/pk_wrap.c \
 libs/crypto/mbedtls/library/rsa.c \
-libs/crypto/mbedtls/library/sha1.c \
-libs/crypto/mbedtls/library/sha256.c \
-libs/crypto/mbedtls/library/sha512.c \
 libs/crypto/mbedtls/library/ssl_ciphersuites.c \
 libs/crypto/mbedtls/library/ssl_cli.c \
 libs/crypto/mbedtls/library/ssl_tls.c \
@@ -1039,6 +1034,12 @@ libs/crypto/mbedtls/library/ssl_srv.c \
 libs/crypto/mbedtls/library/x509.c \
 libs/crypto/mbedtls/library/x509_crt.c
 else
+ifndef ESP8266_BOARD
+ DEFINES += -DUSE_AES=1
+endif
+endif
+ifdef USE_AES
+  DEFINES += -DUSE_AES
   SOURCES += \
 libs/crypto/mbedtls/library/aes.c \
 libs/crypto/mbedtls/library/asn1parse.c \
@@ -1047,10 +1048,7 @@ libs/crypto/mbedtls/library/cipher_wrap.c \
 libs/crypto/mbedtls/library/md.c \
 libs/crypto/mbedtls/library/md_wrap.c \
 libs/crypto/mbedtls/library/oid.c \
-libs/crypto/mbedtls/library/pkcs5.c \
-libs/crypto/mbedtls/library/sha1.c \
-libs/crypto/mbedtls/library/sha256.c \
-libs/crypto/mbedtls/library/sha512.c
+libs/crypto/mbedtls/library/pkcs5.c 
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -499,6 +499,7 @@ else ifdef ESP8266_BOARD
 EMBEDDED=1
 USE_NET=1
 USE_TELNET=1
+USE_CRYPTO=1
 #USE_GRAPHICS=1
 BOARD=ESP8266_BOARD
 # Enable link-time optimisations (inlining across files), use -Os 'cause else we end up with

--- a/libs/crypto/jswrap_crypto.c
+++ b/libs/crypto/jswrap_crypto.c
@@ -17,7 +17,9 @@
 #include "jsvariterator.h"
 #include "jswrap_crypto.h"
 
+#ifdef USE_AES
 #include "mbedtls/include/mbedtls/aes.h"
+#endif
 #include "mbedtls/include/mbedtls/sha1.h"
 #include "mbedtls/include/mbedtls/sha256.h"
 #include "mbedtls/include/mbedtls/sha512.h"
@@ -32,7 +34,7 @@
 /*JSON{
   "type" : "library",
   "class" : "crypto",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_CRYPTO"
 }
 Cryptographic functions
 
@@ -57,7 +59,7 @@ Class containing AES encryption/decryption
   "generate_full" : "jspNewBuiltin(\"AES\");",
   "return" : ["JsVar"],
   "return_object" : "AES",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_AES"
 }
 Class containing AES encryption/decryption
 */
@@ -75,7 +77,9 @@ const char *jswrap_crypto_error_to_str(int err) {
     case MBEDTLS_ERR_MD_ALLOC_FAILED: return "Not enough memory";
     case MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE: return "Feature unavailable";
     case MBEDTLS_ERR_MD_BAD_INPUT_DATA: return "Bad input data";
+#ifdef USE_AES	
     case MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH: return "Invalid input length";
+#endif
   }
   return 0;
 }
@@ -153,7 +157,7 @@ JsVar *jswrap_crypto_SHAx(JsVar *message, int shaNum) {
   ],
   "return" : ["JsVar","Returns a 20 byte ArrayBuffer"],
   "return_object" : "ArrayBuffer",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_CRYPTO"
 }
 
 Performs a SHA1 hash and returns the result as a 20 byte ArrayBuffer
@@ -168,7 +172,7 @@ Performs a SHA1 hash and returns the result as a 20 byte ArrayBuffer
   ],
   "return" : ["JsVar","Returns a 20 byte ArrayBuffer"],
   "return_object" : "ArrayBuffer",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_CRYPTO"
 }
 
 Performs a SHA224 hash and returns the result as a 28 byte ArrayBuffer
@@ -183,7 +187,7 @@ Performs a SHA224 hash and returns the result as a 28 byte ArrayBuffer
   ],
   "return" : ["JsVar","Returns a 20 byte ArrayBuffer"],
   "return_object" : "ArrayBuffer",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_CRYPTO"
 }
 
 Performs a SHA256 hash and returns the result as a 32 byte ArrayBuffer
@@ -198,7 +202,7 @@ Performs a SHA256 hash and returns the result as a 32 byte ArrayBuffer
   ],
   "return" : ["JsVar","Returns a 20 byte ArrayBuffer"],
   "return_object" : "ArrayBuffer",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_CRYPTO"
 }
 
 Performs a SHA384 hash and returns the result as a 48 byte ArrayBuffer
@@ -213,13 +217,13 @@ Performs a SHA384 hash and returns the result as a 48 byte ArrayBuffer
   ],
   "return" : ["JsVar","Returns a 32 byte ArrayBuffer"],
   "return_object" : "ArrayBuffer",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_CRYPTO"
 }
 
 Performs a SHA512 hash and returns the result as a 64 byte ArrayBuffer
 */
 
-
+#ifdef USE_TLS
 /*JSON{
   "type" : "staticmethod",
   "class" : "crypto",
@@ -405,6 +409,8 @@ static NO_INLINE JsVar *jswrap_crypto_AEScrypt(JsVar *message, JsVar *key, JsVar
     return 0;
   }
 }
+#endif
+#ifdef USE_AES
 
 /*JSON{
   "type" : "staticmethod",
@@ -418,7 +424,7 @@ static NO_INLINE JsVar *jswrap_crypto_AEScrypt(JsVar *message, JsVar *key, JsVar
   ],
   "return" : ["JsVar","Returns an ArrayBuffer"],
   "return_object" : "ArrayBuffer",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_AES"
 }
 */
 JsVar *jswrap_crypto_AES_encrypt(JsVar *message, JsVar *key, JsVar *options) {
@@ -437,9 +443,10 @@ JsVar *jswrap_crypto_AES_encrypt(JsVar *message, JsVar *key, JsVar *options) {
   ],
   "return" : ["JsVar","Returns an ArrayBuffer"],
   "return_object" : "ArrayBuffer",
-  "ifdef" : "USE_TLS"
+  "ifdef" : "USE_AES"
 }
 */
 JsVar *jswrap_crypto_AES_decrypt(JsVar *message, JsVar *key, JsVar *options) {
   return jswrap_crypto_AEScrypt(message, key, options, false);
 }
+#endif

--- a/libs/crypto/jswrap_crypto.h
+++ b/libs/crypto/jswrap_crypto.h
@@ -14,10 +14,12 @@
  * ----------------------------------------------------------------------------
  */
 #include "jsvar.h"
-
 JsVar *jswrap_crypto_error_to_jsvar(int err);
-
 JsVar *jswrap_crypto_SHAx(JsVar *message, int shaNum);
+#ifdef USE_TLS
 JsVar *jswrap_crypto_PBKDF2(JsVar *passphrase, JsVar *salt, JsVar *options);
+#endif
+#ifdef USE_AES
 JsVar *jswrap_crypto_AES_encrypt(JsVar *message, JsVar *key, JsVar *options);
 JsVar *jswrap_crypto_AES_decrypt(JsVar *message, JsVar *key, JsVar *options);
+#endif


### PR DESCRIPTION
I have tested with the Linux build and the Esp8266 build.

The linux builds as before.

For the esp   ./build-crypto.sh:

````
#! /bin/bash
export ESP8266_BOARD=1
export FLASH_4MB=1
export USE_CRYPTO=1
export ESP8266_SDK_ROOT=/home/esp8266/Espruino/esp_iot_sdk_v1.5.0
export PATH=~/esp-open-sdk/xtensa-lx106-elf/bin:$PATH
export COMPORT=/dev/ttyUSB0
export release=1
make $*
```

