### PR TITLE
Telnet - prevent New interpreter error: FIFO_FULL

### DIFF
--- a/libs/network/telnet/jswrap_telnet.c
+++ b/libs/network/telnet/jswrap_telnet.c
@@ -286,8 +286,9 @@ void telnetSendChar(char ch) {
 bool telnetRecv(JsNetwork *net) {
   if (tnSrv.sock == 0 || tnSrv.cliSock == 0) return false;
 
-  char buff[256];
-  int r = netRecv(net, ST_NORMAL, tnSrv.cliSock-1, buff, 256);
+  char buff[64];
+  if (!jshHasEventSpaceForChars(sizeof(buff))) return false;
+  int r = netRecv(net, ST_NORMAL, tnSrv.cliSock-1, buff, sizeof(buff));
   if (r > 0) {
     jshPushIOCharEvents(EV_TELNET, buff, (unsigned int)r);
   } else if (r < 0) {


### PR DESCRIPTION
Allow TCP/IP in Telnet have flow control in the firmware itself.

http://forum.espruino.com/conversations/317981/#comment14206992