### PR TITLE
No timeout argument setTimeout() calls work

### DIFF
--- a/src/jswrap_interactive.c
+++ b/src/jswrap_interactive.c
@@ -441,7 +441,7 @@ JsVar *_jswrap_interface_setTimeoutOrInterval(JsVar *func, JsVarFloat interval, 
   } else {
     // Create a new timer
     JsVar *timerPtr = jsvNewObject();
-    if (interval<TIMER_MIN_INTERVAL) interval=TIMER_MIN_INTERVAL;
+    if (isnan(interval) || interval<TIMER_MIN_INTERVAL) interval=TIMER_MIN_INTERVAL;
     JsSysTime intervalInt = jshGetTimeFromMilliseconds(interval);
     jsvObjectSetChildAndUnLock(timerPtr, "time", jsvNewFromLongInteger((jshGetSystemTime() - jsiLastIdleTime) + intervalInt));
     if (!isTimeout) {

--- a/tests/test_settimeout_noarg.js
+++ b/tests/test_settimeout_noarg.js
@@ -1,0 +1,2 @@
+result=0
+setTimeout("result=1");


### PR DESCRIPTION
It behaves as if zero (0) was passed in. Compliant to the spec: see
https://www.w3.org/TR/2011/WD-html5-20110525/timers.html#get-the-timeout