### PR TITLE
Split i2c and spi from jshardware.c - to allow easier port to esp-idf implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1005,6 +1005,7 @@ ifdef USE_NET
  INCLUDE += -I$(ROOT)/libs/network/esp32
  SOURCES +=  libs/network/esp32/network_esp32.c \
   targets/esp32/i2c.c \
+  targets/esp32/spi.c \
   targets/esp32/jshardwareUart.c \
   targets/esp32/jshardwareAnalog.c
   ifdef RTOS

--- a/Makefile
+++ b/Makefile
@@ -1004,6 +1004,7 @@ ifdef USE_NET
    targets/esp32/jswrap_esp32.c
  INCLUDE += -I$(ROOT)/libs/network/esp32
  SOURCES +=  libs/network/esp32/network_esp32.c \
+  targets/esp32/i2c.c \
   targets/esp32/jshardwareUart.c \
   targets/esp32/jshardwareAnalog.c
   ifdef RTOS
@@ -1784,7 +1785,8 @@ endif
 CCPREFIX=xtensa-esp32-elf-
 SOURCES += targets/esp32/main.c
 LDFLAGS +=-L$(ESP_IDF_PATH)/lib -L$(ESP_IDF_PATH)/ld -L$(ESP_IDF_PATH)/components/bt/lib \
--L$(ESP_IDF_PATH)/components/esp32/lib \
+#-L$(ESP_IDF_PATH)/components/esp32/lib \
+-L$(ESP_APP_TEMPLATE_PATH)/components/esp32/lib \
 -L$(ESP_APP_TEMPLATE_PATH)/build/bootloader \
 -L$(ESP_APP_TEMPLATE_PATH)/build/bt \
 -L$(ESP_APP_TEMPLATE_PATH)/build/driver \
@@ -1811,6 +1813,7 @@ ESPTOOL?=
 INCLUDE+=\
 -I$(ESP_APP_TEMPLATE_PATH)/build/include \
 -I$(ESP_IDF_PATH)/components \
+-I$(ESP_IDF_PATH)/components \
 -I$(ESP_IDF_PATH)/components/newlib/include \
 -I$(ESP_IDF_PATH)/components/bt/include \
 -I$(ESP_IDF_PATH)/components/driver/include \
@@ -1829,7 +1832,9 @@ INCLUDE+=\
 -I$(ESP_APP_TEMPLATE_PATH)/components/arduino-esp32/cores/esp32 \
 -Itargets/esp32/include
 LDFLAGS+=-nostdlib -u call_user_start_cpu0 -Wl,--gc-sections -Wl,-static -Wl,-EL
-LIBS+=-T esp32_out.ld \
+#LIBS+=-T$(ESP_IDF_PATH)/components/esp32/ld/esp32_out.ld \
+#LIBS+=-T$(ESP_APP_TEMPLATE_PATH)/components/arduino-esp32/tools/sdk/ld/esp32_out.ld \
+LIBS+=-T$(ESP_APP_TEMPLATE_PATH)/build/esp32/esp32_out.ld \
 -T$(ESP_IDF_PATH)/components/esp32/ld/esp32.common.ld \
 -T$(ESP_IDF_PATH)/components/esp32/ld/esp32.rom.ld \
 -T$(ESP_IDF_PATH)/components/esp32/ld/esp32.peripherals.ld \

--- a/targets/esp32/i2c.c
+++ b/targets/esp32/i2c.c
@@ -1,0 +1,84 @@
+/*
+ * This file is designed to support i2c functions in Espruino,
+ * a JavaScript interpreter for Microcontrollers designed by Gordon Williams
+ *
+ * Copyright (C) 2016 by Rhys Williams (wilberforce)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * ----------------------------------------------------------------------------
+ * This file is designed to be parsed during the build process
+ *
+ * Contains ESP32 board specific functions.
+ * ----------------------------------------------------------------------------
+ */
+#include "esp_log.h"
+ 
+#include "i2c.h"
+// Using arduino library
+#include "esp32-hal-i2c.h"
+
+// Let's get this working with only one device
+i2c_t * i2c=NULL;
+
+/** Set-up I2C master for ESP32, default pins are SCL:21, SDA:22. Only device I2C1 is supported
+ *  and only master mode. */
+void jshI2CSetup(IOEventFlags device, JshI2CInfo *info) {
+  if (device != EV_I2C1) {
+    jsError("Only I2C1 supported"); 
+	return;
+  }
+  Pin scl = info->pinSCL != PIN_UNDEFINED ? info->pinSCL : 21;
+  Pin sda = info->pinSDA != PIN_UNDEFINED ? info->pinSDA : 22;
+
+  //jshPinSetState(scl, JSHPINSTATE_I2C);
+  //jshPinSetState(sda, JSHPINSTATE_I2C);
+   
+  int num=1; // Master mode only 0 is slave mode..
+ 
+  i2c_err_t err;
+  i2c = i2cInit(num, 0, false);
+  //jsError("jshI2CSetup: Frequency: %d", info->bitrate);
+  err=i2cSetFrequency(i2c, (uint32_t)info->bitrate);
+  if ( err != I2C_ERROR_OK ) {
+    jsError( "jshI2CSetup: i2cSetFrequency error: %d", err);
+	return;
+  }
+  err=i2cAttachSDA(i2c, pinToESP32Pin(sda));
+  if ( err != I2C_ERROR_OK ) {
+    jsError( "jshI2CSetup: i2cAttachSDA error: %d", err);
+	return;
+  }  
+  err=i2cAttachSCL(i2c, pinToESP32Pin(scl));
+  if ( err != I2C_ERROR_OK ) {
+    jsError(  "jshI2CSetup: i2cAttachSCL error: %d", err);
+	return;
+  }
+}
+
+void jshI2CWrite(IOEventFlags device,
+  unsigned char address,
+  int nBytes,
+  const unsigned char *data,
+  bool sendStop) {
+// i2cWrite(i2c_t * i2c, uint16_t address, bool addr_10bit, uint8_t * data, uint8_t len, bool sendStop);
+  i2c_err_t err=i2cWrite(i2c,address,false,data,nBytes,sendStop);
+  if ( err != I2C_ERROR_OK ) {
+    jsError(  "jshI2CSetup: i2cAttachSCL error: %d", err);
+	return;
+  }
+}
+
+void jshI2CRead(IOEventFlags device,
+  unsigned char address,
+  int nBytes,
+  unsigned char *data,
+  bool sendStop) {
+  i2c_err_t err=i2cRead(i2c,address,false,data,nBytes,sendStop);
+  if ( err != I2C_ERROR_OK ) {
+    jsError(  "jshI2CSetup: i2cAttachSCL error: %d", err);
+	return;
+  }
+}

--- a/targets/esp32/i2c.h
+++ b/targets/esp32/i2c.h
@@ -1,0 +1,27 @@
+/*
+ * This file is designed to support i2c functions in Espruino for ESP32,
+ * a JavaScript interpreter for Microcontrollers designed by Gordon Williams
+ *
+ * Copyright (C) 2016 by Rhys Williams (wilberforce)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * ----------------------------------------------------------------------------
+ * This file is designed to be parsed during the build process
+ *
+ * Contains ESP32 board specific functions.
+ * ----------------------------------------------------------------------------
+ */
+
+#include "jspininfo.h"
+#include "jshardware.h"
+#include "driver/gpio.h"
+
+// Convert an Espruino pin to an ESP32 pin number.
+gpio_num_t pinToESP32Pin(Pin pin);
+
+void jshI2CSetup(IOEventFlags device, JshI2CInfo *info);
+void jshI2CWrite(IOEventFlags device, unsigned char address, int nBytes, const unsigned char *data, bool sendStop);
+void jshI2CRead(IOEventFlags device,  unsigned char address, int nBytes, unsigned char *data, bool sendStop);

--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -44,7 +44,7 @@
 #include "driver/gpio.h"
 
 #include "i2c.h"
-#include "esp32-hal-spi.h"
+#include "spi.h"
 
 #define FLASH_MAX (4*1024*1024) //4MB
 #define FLASH_PAGE_SHIFT 12 // Shift is much faster than division by 4096 (size of page)
@@ -55,9 +55,6 @@
 // The logging tag used for log messages issued by this file.
 static char *tag = "jshardware";
 static char *tagGPIO = "jshardware(GPIO)";
-
-static spi_t * _spi[VSPI];
-static uint32_t  g_lastSPIRead = (uint32_t)-1;
 
 /**
  * Convert a pin id to the corresponding Pin Event id.
@@ -486,175 +483,6 @@ void jshUSARTKick(
     c = jshGetCharToTransmit(device);
   }
   //ESP_LOGD(tag,"<< jshUSARTKick");
-}
-
-/*
-https://hackadaycom.files.wordpress.com/2016/10/esp32_pinmap.png
-HSPI  2 //SPI bus normally mapped to pins 12 - 15, but can be matrixed to any pins
-15  HSPI SS
-14  HSPI SCK
-12  HSPI MISO
-13  HSPI MOSI
-VSPI  3 //SPI bus normally attached to pin:
-5   VSPI SS
-18  VSPI SCK
-19  VSPI MISO
-23  VSPI MOSI
-*/
-//===== SPI =====
-int getSPIFromDevice( IOEventFlags device	) {
-  switch(device) {
-  case EV_SPI1: return HSPI;
-  case EV_SPI2: return VSPI;
-  default: return -1;
-  }
-}
-  
-/**
- * Initialize the hardware SPI device.
- * On the ESP32, hardware SPI is implemented via a set of default pins defined
- * as follows:
- *
- *
- */
-void jshSPISetup(
-    IOEventFlags device, //!< The identity of the SPI device being initialized.
-    JshSPIInfo *inf      //!< Flags for the SPI device.
-) {
-  ESP_LOGD(tag,">> jshSPISetup device=%s, baudRate=%d, spiMode=%d, spiMSB=%d",
-      jshGetDeviceString(device),
-      inf->baudRate,
-      inf->spiMode,
-      inf->spiMSB);
-  spi_t *spi = NULL;
-  uint8_t dataMode = SPI_MODE0;
-  switch(inf->spiMode) {
-  case 0:
-    dataMode = SPI_MODE0;
-    break;
-  case 1:
-    dataMode = SPI_MODE1;
-    break;
-  case 2:
-    dataMode = SPI_MODE2;
-    break;
-  case 3:
-    dataMode = SPI_MODE3;
-    break;
-  }
-  uint8_t bitOrder;
-  if (inf->spiMSB == true) {
-    bitOrder = SPI_MSBFIRST;
-  } else {
-    bitOrder = SPI_LSBFIRST;
-  }
-  int which_spi=getSPIFromDevice(device);
-  if (which_spi == -1) {
-	ESP_LOGW(tag, "Unexpected device for SPI initialization: %d", device);
-	}
-  else {
-	int which_spi=getSPIFromDevice(device);
-	Pin sck;
-	Pin miso;
-	Pin mosi;
-	Pin ss; 
-	if ( which_spi == HSPI ) {
-	  sck = inf->pinSCK != PIN_UNDEFINED ? inf->pinSCK : 14;
-	  miso = inf->pinMISO != PIN_UNDEFINED ? inf->pinMISO : 12;
-	  mosi = inf->pinMOSI != PIN_UNDEFINED ? inf->pinMOSI : 13;
-	  // Where do we get the SS pin?
-	  //ss = inf->pinSS != PIN_UNDEFINED ? inf->pinSS : 15;
-	  ss=15;
-	}
-	else {
-	  sck = inf->pinSCK != PIN_UNDEFINED ? inf->pinSCK : 5;
-	  miso = inf->pinMISO != PIN_UNDEFINED ? inf->pinMISO : 19;
-	  mosi = inf->pinMOSI != PIN_UNDEFINED ? inf->pinMOSI : 23;
-	  //ss = inf->pinSS != PIN_UNDEFINED ? inf->pinSS : 18;
-	  ss=18;
-	}
-	spi=spiStartBus(which_spi, inf->baudRate, dataMode, bitOrder);  
-    spiAttachSCK(spi, pinToESP32Pin(sck));
-    spiAttachMISO(spi, pinToESP32Pin(miso));
-    spiAttachMOSI(spi, pinToESP32Pin(mosi));
-    spiAttachSS(spi, 0, pinToESP32Pin(ss));
-    spiEnableSSPins(spi, 1<<0);
-    spiSSEnable(spi);
-	_spi[which_spi]=spi;
-  }
-}
-
-
-/** Send data through the given SPI device (if data>=0), and return the result
- * of the previous send (or -1). If data<0, no data is sent and the function
- * waits for data to be returned */
-int jshSPISend(
-    IOEventFlags device, //!< The identity of the SPI device through which data is being sent.
-    int data             //!< The data to be sent or an indication that no data is to be sent.
-) {
-  int which_spi =getSPIFromDevice(device);
-  if (which_spi == -1) {
-	return -1;
-  }
-  //os_printf("> jshSPISend - device=%d, data=%x\n", device, data);
-  int retData = (int)g_lastSPIRead;
-  if (data >=0) {
-    // Send 8 bits of data taken from "data" over the selected spi and store the returned
-    // data for subsequent retrieval.
-    spiTransferBits(_spi[which_spi], (uint32_t)data, &g_lastSPIRead, 8);
-  } else {
-    g_lastSPIRead = (uint32_t)-1;
-  }
-  return (int)retData;
-}
-
-
-/**
- * Send 16 bit data through the given SPI device.
- */
-void jshSPISend16(
-    IOEventFlags device, //!< Unknown
-    int data             //!< Unknown
-) {
-  int which_spi=getSPIFromDevice(device);  
-  spiWriteWord(_spi[which_spi], data);
-}
-
-
-/**
- * Set whether to send 16 bits or 8 over SPI.
- */
-void jshSPISet16(
-    IOEventFlags device, //!< Unknown
-    bool is16            //!< Unknown
-) {
-  UNUSED(device);
-  UNUSED(is16);
-  ESP_LOGD(tag,">> jshSPISet16");
-  ESP_LOGD(tag, "Not implemented");
-  ESP_LOGD(tag,"<< jshSPISet16");
-}
-
-
-/**
- * Wait until SPI send is finished.
- */
-void jshSPIWait(
-    IOEventFlags device //!< Unknown
-) {
-  UNUSED(device);
-  int which_spi =getSPIFromDevice(device);  
-  spiWaitReady(_spi[which_spi]);
-}
-
-
-/** Set whether to use the receive interrupt or not */
-void jshSPISetReceive(IOEventFlags device, bool isReceive) {
-  UNUSED(device);
-  UNUSED(isReceive);
-  ESP_LOGD(tag,">> jshSPISetReceive");
-  ESP_LOGD(tag, "Not implemented");
-  ESP_LOGD(tag,"<< jshSPISetReceive");
 }
 
 //===== System time stuff =====

--- a/targets/esp32/spi.c
+++ b/targets/esp32/spi.c
@@ -1,0 +1,201 @@
+/*
+ * This file is designed to support spi functions in Espruino for ESP32,
+ * a JavaScript interpreter for Microcontrollers designed by Gordon Williams
+ *
+ * Copyright (C) 2016 by Rhys Williams (wilberforce)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * ----------------------------------------------------------------------------
+ * This file is designed to be parsed during the build process
+ *
+ * Contains ESP32 board specific functions.
+ * ----------------------------------------------------------------------------
+ */
+
+#include "jspininfo.h"
+#include "jshardware.h"
+#include "driver/gpio.h"
+// Using arduino library
+#include "esp32-hal-spi.h"
+
+#define UNUSED(x) (void)(x)
+
+// Convert an Espruino pin to an ESP32 pin number.
+gpio_num_t pinToESP32Pin(Pin pin);
+
+static spi_t * _spi[VSPI];
+static uint32_t  g_lastSPIRead = (uint32_t)-1;
+
+/*
+https://hackadaycom.files.wordpress.com/2016/10/esp32_pinmap.png
+HSPI  2 //SPI bus normally mapped to pins 12 - 15, but can be matrixed to any pins
+15  HSPI SS
+14  HSPI SCK
+12  HSPI MISO
+13  HSPI MOSI
+VSPI  3 //SPI bus normally attached to pin:
+5   VSPI SS
+18  VSPI SCK
+19  VSPI MISO
+23  VSPI MOSI
+*/
+//===== SPI =====
+int getSPIFromDevice( IOEventFlags device	) {
+  switch(device) {
+  case EV_SPI1: return HSPI;
+  case EV_SPI2: return VSPI;
+  default: return -1;
+  }
+}
+  
+/**
+ * Initialize the hardware SPI device.
+ * On the ESP32, hardware SPI is implemented via a set of default pins defined
+ * as follows:
+ *
+ *
+ */
+void jshSPISetup(
+    IOEventFlags device, //!< The identity of the SPI device being initialized.
+    JshSPIInfo *inf      //!< Flags for the SPI device.
+) {
+  jsError(">> jshSPISetup device=%s, baudRate=%d, spiMode=%d, spiMSB=%d",
+      jshGetDeviceString(device),
+      inf->baudRate,
+      inf->spiMode,
+      inf->spiMSB);
+  spi_t *spi = NULL;
+  uint8_t dataMode = SPI_MODE0;
+  switch(inf->spiMode) {
+  case 0:
+    dataMode = SPI_MODE0;
+    break;
+  case 1:
+    dataMode = SPI_MODE1;
+    break;
+  case 2:
+    dataMode = SPI_MODE2;
+    break;
+  case 3:
+    dataMode = SPI_MODE3;
+    break;
+  }
+  uint8_t bitOrder;
+  if (inf->spiMSB == true) {
+    bitOrder = SPI_MSBFIRST;
+  } else {
+    bitOrder = SPI_LSBFIRST;
+  }
+  int which_spi=getSPIFromDevice(device);
+  if (which_spi == -1) {
+	jsError( "Unexpected device for SPI initialization: %d", device);
+	}
+  else {
+	int which_spi=getSPIFromDevice(device);
+	Pin sck;
+	Pin miso;
+	Pin mosi;
+	Pin ss; 
+	if ( which_spi == HSPI ) {
+	  sck = inf->pinSCK != PIN_UNDEFINED ? inf->pinSCK : 14;
+	  miso = inf->pinMISO != PIN_UNDEFINED ? inf->pinMISO : 12;
+	  mosi = inf->pinMOSI != PIN_UNDEFINED ? inf->pinMOSI : 13;
+	  // Where do we get the SS pin?
+	  //ss = inf->pinSS != PIN_UNDEFINED ? inf->pinSS : 15;
+	  ss=15;
+	}
+	else {
+	  sck = inf->pinSCK != PIN_UNDEFINED ? inf->pinSCK : 5;
+	  miso = inf->pinMISO != PIN_UNDEFINED ? inf->pinMISO : 19;
+	  mosi = inf->pinMOSI != PIN_UNDEFINED ? inf->pinMOSI : 23;
+	  //ss = inf->pinSS != PIN_UNDEFINED ? inf->pinSS : 18;
+	  ss=18;
+	}
+	spi=spiStartBus(which_spi, inf->baudRate, dataMode, bitOrder);  
+    spiAttachSCK(spi, pinToESP32Pin(sck));
+    spiAttachMISO(spi, pinToESP32Pin(miso));
+    spiAttachMOSI(spi, pinToESP32Pin(mosi));
+    spiAttachSS(spi, 0, pinToESP32Pin(ss));
+    spiEnableSSPins(spi, 1<<0);
+    spiSSEnable(spi);
+	_spi[which_spi]=spi;
+  }
+}
+
+
+/** Send data through the given SPI device (if data>=0), and return the result
+ * of the previous send (or -1). If data<0, no data is sent and the function
+ * waits for data to be returned */
+int jshSPISend(
+    IOEventFlags device, //!< The identity of the SPI device through which data is being sent.
+    int data             //!< The data to be sent or an indication that no data is to be sent.
+) {
+  int which_spi =getSPIFromDevice(device);
+  if (which_spi == -1) {
+	return -1;
+  }
+  //os_printf("> jshSPISend - device=%d, data=%x\n", device, data);
+  int retData = (int)g_lastSPIRead;
+  if (data >=0) {
+    // Send 8 bits of data taken from "data" over the selected spi and store the returned
+    // data for subsequent retrieval.
+    spiTransferBits(_spi[which_spi], (uint32_t)data, &g_lastSPIRead, 8);
+  } else {
+    g_lastSPIRead = (uint32_t)-1;
+  }
+  return (int)retData;
+}
+
+
+/**
+ * Send 16 bit data through the given SPI device.
+ */
+void jshSPISend16(
+    IOEventFlags device, //!< Unknown
+    int data             //!< Unknown
+) {
+  int which_spi=getSPIFromDevice(device);  
+  spiWriteWord(_spi[which_spi], data);
+}
+
+
+/**
+ * Set whether to send 16 bits or 8 over SPI.
+ */
+void jshSPISet16(
+    IOEventFlags device, //!< Unknown
+    bool is16            //!< Unknown
+) {
+  UNUSED(device);
+  UNUSED(is16);
+  jsError(">> jshSPISet16");
+  jsError( "Not implemented");
+  jsError("<< jshSPISet16");
+}
+
+
+/**
+ * Wait until SPI send is finished.
+ */
+void jshSPIWait(
+    IOEventFlags device //!< Unknown
+) {
+  UNUSED(device);
+  int which_spi =getSPIFromDevice(device);  
+  spiWaitReady(_spi[which_spi]);
+}
+
+
+/** Set whether to use the receive interrupt or not */
+void jshSPISetReceive(IOEventFlags device, bool isReceive) {
+  UNUSED(device);
+  UNUSED(isReceive);
+  jsError(">> jshSPISetReceive");
+  jsError( "Not implemented");
+  jsError("<< jshSPISetReceive");
+}
+
+

--- a/targets/esp32/spi.h
+++ b/targets/esp32/spi.h
@@ -1,0 +1,31 @@
+/*
+ * This file is designed to support spi functions in Espruino for ESP32,
+ * a JavaScript interpreter for Microcontrollers designed by Gordon Williams
+ *
+ * Copyright (C) 2016 by Rhys Williams (wilberforce)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * ----------------------------------------------------------------------------
+ * This file is designed to be parsed during the build process
+ *
+ * Contains ESP32 board specific functions.
+ * ----------------------------------------------------------------------------
+ */
+
+#include "jspininfo.h"
+#include "jshardware.h"
+#include "driver/gpio.h"
+
+// Convert an Espruino pin to an ESP32 pin number.
+gpio_num_t pinToESP32Pin(Pin pin);
+
+void jshSPISetup( IOEventFlags device, JshSPIInfo *inf );
+
+int jshSPISend( IOEventFlags device, int data );
+void jshSPISend16( IOEventFlags device, int data );
+void jshSPISet16( IOEventFlags device, bool is16 );
+void jshSPIWait( IOEventFlags device );
+void jshSPISetReceive(IOEventFlags device, bool isReceive);


### PR DESCRIPTION
Please note there are changes to the linked part of the Makefile that might wont compile - currently getting this error:

/opt/xtensa-esp32-elf/bin/../lib/gcc/xtensa-esp32-elf/4.8.5/../../../../xtensa-esp32-elf/bin/ld: warning: cannot find entry symbol _start; not setting start address