### PR TITLE
Introduced sockerserver:serverAddMembership

### DIFF
--- a/libs/network/jswrap_net.c
+++ b/libs/network/jswrap_net.c
@@ -569,13 +569,10 @@ void jswrap_dgram_close(JsVar *parent) {
 }
 */
 void jswrap_dgram_addMembership(JsVar *parent, JsVar *group, JsVar *ip) {
-  // FIXME: perhaps extend the JsNetwork with addmembership/removemembership instead of using options
-  JsVar *options = jsvObjectGetChild(parent, "opt" /* socketserver.c:HTTP_NAME_OPTIONS_VAR */, 0);
-  if (options) {
-      jsvObjectSetChild(options, "multicastGroup", group);
-      jsvObjectSetChild(options, "multicastIp", ip);
-      jsvUnLock(options);
-  }
+  JsNetwork net;
+  if (!networkGetFromVarIfOnline(&net)) return;
+
+  serverAddMembership(&net, parent, group, ip);
 }
 
 /*JSON{

--- a/libs/network/socketserver.c
+++ b/libs/network/socketserver.c
@@ -742,6 +742,16 @@ JsVar *serverNew(SocketType socketType, JsVar *callback) {
   return server;
 }
 
+void serverAddMembership(JsNetwork *net, JsVar *server, JsVar *group, JsVar *ip) {
+  // FIXME: perhaps extend the JsNetwork with addmembership/removemembership instead of using options
+  JsVar *options = jsvObjectGetChild(server, HTTP_NAME_OPTIONS_VAR, 0);
+  if (options) {
+      jsvObjectSetChild(options, "multicastGroup", group);
+      jsvObjectSetChild(options, "multicastIp", ip);
+      jsvUnLock(options);
+  }
+}
+
 void serverListen(JsNetwork *net, JsVar *server, unsigned short port, SocketType socketType) {
   JsVar *arr = socketGetArray(HTTP_ARRAY_HTTP_SERVERS, true);
   if (!arr) return; // out of memory

--- a/libs/network/socketserver.h
+++ b/libs/network/socketserver.h
@@ -26,6 +26,7 @@ bool socketIdle(JsNetwork *net);
 
 // -----------------------------
 JsVar *serverNew(SocketType socketType, JsVar *callback);
+void serverAddMembership(JsNetwork *net, JsVar *socket, JsVar *group, JsVar *ip);
 void serverListen(JsNetwork *net, JsVar *httpServerVar, unsigned short port, SocketType socketType);
 void serverClose(JsNetwork *net, JsVar *server);
 


### PR DESCRIPTION
This avoids the HTTP_NAME_OPTIONS_VAR server property leaking the
socketserver.c local abstraction.