### PR TITLE
Compare Transfer-Encoding value case-insensitively

### DIFF
--- a/tests/test_http_post_chunked.js
+++ b/tests/test_http_post_chunked.js
@@ -36,7 +36,7 @@ var options = {
   method: 'POST',
   protocol: 'http:',
   headers: {
-    'Transfer-Encoding': 'chunked'
+    'Transfer-Encoding': 'Chunked'
   }
 };
 var req = http.request(options, function(res) {


### PR DESCRIPTION
By RFC 2616: All transfer-coding values are case-insensitive.