### PR TITLE
NFC: Backport HAL_NFC_PARAM_ID_NFCID1 from SDK 14.2.0

### DIFF
--- a/targetlibs/nrf5x_12/components/nfc/t2t_lib/hal_t2t/hal_nfc_t2t.c
+++ b/targetlibs/nrf5x_12/components/nfc/t2t_lib/hal_t2t/hal_nfc_t2t.c
@@ -442,12 +442,19 @@ ret_code_t hal_nfc_parameter_set(hal_nfc_param_id_t id, const void * p_data, siz
 {
     switch(id)
     {
-        case HAL_NFC_PARAM_ID_UID:
-            if(data_length != NFC_UID_SIZE)
+        case HAL_NFC_PARAM_ID_NFCID1:
+            if(data_length == NFC_UID_SIZE)
+            {
+                memcpy((void *)m_nfc_uid, p_data, NFC_UID_SIZE);
+            } 
+            else if (data_length == 1 && ((char*)p_data)[0] == NFC_UID_SIZE)
+            {
+                memset((void *)m_nfc_uid, '\0', NFC_UID_SIZE);
+            } 
+            else
             {
                 return NRF_ERROR_INVALID_LENGTH;
-            }
-            memcpy((void *)m_nfc_uid, p_data, NFC_UID_SIZE);
+            } 
             break;
         default:
             break;

--- a/targetlibs/nrf5x_12/components/nfc/t2t_lib/hal_t2t/hal_nfc_t2t.h
+++ b/targetlibs/nrf5x_12/components/nfc/t2t_lib/hal_t2t/hal_nfc_t2t.h
@@ -72,7 +72,9 @@ typedef enum {
 /** @brief Parameter IDs for set/get function. */
 typedef enum {
     HAL_NFC_PARAM_ID_TESTING,         ///<  Used for unit tests.
-    HAL_NFC_PARAM_ID_UID,             ///<  Set custom UID
+    HAL_NFC_PARAM_ID_NFCID1,          /**<  NFCID1 value, data can 7 bytes long (double size).
+                                            To use default NFCID1 pass one byte containing a 7.
+                                            This parameter can be set before nfc_t2t_setup() to set initial NFCID1. */
     HAL_NFC_PARAM_ID_INTERNAL,        ///<  Get internal bytes, replaces nfc_t2t_internal_set()
     HAL_NFC_PARAM_ID_UNKNOWN
 } hal_nfc_param_id_t;

--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -2189,9 +2189,9 @@ void jsble_nfc_start(const uint8_t *data, size_t len) {
 
   /* Set UID / UID Length */
   if (len)
-    ret_val = hal_nfc_parameter_set(HAL_NFC_PARAM_ID_UID, data, len);
+    ret_val = hal_nfc_parameter_set(HAL_NFC_PARAM_ID_NFCID1, data, len);
   else
-    ret_val = hal_nfc_parameter_set(HAL_NFC_PARAM_ID_UID, "\0\0\0\0\0\0\0", 7);
+    ret_val = hal_nfc_parameter_set(HAL_NFC_PARAM_ID_NFCID1, "\x07", 1);
   if (ret_val)
     return jsExceptionHere(JSET_ERROR, "nfcSetUid: Got NFC error code %d", ret_val);
 


### PR DESCRIPTION
In 141752c HAL_NFC_PARAM_ID_UID was introduced for setting custom NFC UID. In SDK 14 Nordic introduced the very same function officially. For future compatibility Nordic's HAL_NFC_PARAM_ID_NFCID1 API is backported and HAL_NFC_PARAM_ID_UID is renamed.

HAL_NFC_PARAM_ID_NFCID1 takes either a 7 byte UID or a 0x07 to set the default UID.

Support 4 byte and 10 byte UID is not backported.