### PR TITLE
Serial6 is now exposed as an object on NUCLEOF401RE & NUCLEOF411RE

### DIFF
--- a/boards/NUCLEOF401RE.py
+++ b/boards/NUCLEOF401RE.py
@@ -38,7 +38,7 @@ chip = {
   'ram' : 96, # 0x0001 8000 long, from 0x2000 0000 to 0x2001 7FFF
   'flash' : 512, # 0x0008 0000 long, from 0x0800 0000 to 0x0807 FFFF
   'speed' : 84,
-  'usart' : 3,
+  'usart' : 6,
   'spi' : 4,
   'i2c' : 3,
   'adc' : 1,

--- a/boards/NUCLEOF411RE.py
+++ b/boards/NUCLEOF411RE.py
@@ -38,7 +38,7 @@ chip = {
   'ram' : 128, # 0x0001 8000 long, from 0x2000 0000 to 0x2001 7FFF
   'flash' : 512, # 0x0008 0000 long, from 0x0800 0000 to 0x0807 FFFF
   'speed' : 100,
-  'usart' : 3,
+  'usart' : 6,
   'spi' : 4,
   'i2c' : 3,
   'adc' : 1,


### PR DESCRIPTION
The STM32F4x1RE microcontrollers embeds 3 USART (USART1,USART2,USART6), but the current board descriptions for NUCLEO401RE and NUCLEO411RE are only exposing 3 Serial objects , respectively Serial1, Serial2, Serial3. This PR allows using Serial1, Serial2 and Serial6 as usual. Even if Serial[3..5] are potentially existing objects, they can not be used as they are not physically existing.