### PR TITLE
Remove incorrect line number in documentation

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -46,7 +46,14 @@ You can add more files here if you need. It's up to you!
 
 ## Modify the `Makefile`
 
-Go to line [606](https://github.com/espruino/Espruino/blob/master/Makefile#L606) and append
+Find the text
+``` 
+# ---------------------------------------------------------------------------------
+# When adding stuff here, also remember build_pininfo, platform_config.h, jshardware.c
+# TODO: Load more of this out of the BOARDNAME.py files if at all possible (see next section)
+# --------------------------------------------------------------------------------- 
+```
+and add those two lines just before it
 
 ```make
 INCLUDE += -I$(ROOT)/libs/hello


### PR DESCRIPTION
I just removed the static reference to line 606 of Makefile, which has been modified since. Thus, the line number is not relevant anymore. I tried to find a good location for the addition of two lines, which is just before the "ifdef ESPRUINO_1V3" section