### PR TITLE
add `tone()` and `noTone()` for ESP8266

### DIFF
--- a/targets/esp8266/jswrap_esp8266.h
+++ b/targets/esp8266/jswrap_esp8266.h
@@ -44,4 +44,7 @@ uint32_t crc32(uint8_t *buf, uint32_t len);
 void   jswrap_ESP8266_deepSleep(JsVar *jsMicros);
 void   jswrap_ESP8266_modemSleep();
 
+void   jswrap_ESP8266_tone(Pin pin, JsVar *freq);
+void   jswrap_ESP8266_noTone();
+
 #endif /* TARGETS_ESP8266_JSWRAP_ESP8266_H_ */


### PR DESCRIPTION
Hi, I have implemented `tone()` and `noTone()` for the ESP8266 port. 

I tested them on a WeMos D1 Mini device with a speaker connected, and they seem to produce the correct tones (I tested several frequency). The implementation uses the internal ESP8266 hardware timer (timer 1), and was inspired by [ESP8266/Arduino](http://github.com/ESP8266/Arduino).

I copied the Arduino code constants for setting up the timer interrupts as I haven't found any example of using the ESP8266 hardware timers inside Espruino, but I am pretty sure I missed something. Otherwise, I think that we can adopt [esp8266_peri.h](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/esp8266_peri.h) instead of defining all the constants inside the C file.

I would really love to see this merged, as I want to use Espruino in a demo I am giving in a talk next month in London.

Thoughts?
