### PR TITLE
change jsError() to jsExceptionHere(). Suppress jsiConsolePrintf() for HTTPS connections

### DIFF
--- a/libs/network/socketserver.c
+++ b/libs/network/socketserver.c
@@ -681,7 +681,7 @@ void serverListen(JsNetwork *net, JsVar *server, int port) {
 
   int sckt = netCreateSocket(net, 0/*server*/, (unsigned short)port, NCF_NORMAL, 0 /*options*/);
   if (sckt<0) {
-    jsError("Unable to create socket\n");
+    jsExceptionHere(JSET_INTERNALERROR, "Unable to create socket\n");
     jsvObjectSetChildAndUnLock(server, HTTP_NAME_CLOSENOW, jsvNewFromBool(true));
   } else {
     jsvObjectSetChildAndUnLock(server, HTTP_NAME_SOCKET, jsvNewFromInteger(sckt+1));
@@ -826,7 +826,7 @@ void clientRequestConnect(JsNetwork *net, JsVar *httpClientReqVar) {
   networkGetHostByName(net, hostName, &host_addr);
 
   if(!host_addr) {
-    jsError("Unable to locate host\n");
+    jsExceptionHere(JSET_INTERNALERROR, "Unable to locate host\n");
     // As this is already in the list of connections, an error will be thrown on idle anyway
     jsvObjectSetChildAndUnLock(httpClientReqVar, HTTP_NAME_CLOSENOW, jsvNewFromBool(true));
     jsvUnLock(options);
@@ -846,7 +846,7 @@ void clientRequestConnect(JsNetwork *net, JsVar *httpClientReqVar) {
 
   int sckt =  netCreateSocket(net, host_addr, port, flags, options);
   if (sckt<0) {
-    jsError("Unable to create socket\n");
+    jsExceptionHere(JSET_INTERNALERROR, "Unable to create socket\n");
     // As this is already in the list of connections, an error will be thrown on idle anyway
     jsvObjectSetChildAndUnLock(httpClientReqVar, HTTP_NAME_CLOSENOW, jsvNewFromBool(true));
   } else {


### PR DESCRIPTION
Currently, there are places in `network.c` which raise errors that we have no chance to handle with JavaScript. Also, there are places when the console is polluted with a forced debug/trace output to it. The PR fixes that.

### Rationale

We’ve tried to make a device that could work with HTTPS API for a long time without restarts. In our case, it’s Telegram Messenger API. Works fine, but fails forever at some point when a problem that otherwise could be solved by retrying lead to a unhandled error.

With this patch applied we can handle such cases by using trivial `try { ... } catch` blocks.