### PR TITLE
Add E.pipe as fs.pipe alternative

### DIFF
--- a/src/jswrap_espruino.c
+++ b/src/jswrap_espruino.c
@@ -720,6 +720,19 @@ Run `E.getFlags()` and check its description for a list of available flags and t
 /*JSON{
   "type" : "staticmethod",
   "class" : "E",
+  "name" : "pipe",
+  "ifndef" : "SAVE_ON_FLASH",
+  "generate" : "jswrap_pipe",
+  "params" : [
+    ["source","JsVar","The source file/stream that will send content."],
+    ["destination","JsVar","The destination file/stream that will receive content from the source."],
+    ["options","JsVar",["An optional object `{ chunkSize : int=64, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+  ]
+}*/
+
+/*JSON{
+  "type" : "staticmethod",
+  "class" : "E",
   "name" : "toArrayBuffer",
   "generate" : "jswrap_espruino_toArrayBuffer",
   "params" : [


### PR DESCRIPTION
For boards not having the 'fs' module it is still useful to have the built-in pipe() functionality.

They could stream for example Storage contents via https://github.com/espruino/Espruino/issues/1432