### PR TITLE
Added dgramSocket.send() offset + len support

### DIFF
--- a/libs/network/jswrap_net.c
+++ b/libs/network/jswrap_net.c
@@ -411,8 +411,8 @@ JsVar *jswrap_net_connect(JsVar *options, JsVar *callback, SocketType socketType
     JsNetwork net;
     if (networkGetFromVarIfOnline(&net)) {
       clientRequestConnect(&net, rq);
+      networkFree(&net);
     }
-    networkFree(&net);
   }
 
   return rq;
@@ -464,19 +464,47 @@ An actual socket connection - allowing transmit/receive of TCP data
   "name" : "send",
   "generate" : "jswrap_dgram_socket_send",
   "params" : [
-    ["message","JsVar","A string containing message to send"],
-    ["port","int32","The port to send the message to"],
-    ["host","JsVar","A string containing the message target host"]
-  ],
-  "return" : ["bool","For note compatibility, the boolean false. When the send buffer is empty, a `drain` event will be sent"]
+    ["buffer","JsVar","A string containing message to send"],
+    ["offset","JsVar","Offset in the passed string where the message starts [optional]"],
+    ["length","JsVar","Number of bytes in the message [optional]"],
+    ["args","JsVarArray","Destination port number, Destination IP address string"]
+  ]
 }*/
-bool jswrap_dgram_socket_send(JsVar *parent, JsVar *data, unsigned short port, JsVar *host) {
+// There are futher arguments within the 'args' JsVarArray:
+//  ["port","JsVar","Destination port number to send the message to"],
+//  ["address","JsVar","Destination hostname or IP address string"]
+void jswrap_dgram_socket_send(JsVar *parent, JsVar *buffer, JsVar *offset, JsVar *length, JsVar *args) {
+  assert(jsvIsObject(parent));
+  assert(jsvIsString(buffer));
   JsNetwork net;
-  if (!networkGetFromVarIfOnline(&net)) return false;
+  if (!networkGetFromVarIfOnline(&net)) return;
 
-  clientRequestWrite(&net, parent, data, host, port);
+  JsVar *msg;
+  JsVar *address;
+  JsVar *port = jsvGetArrayItem(args, 0);
+  if (jsvIsNumeric(port)) {
+    int from = jsvGetInteger(offset);
+    int count = jsvGetInteger(length);
+    msg = jsvNewFromEmptyString();
+    if (!msg) {
+      networkFree(&net);
+      return; // out of memory
+    }
+    jsvAppendStringVar(msg, buffer, (size_t)from, (size_t)count);
+    address = jsvGetArrayItem(args, 1);
+  } else {
+    jsvUnLock(port);
+
+    msg = buffer;
+    port = offset;
+    address = length;
+    assert(jsvIsNumeric(port));
+  }
+  clientRequestWrite(&net, parent, msg, address, jsvGetInteger(port));
+  if (msg != buffer) {
+    jsvUnLock3(msg, port, address);
+  }
   networkFree(&net);
-  return false;
 }
 
 /*JSON{
@@ -522,9 +550,9 @@ void jswrap_dgram_messageCallback(JsVar *parent, JsVar *msg, JsVar *rinfo) {
 JsVar *jswrap_dgramSocket_bind(JsVar *parent, unsigned short port, JsVar *callback) {
   parent = jsvLockAgain(parent); // we're returning the parent, so need to re-lock it
 
-  jsvObjectSetChild(parent, "#onbind", callback);
+  jsvObjectSetChild(parent, DGRAM_ON_BIND_NAME, callback);
   jsvUnLock(jswrap_net_server_listen(parent, port, ST_UDP)); // create bound socket
-  jsiQueueObjectCallbacks(parent, "#onbind", &parent, 1);
+  jsiQueueObjectCallbacks(parent, DGRAM_ON_BIND_NAME, &parent, 1);
 
   return parent;
 }

--- a/libs/network/jswrap_net.h
+++ b/libs/network/jswrap_net.h
@@ -14,6 +14,7 @@
 #include "jsvar.h"
 #include "socketserver.h"
 
+#define DGRAM_ON_BIND_NAME          JS_EVENT_PREFIX"bind"
 #define DGRAM_MESSAGE_CALLBACK_NAME JS_EVENT_PREFIX"message"
 
 bool jswrap_net_idle();
@@ -36,9 +37,4 @@ JsVar *jswrap_dgramSocket_bind(JsVar *parent, unsigned short port, JsVar *callba
 void jswrap_dgram_messageCallback(JsVar *parent, JsVar *dataString, JsVar *dataInfo);
 void jswrap_dgram_close(JsVar *parent);
 void jswrap_dgram_addMembership(JsVar *parent, JsVar *group, JsVar *ip);
-bool jswrap_dgram_socket_send(JsVar *parent, JsVar *data, unsigned short portNumber, JsVar *host);
-
-
-
-
-
+void jswrap_dgram_socket_send(JsVar *parent, JsVar *buffer, JsVar *offset, JsVar *length, JsVar *args);

--- a/tests/test_dgram_multi.js
+++ b/tests/test_dgram_multi.js
@@ -62,4 +62,4 @@ setTimeout(function() {
 }, 100);
 
 client.send('42', port1, 'localhost');
-client.send('24', port2, 'localhost');
+client.send('___24___', 3, 2, port2, 'localhost');


### PR DESCRIPTION
Both of the following #send() signatures supported:
  client.send('msg', port, address);
  client.send('  msg  ', 2, 3, port, address); // sends 'msg' message

Partial fix for #1271