### PR TITLE
fix: http.get leak via "method" field duplicate

### DIFF
--- a/libs/network/http/jswrap_http.c
+++ b/libs/network/http/jswrap_http.c
@@ -314,7 +314,7 @@ JsVar *jswrap_http_get(JsVar *options, JsVar *callback) {
   if (jsvIsObject(options)) {
     // if options is a string - it will be parsed, and GET will be set automatically
     JsVar *method = jsvNewFromString("GET");
-    jsvUnLock2(jsvAddNamedChild(options, method, "method"), method);
+    jsvUnLock2(jsvSetNamedChild(options, method, "method"), method);
   }
   JsVar *skippedCallback = jsvSkipName(callback);
   if (!jsvIsUndefined(skippedCallback) && !jsvIsFunction(skippedCallback)) {


### PR DESCRIPTION
`http.get` cause a memory leak in the following scenario:

```javascript
var opts = {
  host: 'lala.com',
  patch: '/'
};

setInterval(function() {
  http.get(opts, function(res) { ... })
}, 1000);
```

Every tick `opts` would get an additional copy of `opts.method = "GET"` field.