### PR TITLE
Update vector_font.h

### DIFF
--- a/libs/graphics/vector_font.h
+++ b/libs/graphics/vector_font.h
@@ -15,7 +15,7 @@
 #define VECTOR_FONT_IS_EDGE 128 // applied to X coord if this point and the next are on an edge
 #define VECTOR_FONT_POLY_SEPARATOR 128 // applied to Y coord if the end of a poly
 #define VECTOR_FONT_POLY_SIZE 96 // the actual size of the font
-static const unsigned char vectorFontPolys[] IN_FLASH_MEMORY = {
+unsigned char vectorFontPolys[] IN_FLASH_MEMORY = {
 // Character code 32
 // Character code 33
 	24,8,


### PR DESCRIPTION
have to remove  static const otherwise there is a conflict with FLASH_STR

libs/graphics/vector_font.h:18:28: error: vectorFontPolys causes a section type conflict with flash_X
 static const unsigned char vectorFontPolys[] IN_FLASH_MEMORY = {
                            ^
In file included from libs/graphics/graphics.h:18:0,
                 from libs/graphics/graphics.c:15:
/Volumes/ESPTools/Espruino/1v85/master.new/src/jsutils.h:233:16: note: 'flash_X' was declared here
      FLASH_STR(flash_X, __STRING(X)); \
                ^
/Volumes/ESPTools/Espruino/1v85/master.new/src/jsutils.h:52:40: note: in definition of macro 'FLASH_STR'
 #define FLASH_STR(name, x) static char name[] IN_FLASH_MEMORY = x
                                        ^
libs/graphics/graphics.c:102:3: note: in expansion of macro 'assert'
   assert(data);
   ^