### PR TITLE
ESP8266: Fix when USE_DEBUGGER not defined

### DIFF
--- a/src/jsinteractive.c
+++ b/src/jsinteractive.c
@@ -942,9 +942,9 @@ static JsVar *jsiGetHistory() {
   return jsvObjectGetChild(
       execInfo.hiddenRoot,
 #ifdef USE_DEBUGGER
-    (jsiStatus & JSIS_IN_DEBUGGER) ? JSI_DEBUG_HISTORY_NAME : JSI_HISTORY_NAME,
+      (jsiStatus & JSIS_IN_DEBUGGER) ? JSI_DEBUG_HISTORY_NAME : JSI_HISTORY_NAME,
 #else
-    JSI_HISTORY_NAME,
+      JSI_HISTORY_NAME,
 #endif
       JSV_ARRAY);
 }

--- a/src/jsinteractive.c
+++ b/src/jsinteractive.c
@@ -941,7 +941,11 @@ bool jsiFreeMoreMemory() {
 static JsVar *jsiGetHistory() {
   return jsvObjectGetChild(
       execInfo.hiddenRoot,
-      (jsiStatus & JSIS_IN_DEBUGGER) ? JSI_DEBUG_HISTORY_NAME : JSI_HISTORY_NAME,
+#ifdef USE_DEBUGGER
+    (jsiStatus & JSIS_IN_DEBUGGER) ? JSI_DEBUG_HISTORY_NAME : JSI_HISTORY_NAME,
+#else
+    JSI_HISTORY_NAME,
+#endif
       JSV_ARRAY);
 }
 


### PR DESCRIPTION
Failing here:
https://travis-ci.org/espruino/Espruino/jobs/362880677#L480


```
src/jsinteractive.c:944:20: error: 'JSIS_IN_DEBUGGER' undeclared (first use in this function)
       (jsiStatus & JSIS_IN_DEBUGGER) ? JSI_DEBUG_HISTORY_NAME : JSI_HISTORY_NAME,
      
```