### PR TITLE
Fix receiving of large HTTP headers

### DIFF
--- a/libs/network/socketserver.c
+++ b/libs/network/socketserver.c
@@ -410,7 +410,9 @@ void socketReceived(JsVar *connection, JsVar *socket, SocketType socketType, JsV
   bool isHttp = (socketType&ST_TYPE_MASK)==ST_HTTP;
   bool hadHeaders = jsvGetBoolAndUnLock(jsvObjectGetChild(reader,HTTP_NAME_HAD_HEADERS,0));
   if (!hadHeaders) {
-    if (isHttp && httpParseHeaders(receiveData, reader, isServer)) {
+    if (!isHttp) {
+      hadHeaders = true;
+    } else if (httpParseHeaders(receiveData, reader, isServer)) {
       hadHeaders = true;
 
       // on connect only when just parsed the HTTP headers
@@ -422,8 +424,6 @@ void socketReceived(JsVar *connection, JsVar *socket, SocketType socketType, JsV
       } else {
         jsiQueueObjectCallbacks(connection, HTTP_NAME_ON_CONNECT, &socket, 1);
       }
-    } else {
-      hadHeaders = true;
     }
     jsvObjectSetChildAndUnLock(reader, HTTP_NAME_HAD_HEADERS, jsvNewFromBool(hadHeaders));
   }

--- a/tests/test_http_headers.js
+++ b/tests/test_http_headers.js
@@ -1,0 +1,59 @@
+// HTTP Headers longer than MSS server and client test
+
+var result = 0;
+var http = require("http");
+
+var server = http.createServer(function (req, res) {
+  console.log("Connected");
+  var body = '';
+  req.on('data', function(data) {
+    console.log("<" + data);
+    body += data;
+  });
+  req.on('end', function() {
+    console.log("<end");
+    res.writeHead(200);
+    res.end('42'+body+req.headers['X-Check']);
+  });
+  req.on('close', function() {
+    console.log("<close");
+  });
+  req.on('error', function(e) {
+    console.log("<error: " + e.message);
+  });
+});
+server.listen(8080);
+
+var options = {
+  host: 'localhost',
+  port: 8080,
+  path: '/post.html',
+  method: 'POST',
+  protocol: 'http:',
+  headers: {
+    'X-LongHeader': new Array(35).fill('long header item').join(','),
+    'X-Check': '24'
+  }
+};
+var req = http.request(options, function(res) {
+  console.log(">RES ", res.headers);
+  var body = '';
+  res.on('data', function(data) {
+    console.log(">" + data);
+    body += data;
+  });
+  res.on('end', function() {
+    console.log(">END");
+    server.close();
+    result = body=="42-0123456789abcdef-24";
+  });
+  res.on('close', function() {
+    console.log(">CLOSE");
+  });
+})
+
+req.on('error', function(e) {
+  console.log(">ERROR: " + e.message);
+});
+
+req.end('-0123456789abcdef-'); // longer than 15 chars


### PR DESCRIPTION
Added a test which sends HTTP headers which take more than
MSS bytes (536) and therefore the httpParseHeaders() needs to be
called later again after the next packet arrives.

The websocket `Connection: Upgrade` request with the
`Sec-WebSocket-*` headers made the HTTP header section larger
as described above so it exhibited in the websocket scenario in #1405