### PR TITLE
Fix Makefile, use esp-idf api for i2c - untested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1786,8 +1786,7 @@ endif
 CCPREFIX=xtensa-esp32-elf-
 SOURCES += targets/esp32/main.c
 LDFLAGS +=-L$(ESP_IDF_PATH)/lib -L$(ESP_IDF_PATH)/ld -L$(ESP_IDF_PATH)/components/bt/lib \
-#-L$(ESP_IDF_PATH)/components/esp32/lib \
--L$(ESP_APP_TEMPLATE_PATH)/components/esp32/lib \
+-L$(ESP_IDF_PATH)/components/esp32/lib \
 -L$(ESP_APP_TEMPLATE_PATH)/build/bootloader \
 -L$(ESP_APP_TEMPLATE_PATH)/build/bt \
 -L$(ESP_APP_TEMPLATE_PATH)/build/driver \
@@ -1814,7 +1813,6 @@ ESPTOOL?=
 INCLUDE+=\
 -I$(ESP_APP_TEMPLATE_PATH)/build/include \
 -I$(ESP_IDF_PATH)/components \
--I$(ESP_IDF_PATH)/components \
 -I$(ESP_IDF_PATH)/components/newlib/include \
 -I$(ESP_IDF_PATH)/components/bt/include \
 -I$(ESP_IDF_PATH)/components/driver/include \
@@ -1833,9 +1831,7 @@ INCLUDE+=\
 -I$(ESP_APP_TEMPLATE_PATH)/components/arduino-esp32/cores/esp32 \
 -Itargets/esp32/include
 LDFLAGS+=-nostdlib -u call_user_start_cpu0 -Wl,--gc-sections -Wl,-static -Wl,-EL
-#LIBS+=-T$(ESP_IDF_PATH)/components/esp32/ld/esp32_out.ld \
-#LIBS+=-T$(ESP_APP_TEMPLATE_PATH)/components/arduino-esp32/tools/sdk/ld/esp32_out.ld \
-LIBS+=-T$(ESP_APP_TEMPLATE_PATH)/build/esp32/esp32_out.ld \
+LIBS+=-T esp32_out.ld \
 -T$(ESP_IDF_PATH)/components/esp32/ld/esp32.common.ld \
 -T$(ESP_IDF_PATH)/components/esp32/ld/esp32.rom.ld \
 -T$(ESP_IDF_PATH)/components/esp32/ld/esp32.peripherals.ld \

--- a/targets/esp32/i2c.c
+++ b/targets/esp32/i2c.c
@@ -76,17 +76,34 @@ static esp_err_t checkError( char * caller, esp_err_t ret ) {
   return ret;
 }
 
+int getI2cFromDevice( IOEventFlags device	) {
+  switch(device) {
+  case EV_I2C1: return I2C_NUM_0;
+  case EV_I2C2: return I2C_NUM_1;
+  default: return -1;
+  }
+}
+
 /** Set-up I2C master for ESP32, default pins are SCL:21, SDA:22. Only device I2C1 is supported
  *  and only master mode. */
 void jshI2CSetup(IOEventFlags device, JshI2CInfo *info) {
-  if (device != EV_I2C1) {
-  jsError("Only I2C1 supported"); 
+  int i2c_master_port = getI2cFromDevice(device);
+  if (i2c_master_port == -1) {
+  jsError("Only I2C1 and I2C2 supported"); 
 	return;
   }
-  Pin scl = info->pinSCL != PIN_UNDEFINED ? info->pinSCL : 21;
-  Pin sda = info->pinSDA != PIN_UNDEFINED ? info->pinSDA : 22;
+  Pin scl;
+  Pin sda;
+  if ( i2c_master_port == I2C_NUM_0 ) {
+    scl = info->pinSCL != PIN_UNDEFINED ? info->pinSCL : 21;
+    sda = info->pinSDA != PIN_UNDEFINED ? info->pinSDA : 22;
+  }
+  // Unsure on what to default these pins to?
+  if ( i2c_master_port == I2C_NUM_1 ) {
+    scl = info->pinSCL != PIN_UNDEFINED ? info->pinSCL : 16;
+    sda = info->pinSDA != PIN_UNDEFINED ? info->pinSDA : 17;
+  }  
 
-  int i2c_master_port = I2C_NUM_1;
   i2c_config_t conf;
   conf.mode = I2C_MODE_MASTER;
   conf.sda_io_num = pinToESP32Pin(sda);

--- a/targets/esp32/i2c.c
+++ b/targets/esp32/i2c.c
@@ -14,18 +14,109 @@
  * Contains ESP32 board specific functions.
  * ----------------------------------------------------------------------------
  */
-#include "esp_log.h"
+//#include "esp_log.h"
  
 #include "i2c.h"
+
+// Switch while debugging native i2c code - comment out to use native
+//#define USE_ARDUINO
+
+#ifdef USE_ARDUINO
 // Using arduino library
 #include "esp32-hal-i2c.h"
+#endif
 
+#ifndef USE_ARDUINO
+#include "driver/i2c.h"
+#endif
+
+#ifndef USE_ARDUINO
+
+#define I2C_MASTER_SCL_IO    19    /*!< gpio number for I2C master clock */
+#define I2C_MASTER_SDA_IO    18    /*!< gpio number for I2C master data  */
+#define I2C_MASTER_NUM I2C_NUM_1   /*!< I2C port number for master dev */
+#define I2C_MASTER_TX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
+#define I2C_MASTER_FREQ_HZ    100000     /*!< I2C master clock frequency */
+
+#define ACK_CHECK_EN   0x1     /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_DIS  0x0     /*!< I2C master will not check ack from slave */
+
+#define ACK_VAL    0x0         /*!< I2C ack value */
+#define NACK_VAL   0x1         /*!< I2C nack value */
+
+// Let's get this working with only one device
+
+/** Set-up I2C master for ESP32, default pins are SCL:21, SDA:22. Only device I2C1 is supported
+ *  and only master mode. */
+void jshI2CSetup(IOEventFlags device, JshI2CInfo *info) {
+  if (device != EV_I2C1) {
+    jsError("Only I2C1 supported"); 
+	return;
+  }
+  Pin scl = info->pinSCL != PIN_UNDEFINED ? info->pinSCL : 21;
+  Pin sda = info->pinSDA != PIN_UNDEFINED ? info->pinSDA : 22;
+
+  int i2c_master_port = I2C_NUM_1;
+  i2c_config_t conf;
+	conf.mode = I2C_MODE_MASTER;
+	conf.sda_io_num = pinToESP32Pin(sda);
+	conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+	conf.scl_io_num = pinToESP32Pin(scl);
+	conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+	conf.master.clk_speed = info->bitrate;
+	i2c_param_config(i2c_master_port, &conf);
+	i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+}
+
+void jshI2CWrite(IOEventFlags device,
+  unsigned char address,
+  int nBytes,
+  const unsigned char *data,
+  bool sendStop) {
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, address << 1 | I2C_MASTER_WRITE, ACK_CHECK_EN);
+    i2c_master_write(cmd, data, nBytes, ACK_CHECK_EN);	
+    i2c_master_stop(cmd);
+	int i2c_master_port = I2C_NUM_1;
+    int ret = i2c_master_cmd_begin(i2c_master_port, cmd, 1000 / portTICK_RATE_MS); // 1000 seems very large???
+    i2c_cmd_link_delete(cmd);
+    if (ret == ESP_FAIL) {
+        jsError(  "jshI2CWrite: write failed.");
+    }
+}
+
+void jshI2CRead(IOEventFlags device,
+  unsigned char address,
+  int nBytes,
+  unsigned char *data,
+  bool sendStop) {
+  
+  if (nBytes <= 0) {
+        return;
+    }
+	int i2c_master_port = I2C_NUM_1;
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, ( i2c_master_port << 1 ) | I2C_MASTER_READ, ACK_CHECK_EN);
+    if (nBytes > 1) {
+        i2c_master_read(cmd, data, nBytes - 1, ACK_VAL);
+    }
+    i2c_master_read_byte(cmd, data + nBytes - 1, NACK_VAL);
+    i2c_master_stop(cmd);
+    esp_err_t ret = i2c_master_cmd_begin(i2c_master_port, cmd, 1000 / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+}
+#endif
+
+#ifdef USE_ARDUINO
 // Let's get this working with only one device
 i2c_t * i2c=NULL;
 
 /** Set-up I2C master for ESP32, default pins are SCL:21, SDA:22. Only device I2C1 is supported
  *  and only master mode. */
-void jshI2CSetup(IOEventFlags device, JshI2CInfo *info) {
+vxoid jshI2CSetup(IOEventFlags device, JshI2CInfo *info) {
   if (device != EV_I2C1) {
     jsError("Only I2C1 supported"); 
 	return;
@@ -82,3 +173,4 @@ void jshI2CRead(IOEventFlags device,
 	return;
   }
 }
+#endif


### PR DESCRIPTION
I got it compiling by:
reverting the makefile
git pull and build of the arduino libraries
copy esp32\template\components\arduino-esp32\tools\sdk\lib libs to:
esp32\esp-idf\components\esp32\lib

For some reason the libs at esp32\esp-idf\components\esp32\lib are not updating after a git submodule update


