### PR TITLE
dgramSocket.bind() returns the dgramSocket instance

### DIFF
--- a/libs/network/jswrap_net.c
+++ b/libs/network/jswrap_net.c
@@ -515,10 +515,13 @@ void jswrap_dgram_messageCallback(JsVar *parent, JsVar *msg, JsVar *rinfo) {
   "params" : [
     ["port","int32","The port to bind at"],
     ["callback","JsVar","A function(res) that will be called when the socket is bound. You can then call `res.on('message', function(message, info) { ... })` and `res.on('close', function() { ... })` to deal with the response."]
-  ]
+  ],
+  "return" : ["JsVar","The dgramSocket instance that 'bind' was called on"]
 }
 */
 JsVar *jswrap_dgramSocket_bind(JsVar *parent, unsigned short port, JsVar *callback) {
+  parent = jsvLockAgain(parent); // we're returning the parent, so need to re-lock it
+
   // FIXME: move elsewhere...
   // re-used dgramSocket instance...
   {

--- a/tests/test_dgram_socket.js
+++ b/tests/test_dgram_socket.js
@@ -5,11 +5,11 @@ var port = 41234;
 let dgram = require('dgram');
 
 let srv = dgram.createSocket('udp4');
-srv.bind(port, function(bsrv) {
-  bsrv.on('message', function(msg, info) {
+srv = srv.bind(port, function() {
+  srv.on('message', function(msg, info) {
     console.log("<"+JSON.stringify(msg));
     console.log("<"+JSON.stringify(info));
-    bsrv.send(msg+'!', info.port, info.address);
+    srv.send(msg+'!', info.port, info.address);
   });
 });
 srv.on('close', function() {
@@ -23,7 +23,7 @@ client.on('message', function(msg, info) {
 
   result = msg=="42!" && info.address=="127.0.0.1" && info.port==port;
 
-  clearTimeout(); // stop the fail fast
+  clearTimeout(failTimeout); // stop the fail fast
 
   srv.close();
   client.close();
@@ -33,7 +33,7 @@ client.on('close', function() {
 });
 
 // fail the test fast if broken
-setTimeout(function() {
+failTimeout = setTimeout(function() {
   client.close();
   srv.close();
 }, 100);


### PR DESCRIPTION
Added the required jsvLockAgain(parent).

The tests/test_dgram_socket.js now also works directly
in node.jsl (tested in v6.9.4).
