### PR TITLE
Minor typo: require("flash") => require("Flash")

### DIFF
--- a/targets/esp8266/jswrap_esp8266.c
+++ b/targets/esp8266/jswrap_esp8266.c
@@ -242,7 +242,7 @@ JsVar *jswrap_ESP8266_getState() {
   "generate" : "jswrap_ESP8266_getFreeFlash",
   "return"   : ["JsVar", "Array of objects with `addr` and `length` properties describing the free flash areas available"]
 }
-**Note:** This is deprecated. Use `require("flash").getFree()`
+**Note:** This is deprecated. Use `require("Flash").getFree()`
 */
 JsVar *jswrap_ESP8266_getFreeFlash() {
   return jshFlashGetFree();


### PR DESCRIPTION
Minor typo in the builtin documentation for require('ESP8266').getFreeFlash().