### PR TITLE
nRF5x: add "connectable" option to setAdvertising()

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -470,6 +470,7 @@ NRF.setAdvertising([
   name: "Hello" // The name of the device
   showName: true/false // include full name, or nothing
   discoverable: true/false // general discoverable, or limited - default is limited
+  connectable: true/false // whether device is connectable - default is true
   interval: 600 // Advertising interval in msec, between 20 and 10000
 }
 ```
@@ -506,6 +507,12 @@ void jswrap_nrf_bluetooth_setAdvertising(JsVar *data, JsVar *options) {
         bleAdvertisingInterval = new_advertising_interval;
         bleChanged = true;
       }
+    }
+
+    v = jsvObjectGetChild(options, "connectable", 0);
+    if (v) {
+      bleConnectable = jsvGetBoolAndUnLock(v);
+      bleChanged = true;
     }
 
     v = jsvObjectGetChild(options, "name", 0);

--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -511,7 +511,8 @@ void jswrap_nrf_bluetooth_setAdvertising(JsVar *data, JsVar *options) {
 
     v = jsvObjectGetChild(options, "connectable", 0);
     if (v) {
-      bleConnectable = jsvGetBoolAndUnLock(v);
+      if (jsvGetBoolAndUnLock(v)) bleStatus &= ~BLE_IS_NOT_CONNECTABLE;
+      else bleStatus |= BLE_IS_NOT_CONNECTABLE;
       bleChanged = true;
     }
 

--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -103,6 +103,7 @@ uint16_t                         m_central_conn_handle = BLE_CONN_HANDLE_INVALID
 bool nfcEnabled = false;
 #endif
 
+bool bleConnectable = true;
 uint16_t bleAdvertisingInterval = ADVERTISING_INTERVAL;
 
 volatile BLEStatus bleStatus = 0;
@@ -1462,7 +1463,7 @@ void jsble_advertising_start() {
 
   ble_gap_adv_params_t adv_params;
   memset(&adv_params, 0, sizeof(adv_params));
-  adv_params.type        = BLE_GAP_ADV_TYPE_ADV_IND;
+  adv_params.type        = bleConnectable ? BLE_GAP_ADV_TYPE_ADV_IND : BLE_GAP_ADV_TYPE_ADV_NONCONN_IND;
   adv_params.p_peer_addr = NULL;
   adv_params.fp          = BLE_GAP_ADV_FP_ANY;
   adv_params.timeout  = APP_ADV_TIMEOUT_IN_SECONDS;

--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -103,7 +103,6 @@ uint16_t                         m_central_conn_handle = BLE_CONN_HANDLE_INVALID
 bool nfcEnabled = false;
 #endif
 
-bool bleConnectable = true;
 uint16_t bleAdvertisingInterval = ADVERTISING_INTERVAL;
 
 volatile BLEStatus bleStatus = 0;
@@ -1463,7 +1462,7 @@ void jsble_advertising_start() {
 
   ble_gap_adv_params_t adv_params;
   memset(&adv_params, 0, sizeof(adv_params));
-  adv_params.type        = bleConnectable ? BLE_GAP_ADV_TYPE_ADV_IND : BLE_GAP_ADV_TYPE_ADV_NONCONN_IND;
+  adv_params.type        = (bleStatus & BLE_IS_NOT_CONNECTABLE) ? BLE_GAP_ADV_TYPE_ADV_NONCONN_IND : BLE_GAP_ADV_TYPE_ADV_IND;
   adv_params.p_peer_addr = NULL;
   adv_params.fp          = BLE_GAP_ADV_FP_ANY;
   adv_params.timeout  = APP_ADV_TIMEOUT_IN_SECONDS;

--- a/targets/nrf5x/bluetooth.h
+++ b/targets/nrf5x/bluetooth.h
@@ -48,16 +48,16 @@ typedef enum  {
   BLE_IS_RSSI_SCANNING = 256, // Are we scanning for RSSI values
   BLE_IS_SLEEPING = 512,      // NRF.sleep has been called
   BLE_PM_INITIALISED = 1024,  // Set when the Peer Manager has been initialised (only needs doing once, even after SD restart)
+  BLE_IS_NOT_CONNECTABLE = 2048, // Is the device connectable?
 
-  BLE_IS_ADVERTISING_MULTIPLE = 2048, // We have multiple different advertising packets
-  BLE_ADVERTISING_MULTIPLE_ONE = 4096,
+  BLE_IS_ADVERTISING_MULTIPLE = 4096, // We have multiple different advertising packets
+  BLE_ADVERTISING_MULTIPLE_ONE = 8192,
   BLE_ADVERTISING_MULTIPLE_SHIFT = GET_BIT_NUMBER(BLE_ADVERTISING_MULTIPLE_ONE),
   BLE_ADVERTISING_MULTIPLE_MASK = 255 << BLE_ADVERTISING_MULTIPLE_SHIFT,
 } BLEStatus;
 
 
 extern volatile BLEStatus bleStatus;
-extern bool bleConnectable;                       /**< whether the device is connectable */
 extern uint16_t bleAdvertisingInterval;           /**< The advertising interval (in units of 0.625 ms). */
 extern uint16_t                         m_conn_handle;    /**< Handle of the current connection. */
 #if CENTRAL_LINK_COUNT>0

--- a/targets/nrf5x/bluetooth.h
+++ b/targets/nrf5x/bluetooth.h
@@ -57,6 +57,7 @@ typedef enum  {
 
 
 extern volatile BLEStatus bleStatus;
+extern bool bleConnectable;                       /**< whether the device is connectable */
 extern uint16_t bleAdvertisingInterval;           /**< The advertising interval (in units of 0.625 ms). */
 extern uint16_t                         m_conn_handle;    /**< Handle of the current connection. */
 #if CENTRAL_LINK_COUNT>0


### PR DESCRIPTION
This allows the device to be non connectable, useful for beacons