### PR TITLE
Update jswrap_esp8266.c

### DIFF
--- a/targets/esp8266/jswrap_esp8266.c
+++ b/targets/esp8266/jswrap_esp8266.c
@@ -346,7 +346,7 @@ void jswrap_ESP8266_neopixelWrite(Pin pin, JsVar *jsArrayOfData) {
     return;
   }
 
-  if (!jshGetPinStateIsManual(pin))
+  if (jshGetPinStateIsManual(pin) != JSHPINSTATE_GPIO_OUT)
     jshPinSetState(pin, JSHPINSTATE_GPIO_OUT);
 
   // values for 160Mhz clock


### PR DESCRIPTION
make sure neopixelWrite() is working even if pinMode(pin,"output") is missing in coding.