### PR TITLE
ESP32: Fix jshFlashGetMemMapAddress offset

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -718,13 +718,16 @@ void jshFlashErasePage(
 }
 
 size_t jshFlashGetMemMapAddress(size_t ptr) {
-  // Treat 0-based as external flash
-  // 0x3F400000 - 0x3F7FFFFF = external Flash
-  if (ptr < 0x400000)
-    return 0x3F400000 + ptr;
-
-  // Otherwise lets assume we know what we should be accessing
-  return ptr;
+   // if ptr is high already, assume we know what we're accessing
+  if (ptr > 0x10000000) return ptr;
+  // romdata_jscode is memory mapped address from the js_code partition in rom - targets/esp32/main.c
+  extern char* romdata_jscode;
+  if (romdata_jscode==0) {
+    jsError("Couldn't find js_code partition - update with partition_espruino.bin\n");
+    return 0;
+  }
+  // Flash memory access is offset to 0, so remove starting location as already accounted for
+  return &romdata_jscode[ptr - 0x100000 ];
 }
 
 unsigned int jshSetSystemClock(JsVar *options) {


### PR DESCRIPTION
The romdata_jscode point is mapped by the MMU to the real address of the jscode partition. The offset from the start of flash for the code areas is 0x100000 so this has be removed in the direct access of memory case.