### PR TITLE
ld errors with mispelt BOARD definition

### DIFF
--- a/README_Building.md
+++ b/README_Building.md
@@ -1,8 +1,10 @@
 Building
 ========
 
-**Note:** If you're swapping between compiling for different targets, **you
+**Note:** 
+- If you're swapping between compiling for different targets, **you
 need to call `make clean`** before you compile for the new target.
+- If you have a ld error, double check the board name in the <BOARD>=1 make
 
 Under Linux
 -----------


### PR DESCRIPTION
It is very easy to make a mistake writing in the board name when doing BOARD=1 RELEASE=1 make
Make a note of it.

---

Background:
I was getting ld errors and was busy wasting time with google: it was just a missing digit in my BOARD
Possible need for a flag, BOARDDEFINED, in connection with Makefile: in the meantime, a heads up

```
LD espruino
/usr/bin/ld: cannot find -lstdc++
collect2: error: ld returned 1 exit status
make: *** [espruino] Error 1

```