### PR TITLE
test travis for ESP32 - please don't merge as testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ before_install:
  - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
  - sudo apt-get update
  - sudo apt-get install libsdl1.2-dev gcc-arm-embedded
- #- curl -Ls http://s3.voneicken.com/xtensa-lx106-elf-20160330.tgx | tar Jxf -
- #- curl -Ls http://s3.voneicken.com/esp_iot_sdk_v2.0.0.p1.tgx | tar Jxf -
- - curl -Ls https://github.com/wilberforce/EspruinoBuildTools/raw/master/esp32/deploy/app.tgz | tar xfz -
- - curl -Ls https://github.com/wilberforce/EspruinoBuildTools/raw/master/esp32/deploy/esp-idf.tgz | tar xfz -
+ - curl -Ls http://s3.voneicken.com/xtensa-lx106-elf-20160330.tgx | tar Jxf -
+ - curl -Ls http://s3.voneicken.com/esp_iot_sdk_v2.0.0.p1.tgx | tar Jxf -
+ - curl -Ls https://github.com/espruino/EspruinoBuildTools/raw/master/esp32/deploy/app.tgz | tar xfz -
+ - curl -Ls https://github.com/espruino/EspruinoBuildTools/raw/master/esp32/deploy/esp-idf.tgz | tar xfz -
  - curl -Ls https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz | tar xfz -
 before_script:
  - arm-none-eabi-gcc --version
@@ -45,15 +45,15 @@ env:
     - RELEASE=1
     - TRAVIS=1
     - V=0
-#    - ESP8266_SDK_ROOT=$TRAVIS_BUILD_DIR/esp_iot_sdk_v2.0.0.p1
-#    - PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-lx106-elf/bin/
+    - ESP8266_SDK_ROOT=$TRAVIS_BUILD_DIR/esp_iot_sdk_v2.0.0.p1
+    - PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-lx106-elf/bin/
     -  ESP_IDF_PATH=$TRAVIS_BUILD_DIR/esp-idf
     -  ESP_APP_TEMPLATE_PATH=$TRAVIS_BUILD_DIR/app
     -  RELEASE=1
     -  PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-esp32-elf/bin/
   matrix:
     - ESP32=1
-#    - ESP8266_BOARD=1
+    - ESP8266_BOARD=1
 #    - ESPRUINO_1V3=1
     - PICO_1V3=1
 #    - MICROBIT=1
@@ -72,7 +72,7 @@ env:
     - LINUX_BUILD=1
 #    - EFM32GGSTK=1
 #    - NUCLEOL476RG=1
-script: make
+script: make -j 4
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,16 @@ language: c
 #      - libsdl1.2-dev gcc-arm-embedded
 
 before_install:
- #- sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+ - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
  - sudo apt-get update
- #- sudo apt-get install libsdl1.2-dev gcc-arm-embedded
+ - sudo apt-get install libsdl1.2-dev gcc-arm-embedded
  #- curl -Ls http://s3.voneicken.com/xtensa-lx106-elf-20160330.tgx | tar Jxf -
  #- curl -Ls http://s3.voneicken.com/esp_iot_sdk_v2.0.0.p1.tgx | tar Jxf -
  - curl -Ls https://github.com/wilberforce/EspruinoBuildTools/raw/master/esp32/deploy/app.tgz | tar xfz -
  - curl -Ls https://github.com/wilberforce/EspruinoBuildTools/raw/master/esp32/deploy/esp-idf.tgz | tar xfz -
  - curl -Ls https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz | tar xfz -
 before_script:
-# - arm-none-eabi-gcc --version
+ - arm-none-eabi-gcc --version
  - xtensa-esp32-elf-gcc --version
 
 after_script:
@@ -55,7 +55,7 @@ env:
     - ESP32=1
 #    - ESP8266_BOARD=1
 #    - ESPRUINO_1V3=1
-#    - PICO_1V3=1
+    - PICO_1V3=1
 #    - MICROBIT=1
 #    - NRF52832DK=1
 #    - OLIMEXINO_STM32=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,18 @@ before_script:
 # - arm-none-eabi-gcc --version
  - xtensa-esp32-elf-gcc --version
 
+after_script:
+  - ls *.bin *.hex *.tgz | xargs -I {} curl -v -F "binary=@{}" "http://www.espruino.com/travis_upload.php?commit=$TRAVIS_COMMIT"
+  # upload to an S3 bucket, requires S3_BUCKET, AWS_ACCESS_KEY_ID and AWS_SECRET_KEY to be set
+  # in environment using travis' repository settings
+  - "if [[ -n \"$S3_BUCKET\" && -n \"$AWS_ACCESS_KEY_ID\" ]]; then
+      echo Uploading *.tgz to $S3_BUCKET;
+      curl -Ls https://github.com/rlmcpherson/s3gof3r/releases/download/v0.5.0/gof3r_0.5.0_linux_amd64.tar.gz | tar zxf - gof3r_0.5.0_linux_amd64/gof3r;
+      mv gof3r*/gof3r .;
+      ls *.tgz | xargs -I {} ./gof3r put -b $S3_BUCKET -k espruino/{} --acl public-read -p {};
+      ls *.tgz | xargs -I {} echo \"URL: http://$S3_BUCKET/espruino/{}\";
+      fi"
+
 compiler:
   - gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
  #- sudo apt-get install libsdl1.2-dev gcc-arm-embedded
  #- curl -Ls http://s3.voneicken.com/xtensa-lx106-elf-20160330.tgx | tar Jxf -
  #- curl -Ls http://s3.voneicken.com/esp_iot_sdk_v2.0.0.p1.tgx | tar Jxf -
- - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/app.tgz | tar xfz -
- - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/esp-idf.tgz | tar xfz -
+ - curl -Ls https://github.com/wilberforce/EspruinoBuildTools/raw/master/esp32/deploy/app.tgz | tar xfz -
+ - curl -Ls https://github.com/wilberforce/EspruinoBuildTools/raw/master/esp32/deploy/esp-idf.tgz | tar xfz -
  - curl -Ls https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz | tar xfz -
 before_script:
 # - arm-none-eabi-gcc --version
@@ -49,7 +49,6 @@ env:
 #    - PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-lx106-elf/bin/
     -  ESP_IDF_PATH=$TRAVIS_BUILD_DIR/esp-idf
     -  ESP_APP_TEMPLATE_PATH=$TRAVIS_BUILD_DIR/app
-    -  ESP32=1
     -  RELEASE=1
     -  PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-esp32-elf/bin/
   matrix:
@@ -70,7 +69,7 @@ env:
 #    - NUCLEOF401RE=1
 #    - NUCLEOF411RE=1
 #    - LCTECH_STM32F103RBT6=1
-#    - LINUX_BUILD=1
+    - LINUX_BUILD=1
 #    - EFM32GGSTK=1
 #    - NUCLEOL476RG=1
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,19 @@ language: c
 #      - libsdl1.2-dev gcc-arm-embedded
 
 before_install:
- - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+ #- sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
  - sudo apt-get update
- - sudo apt-get install libsdl1.2-dev gcc-arm-embedded
- - curl -Ls http://s3.voneicken.com/xtensa-lx106-elf-20160330.tgx | tar Jxf -
- - curl -Ls http://s3.voneicken.com/esp_iot_sdk_v2.0.0.p1.tgx | tar Jxf -
-
+ #- sudo apt-get install libsdl1.2-dev gcc-arm-embedded
+ #- curl -Ls http://s3.voneicken.com/xtensa-lx106-elf-20160330.tgx | tar Jxf -
+ #- curl -Ls http://s3.voneicken.com/esp_iot_sdk_v2.0.0.p1.tgx | tar Jxf -
+ - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/app.tgz
+ - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/esp-idf.tgz
+ - curl -Ls https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz | tar xfz -
 before_script:
- - arm-none-eabi-gcc --version
-
-after_script:
-  - ls *.bin *.hex *.tgz | xargs -I {} curl -v -F "binary=@{}" "http://www.espruino.com/travis_upload.php?commit=$TRAVIS_COMMIT"
-  # upload to an S3 bucket, requires S3_BUCKET, AWS_ACCESS_KEY_ID and AWS_SECRET_KEY to be set
-  # in environment using travis' repository settings
-  - "if [[ -n \"$S3_BUCKET\" && -n \"$AWS_ACCESS_KEY_ID\" ]]; then
-      echo Uploading *.tgz to $S3_BUCKET;
-      curl -Ls https://github.com/rlmcpherson/s3gof3r/releases/download/v0.5.0/gof3r_0.5.0_linux_amd64.tar.gz | tar zxf - gof3r_0.5.0_linux_amd64/gof3r;
-      mv gof3r*/gof3r .;
-      ls *.tgz | xargs -I {} ./gof3r put -b $S3_BUCKET -k espruino/{} --acl public-read -p {};
-      ls *.tgz | xargs -I {} echo \"URL: http://$S3_BUCKET/espruino/{}\";
-      fi"
+# - arm-none-eabi-gcc --version
+ - xtensa-esp32-elf-gcc -v
+ - ls -l app
+ - ls -l esp-idf
 
 compiler:
   - gcc
@@ -42,29 +35,36 @@ env:
     - RELEASE=1
     - TRAVIS=1
     - V=0
-    - ESP8266_SDK_ROOT=$TRAVIS_BUILD_DIR/esp_iot_sdk_v2.0.0.p1
-    - PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-lx106-elf/bin/
+#    - ESP8266_SDK_ROOT=$TRAVIS_BUILD_DIR/esp_iot_sdk_v2.0.0.p1
+#    - PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-lx106-elf/bin/
+    -  ESP_IDF_PATH=$TRAVIS_BUILD_DIR/esp-idf
+    -  ESP_APP_TEMPLATE_PATH=$TRAVIS_BUILD_DIR/app
+    -  ESP32=1
+    -  RELEASE=1
+    -  PATH=$PATH:$TRAVIS_BUILD_DIR/xtensa-esp32-elf/bin/
   matrix:
-    - ESP8266_BOARD=1
-    - ESPRUINO_1V3=1
-    - PICO_1V3=1
-    - MICROBIT=1
-    - NRF52832DK=1
-    - OLIMEXINO_STM32=1
-    - MAPLERET6_STM32=1
-    - HYSTM32_24=1
-    - HYSTM32_28=1
-    - HYSTM32_32=1
-    - STM32VLDISCOVERY=1
-    - STM32F3DISCOVERY=1
-    - STM32F4DISCOVERY=1
-    - NUCLEOF401RE=1
-    - NUCLEOF411RE=1
-    - LCTECH_STM32F103RBT6=1
-    - LINUX_BUILD=1
-    - EFM32GGSTK=1
-    - NUCLEOL476RG=1
+    - ESP32=1
+#    - ESP8266_BOARD=1
+#    - ESPRUINO_1V3=1
+#    - PICO_1V3=1
+#    - MICROBIT=1
+#    - NRF52832DK=1
+#    - OLIMEXINO_STM32=1
+#    - MAPLERET6_STM32=1
+#    - HYSTM32_24=1
+#    - HYSTM32_28=1
+#    - HYSTM32_32=1
+#    - STM32VLDISCOVERY=1
+#    - STM32F3DISCOVERY=1
+#    - STM32F4DISCOVERY=1
+#    - NUCLEOF401RE=1
+#    - NUCLEOF411RE=1
+#    - LCTECH_STM32F103RBT6=1
+#    - LINUX_BUILD=1
+#    - EFM32GGSTK=1
+#    - NUCLEOL476RG=1
 script: make
 
 notifications:
   email: false
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ before_install:
 before_script:
 # - arm-none-eabi-gcc --version
  - xtensa-esp32-elf-gcc -v
- - ls -l app
- - ls -l esp-idf
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
  - curl -Ls https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz | tar xfz -
 before_script:
 # - arm-none-eabi-gcc --version
- - xtensa-esp32-elf-gcc -v
+ - xtensa-esp32-elf-gcc --version
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
  #- sudo apt-get install libsdl1.2-dev gcc-arm-embedded
  #- curl -Ls http://s3.voneicken.com/xtensa-lx106-elf-20160330.tgx | tar Jxf -
  #- curl -Ls http://s3.voneicken.com/esp_iot_sdk_v2.0.0.p1.tgx | tar Jxf -
- - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/app.tgz
- - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/esp-idf.tgz
+ - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/app.tgz | tar xfz -
+ - curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/esp-idf.tgz | tar xfz -
  - curl -Ls https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz | tar xfz -
 before_script:
 # - arm-none-eabi-gcc --version


### PR DESCRIPTION
@jumjum123 @gfwilliams 

This is a test config for the travis updates for ESP32.

** PLEASE DON'T MERGE **

The script is currently failing and doesn't compile and also would break the build for other boards.

It is  currently failing here:

```
CC libs/network/js/network_js.o
CC libs/network/esp32/network_esp32.o
In file included from /home/travis/build/espruino/Espruino/esp-idf/components/lwip/include/lwip/port/lwipopts.h:39:0,
                 from /home/travis/build/espruino/Espruino/esp-idf/components/lwip/include/lwip/lwip/opt.h:45,
                 from /home/travis/build/espruino/Espruino/esp-idf/components/lwip/include/lwip/lwip/sockets.h:37,
                 from /home/travis/build/espruino/Espruino/esp-idf/components/lwip/include/lwip/posix/sys/socket.h:33,
                 from libs/network/esp32/network_esp32.c:33:
/home/travis/build/espruino/Espruino/esp-idf/components/esp32/include/esp_task.h:29:23: fatal error: sdkconfig.h: No such file or directory
compilation terminated.
make: *** [libs/network/esp32/network_esp32.o] Error 1

https://travis-ci.org/espruino/Espruino/jobs/206076058#L616
```

sdkconfig.h *should* be part of the app.tgz file:
curl -Ls https://raw.githubusercontent.com/wilberforce/espruino-esp32/master/app.tgz | tar xfz -

should be here `app/build/include/sdkconfig.h`

The makefile should be finding it with:

```
INCLUDE+=\
-I$(ESP_APP_TEMPLATE_PATH)/build/include \
```