### PR TITLE
nRF5x: support integer UUIDs in requestDevice

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -1465,19 +1465,19 @@ JsVar *jswrap_nrf_bluetooth_requestDevice_filter_device(JsVar *filter, JsVar *de
     while (jsvObjectIteratorHasValue(&it)) {
       bool foundService = false;
       JsVar *uservice = jsvObjectIteratorGetValue(&it);
-      JsVar *service = jswrap_string_toUpperLowerCase(uservice, false);
-      jsvUnLock(uservice);
+      ble_uuid_t userviceUuid;
+      bleVarToUUIDAndUnLock(&userviceUuid, uservice);
       JsvObjectIterator dit;
       jsvObjectIteratorNew(&dit, deviceServices);
       while (jsvObjectIteratorHasValue(&dit)) {
         JsVar *deviceService = jsvObjectIteratorGetValue(&dit);
-        if (jsvIsEqual(service, deviceService))
+        ble_uuid_t deviceServiceUuid;
+        bleVarToUUIDAndUnLock(&deviceServiceUuid, deviceService);
+        if (bleUUIDEqual(userviceUuid, deviceServiceUuid))
           foundService = true;
-        jsvUnLock(deviceService);
         jsvObjectIteratorNext(&dit);
       }
       jsvObjectIteratorFree(&dit);
-      jsvUnLock(service);
       if (!foundService) matches = false;
       jsvObjectIteratorNext(&it);
     }


### PR DESCRIPTION
This aligns the behavior with [Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth/#standardized-uuids), where you can specify service UUIDs either as strings or integers. 

In addition, it also allows you to use the full 128-bit UUID to match a 16-bit UUID (e.g. `"0000FFE5-0000-1000-8000-00805F9B34FB"` will match service `FFE5`).