### PR TITLE
Fix regression where HTTPS without cert/ca or key failed

### DIFF
--- a/libs/network/network.c
+++ b/libs/network/network.c
@@ -428,7 +428,7 @@ JsVar *decode_certificate_var(JsVar *var) {
 bool ssl_load_key(SSLSocketData *sd, JsVar *options) {
   JsVar *keyVar = jsvObjectGetChild(options, "key", 0);
   if (!keyVar) {
-    return false;
+    return true; // still ok - just no key
   }
   int ret = -1;
   jsiConsolePrintf("Loading the Client Key...\n");
@@ -453,7 +453,7 @@ bool ssl_load_key(SSLSocketData *sd, JsVar *options) {
 bool ssl_load_owncert(SSLSocketData *sd, JsVar *options) {
   JsVar *certVar = jsvObjectGetChild(options, "cert", 0);
   if (!certVar) {
-    return false;
+    return true; // still ok - just no key
   }
   int ret = -1;
   jsiConsolePrintf("Loading the Client certificate...\n");
@@ -477,7 +477,7 @@ bool ssl_load_owncert(SSLSocketData *sd, JsVar *options) {
 bool ssl_load_cacert(SSLSocketData *sd, JsVar *options) {
   JsVar *caVar = jsvObjectGetChild(options, "ca", 0);
   if (!caVar) {
-    return false;
+    return true; // still ok - just no key
   }
   int ret = -1;
   jsiConsolePrintf("Loading the CA root certificate...\n");

--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -114,6 +114,9 @@ void jshInit() {
   esp32_wifi_init();
   jswrap_ESP32_wifi_soft_init();
   jshInitDevices();
+  if (JSHPINSTATE_I2C != 13 || JSHPINSTATE_GPIO_IN_PULLDOWN != 6 || JSHPINSTATE_MASK != 15) {
+    jsError("JshPinState #defines have changed, please update pinStateToString()");
+  }
   gpio_isr_register(gpio_intr_test,NULL,0,NULL);  //changed to automatic assign of interrupt
    // Initialize something for each of the possible pins.
   for (int i=0; i<JSH_PIN_COUNT; i++) {


### PR DESCRIPTION
Apply upstream update:
https://github.com/espruino/Espruino/commit/fc381569987389625054bf57368a4df99d9890b8#diff-8be325101851519f961a95785af06b52R450


https now works without an certificates loaded:

require("http").get("https://www.google.com", function(res) {
  res.on('data', function(data) { console.log(data); });
});