### PR TITLE
Add ignoreCase string comparison helper

### DIFF
--- a/libs/bluetooth/bluetooth_utils.c
+++ b/libs/bluetooth/bluetooth_utils.c
@@ -73,9 +73,9 @@ bool bleVarToAddr(JsVar *mac, ble_gap_addr_t *addr) {
   for (i=0;i<6;i++)
     addr->addr[5-i] = (chtod(jsvGetCharInString(mac, i*3))<<4) | chtod(jsvGetCharInString(mac, (i*3)+1));
   if (jsvGetStringLength(mac)!=17) {
-    if (jsvIsStringEqualOrStartsWithOffset(mac, " public", false, 17))
+    if (jsvIsStringEqualOrStartsWithOffset(mac, " public", false, 17, false))
       addr->addr_type = BLE_GAP_ADDR_TYPE_PUBLIC; // default
-    else if (jsvIsStringEqualOrStartsWithOffset(mac, " random", false, 17))
+    else if (jsvIsStringEqualOrStartsWithOffset(mac, " random", false, 17, false))
       addr->addr_type = BLE_GAP_ADDR_TYPE_RANDOM_STATIC;
     else return false;
   }

--- a/libs/network/socketserver.c
+++ b/libs/network/socketserver.c
@@ -63,13 +63,9 @@ static char DBG_LIB[] = "socketserver"; // library name
 
 // -----------------------------
 
-bool compareTransferEncodingAndUnlock(JsVar *encoding, char *value) {
-    if (encoding) {
-        JsVar *encodingLc = jswrap_string_toUpperLowerCase(encoding, false);
-        jsvUnLock(encoding);
-        encoding = encodingLc;
-    }
-    return jsvIsStringEqualAndUnLock(encoding, value);
+static ALWAYS_INLINE bool compareTransferEncodingAndUnlock(JsVar *encoding, char *value) {
+    // RFC 2616: All transfer-coding values are case-insensitive.
+    return jsvIsStringIEqualAndUnLock(encoding, value);
 }
 
 static void httpAppendHeaders(JsVar *string, JsVar *headerObject) {

--- a/src/jsvar.h
+++ b/src/jsvar.h
@@ -474,7 +474,7 @@ size_t jsvGetIndexFromLineAndCol(JsVar *v, size_t line, size_t col); ///<  IN A 
 
 
 /// Like jsvIsStringEqualOrStartsWith, but starts comparing at some offset (not the beginning of the string)
-bool jsvIsStringEqualOrStartsWithOffset(JsVar *var, const char *str, bool isStartsWith, size_t startIdx);
+bool jsvIsStringEqualOrStartsWithOffset(JsVar *var, const char *str, bool isStartsWith, size_t startIdx, bool ignoreCase);
 /**
   Compare a string with a C string. Returns 0 if A is not a string.
 
@@ -483,7 +483,7 @@ bool jsvIsStringEqualOrStartsWithOffset(JsVar *var, const char *str, bool isStar
 */
 bool jsvIsStringEqualOrStartsWith(JsVar *var, const char *str, bool isStartsWith);
 bool jsvIsStringEqual(JsVar *var, const char *str); ///< see jsvIsStringEqualOrStartsWith
-bool jsvIsStringEqualAndUnLock(JsVar *var, const char *str); ///< see jsvIsStringEqualOrStartsWith
+bool jsvIsStringIEqualAndUnLock(JsVar *var, const char *str); ///< see jsvIsStringEqualOrStartsWithOffset
 int jsvCompareString(JsVar *va, JsVar *vb, size_t starta, size_t startb, bool equalAtEndOfString); ///< Compare 2 strings, starting from the given character positions
 /// Return a new string containing just the characters that are shared between two strings.
 JsVar *jsvGetCommonCharacters(JsVar *va, JsVar *vb);


### PR DESCRIPTION
Add jsvIsStringIEqualAndUnLock helper. No extra allocation solution
for cases where an ignoreCase comparison is necessary.