### PR TITLE
Enable simple READs using NRF.updateServices

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -1550,8 +1550,8 @@ NRF.updateServices({
   }
 });
 ```
-This only works if the chracteristic was create with `notify: true`,
-otherwise the characteristic will be updated but no otification will be sent.
+This only works if the characteristic was create with `notify: true` using `setServices`,
+otherwise the characteristic will be updated but no notification will be sent.
 
 **Note:** See `setServices` for more information
 */
@@ -1639,7 +1639,7 @@ void jswrap_nrf_bluetooth_updateServices(JsVar *data) {
                     hvx_params.offset = 0;
                     hvx_params.p_len = &len;
                     hvx_params.p_data = p_value;
-                    
+
                     err_code = sd_ble_gatts_hvx(m_conn_handle, &hvx_params);
                     if ((err_code != NRF_SUCCESS)
                       && (err_code != NRF_ERROR_INVALID_STATE)


### PR DESCRIPTION
This improves READ supports related to https://github.com/espruino/Espruino/issues/915.

It is now possible to update a characteristic even when no connection is active. Notifications must be explicitly requested by using `notify: true` when calling `NRF.updateServices`.

Documentation has been updated to reflect the changes. 