### PR TITLE
Fix HID on Windows

### DIFF
--- a/targetlibs/stm32usb/usbd_cdc_hid.c
+++ b/targetlibs/stm32usb/usbd_cdc_hid.c
@@ -16,7 +16,7 @@
 #define CDC_CMD_EP                    0x82  /* EP2 for CDC commands */
 
 #define HID_IN_EP                     0x81
-#define HID_INTERFACE_NUMBER          0
+#define HID_INTERFACE_NUMBER          2
 #endif
 
 extern USBD_HandleTypeDef hUsbDeviceFS;
@@ -75,7 +75,7 @@ __ALIGN_BEGIN static const uint8_t USBD_CDC_HID_DeviceQualifierDesc[USB_LEN_DEV_
  * No HID
  * CDC on Interfaces 0 and 1
  */
-#define USBD_CDC_CFGDESC_SIZE              67
+#define USBD_CDC_CFGDESC_SIZE              (67+8)
 const __ALIGN_BEGIN uint8_t USBD_CDC_CfgDesc[USBD_CDC_CFGDESC_SIZE] __ALIGN_END =
 {
   /*Configuration Descriptor*/
@@ -87,6 +87,16 @@ const __ALIGN_BEGIN uint8_t USBD_CDC_CfgDesc[USBD_CDC_CFGDESC_SIZE] __ALIGN_END 
   0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
   0xC0,   /* bmAttributes: self powered */
   0x32,   /* MaxPower 0 mA */
+  
+  /* Interface Association Descriptor */
+  0x08, /* bLength: IAD descriptor size */
+  0x0B, /* bDescriptorType: IAD */
+  0x00, /* bFirstInterface: Number if first interface for grouping */
+  0x02, /* bInterfaceCount: Interfaces count for grouping */
+  0x02, /* bFunctionClass: The same as bInterfaceClass below */
+  0x02, /* bFunctionSubClass: The same as bInterfaceSubClass below */
+  0x01, /* bFunctionProtocol: The same as bInterfaceProtocol below */
+  0x00, /* iFunction */
   
   // -----------------------------------------------------------------------
   /*CDC Interface Descriptor */
@@ -175,8 +185,8 @@ const __ALIGN_BEGIN uint8_t USBD_CDC_CfgDesc[USBD_CDC_CFGDESC_SIZE] __ALIGN_END 
  * HID on Interface 0
  * CDC on Interfaces 1 and 2
  */
-#define USBD_CDC_HID_CFGDESC_SIZE              (67+25)
-#define USBD_CDC_HID_CFGDESC_REPORT_SIZE_IDX   25
+#define USBD_CDC_HID_CFGDESC_SIZE              (67+25+8)
+#define USBD_CDC_HID_CFGDESC_REPORT_SIZE_IDX   91
 // NOT CONST - descriptor size needs updating as this is sent out
 __ALIGN_BEGIN uint8_t USBD_CDC_HID_CfgDesc[USBD_CDC_HID_CFGDESC_SIZE] __ALIGN_END =
 {
@@ -190,6 +200,95 @@ __ALIGN_BEGIN uint8_t USBD_CDC_HID_CfgDesc[USBD_CDC_HID_CFGDESC_SIZE] __ALIGN_EN
   0xC0,   /* bmAttributes: self powered */
   0x32,   /* MaxPower 0 mA */
 
+  /* Interface Association Descriptor */
+  0x08, /* bLength: IAD descriptor size */
+  0x0B, /* bDescriptorType: IAD */
+  0x00, /* bFirstInterface: Number if first interface for grouping */
+  0x02, /* bInterfaceCount: Interfaces count for grouping */
+  0x02, /* bFunctionClass: The same as bInterfaceClass below */
+  0x02, /* bFunctionSubClass: The same as bInterfaceSubClass below */
+  0x01, /* bFunctionProtocol: The same as bInterfaceProtocol below */
+  0x00, /* iFunction */
+  
+  // -----------------------------------------------------------------------
+  /*CDC Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+  0,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x01,   /* bNumEndpoints: One endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+  1,   /* bDataInterface */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+  0,   /* bMasterInterface: Communication class interface */
+  1,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,   /* bDescriptorType: Endpoint */
+  CDC_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SIZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SIZE),
+  0x10,                           /* bInterval: */
+  /*---------------------------------------------------------------------------*/
+
+  /*Data class interface descriptor*/
+  0x09,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: */
+  1,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints: Two endpoints used */
+  0x0A,   /* bInterfaceClass: CDC */
+  0x00,   /* bInterfaceSubClass: */
+  0x00,   /* bInterfaceProtocol: */
+  0x00,   /* iInterface: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_FS_OUT_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_FS_OUT_PACKET_SIZE),
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC_IN_EP,                         /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_FS_IN_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_FS_IN_PACKET_SIZE),
+  0x00,                               /* bInterval: ignore for Bulk transfer */
+  
   /************** Descriptor of Joystick Mouse interface ****************/
   /* 9 */
   0x09,         /*bLength: Interface Descriptor size*/
@@ -219,85 +318,6 @@ __ALIGN_BEGIN uint8_t USBD_CDC_HID_CfgDesc[USBD_CDC_HID_CFGDESC_SIZE] __ALIGN_EN
   0x03,          /*bmAttributes: Interrupt endpoint*/
   HID_DATA_IN_PACKET_SIZE,0x00, /*wMaxPacketSize: 4 Byte max */
   HID_FS_BINTERVAL,          /*bInterval: Polling Interval (10 ms)*/
-
-  // -----------------------------------------------------------------------
-  /*CDC Interface Descriptor */
-  0x09,   /* bLength: Interface Descriptor size */
-  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: Interface */
-  /* Interface descriptor type */
-  1,   /* bInterfaceNumber: Number of Interface */
-  0x00,   /* bAlternateSetting: Alternate setting */
-  0x01,   /* bNumEndpoints: One endpoints used */
-  0x02,   /* bInterfaceClass: Communication Interface Class */
-  0x02,   /* bInterfaceSubClass: Abstract Control Model */
-  0x01,   /* bInterfaceProtocol: Common AT commands */
-  0x00,   /* iInterface: */
-
-  /*Header Functional Descriptor*/
-  0x05,   /* bLength: Endpoint Descriptor size */
-  0x24,   /* bDescriptorType: CS_INTERFACE */
-  0x00,   /* bDescriptorSubtype: Header Func Desc */
-  0x10,   /* bcdCDC: spec release number */
-  0x01,
-
-  /*Call Management Functional Descriptor*/
-  0x05,   /* bFunctionLength */
-  0x24,   /* bDescriptorType: CS_INTERFACE */
-  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
-  0x00,   /* bmCapabilities: D0+D1 */
-  2,   /* bDataInterface */
-
-  /*ACM Functional Descriptor*/
-  0x04,   /* bFunctionLength */
-  0x24,   /* bDescriptorType: CS_INTERFACE */
-  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
-  0x02,   /* bmCapabilities */
-
-  /*Union Functional Descriptor*/
-  0x05,   /* bFunctionLength */
-  0x24,   /* bDescriptorType: CS_INTERFACE */
-  0x06,   /* bDescriptorSubtype: Union func desc */
-  1,   /* bMasterInterface: Communication class interface */
-  2,   /* bSlaveInterface0: Data Class Interface */
-
-  /*Endpoint 2 Descriptor*/
-  0x07,                           /* bLength: Endpoint Descriptor size */
-  USB_DESC_TYPE_ENDPOINT,   /* bDescriptorType: Endpoint */
-  CDC_CMD_EP,                     /* bEndpointAddress */
-  0x03,                           /* bmAttributes: Interrupt */
-  LOBYTE(CDC_CMD_PACKET_SIZE),     /* wMaxPacketSize: */
-  HIBYTE(CDC_CMD_PACKET_SIZE),
-  0x10,                           /* bInterval: */
-  /*---------------------------------------------------------------------------*/
-
-  /*Data class interface descriptor*/
-  0x09,   /* bLength: Endpoint Descriptor size */
-  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: */
-  2,   /* bInterfaceNumber: Number of Interface */
-  0x00,   /* bAlternateSetting: Alternate setting */
-  0x02,   /* bNumEndpoints: Two endpoints used */
-  0x0A,   /* bInterfaceClass: CDC */
-  0x00,   /* bInterfaceSubClass: */
-  0x00,   /* bInterfaceProtocol: */
-  0x00,   /* iInterface: */
-
-  /*Endpoint OUT Descriptor*/
-  0x07,   /* bLength: Endpoint Descriptor size */
-  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
-  CDC_OUT_EP,                        /* bEndpointAddress */
-  0x02,                              /* bmAttributes: Bulk */
-  LOBYTE(CDC_DATA_FS_OUT_PACKET_SIZE),  /* wMaxPacketSize: */
-  HIBYTE(CDC_DATA_FS_OUT_PACKET_SIZE),
-  0x00,                              /* bInterval: ignore for Bulk transfer */
-
-  /*Endpoint IN Descriptor*/
-  0x07,   /* bLength: Endpoint Descriptor size */
-  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
-  CDC_IN_EP,                         /* bEndpointAddress */
-  0x02,                              /* bmAttributes: Bulk */
-  LOBYTE(CDC_DATA_FS_IN_PACKET_SIZE),  /* wMaxPacketSize: */
-  HIBYTE(CDC_DATA_FS_IN_PACKET_SIZE),
-  0x00,                               /* bInterval: ignore for Bulk transfer */
 } ;
 
 #define USB_HID_DESC_SIZ              9
@@ -839,5 +859,3 @@ uint8_t USBD_HID_SendReport     (uint8_t *report,  unsigned int len)
 int USB_IsConnected() {
   return hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED;
 }
-
-

--- a/targetlibs/stm32usb/usbd_conf.h
+++ b/targetlibs/stm32usb/usbd_conf.h
@@ -64,7 +64,7 @@
   */ 
 
 /*---------- -----------*/
-#define USBD_MAX_NUM_INTERFACES     1
+#define USBD_MAX_NUM_INTERFACES     2
 /*---------- -----------*/
 #define USBD_MAX_NUM_CONFIGURATION     1
 /*---------- -----------*/
@@ -78,8 +78,8 @@
 
 /****************************************/
 /* #define for FS and HS identification */
-#define DEVICE_FS 		0
-#define DEVICE_HS 		1
+#define DEVICE_FS     0
+#define DEVICE_HS     1
 
 /** @defgroup USBD_Exported_Macros
   * @{

--- a/targetlibs/stm32usb/usbd_desc.c
+++ b/targetlibs/stm32usb/usbd_desc.c
@@ -128,9 +128,9 @@ __ALIGN_BEGIN uint8_t USBD_FS_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END =
     0x00,                       /* bcdUSB */
 #endif  
     0x02,
-    0x02,                       /*bDeviceClass - CDC */
-    0x00,                       /*bDeviceSubClass*/
-    0x00,                       /*bDeviceProtocol*/
+    0xEF,                       /*bDeviceClass - CDC */
+    0x02,                       /*bDeviceSubClass*/
+    0x01,                       /*bDeviceProtocol*/
     USB_MAX_EP0_SIZE,          /*bMaxPacketSize*/
     LOBYTE(USBD_VID),           /*idVendor*/
     HIBYTE(USBD_VID),           /*idVendor*/


### PR DESCRIPTION
This is a fix of an old standing problem (http://forum.espruino.com/conversations/275155/) when Windows ignores Espruino’s HID role in most cases.

The reason is Espruino in such cases serves both a CDC device and a HID to OS simultaneously. However, both devices share VID/PID. And iff a CDC-driver from STM32 is installed in the system Windows refuses to consider the device as a HID. In other words, Espruino HID works on Windows until the driver will be installed.

The changes resolve the conflict. Tested on Win10, Mac, Linux