### PR TITLE
fix STM32 neopixel timing

### DIFF
--- a/libs/neopixel/jswrap_neopixel.c
+++ b/libs/neopixel/jswrap_neopixel.c
@@ -162,7 +162,9 @@ bool neopixelWrite(Pin pin, unsigned char *rgbData, size_t rgbSize) {
   jshSPISetReceive(device, false);
   jshInterruptOff();
   for (i=0;i<rgbSize;i++)
-    jsspiSend4bit(device, rgbData[i], 1, 3);
+    jsspiSend4bit(device, rgbData[i], 8, 12);
+  // make sure all useful data has been flushed from 32-bit fifo
+  jsspiSend4bit(device, 0, 0, 0);
   jshInterruptOn();
   jshSPIWait(device); // wait until SPI send finished and clear the RX buffer
   jshSPISet16(device, false); // back to 8 bit


### PR DESCRIPTION
STM32 Neopixel timing is incorrect.  The 0/1 bit values should start with a high level and end low.  The current jsspiSend4bit values "1" and "3" result in the high level at the end of the period because SPI is running in MSB-first mode.  Changing these values to "8" and "12" corrects this timing.  I also found that I needed to flush the FIFO to ensure the output didn't get stuck high.  My guess is that the cleanup code is shutting down SPI while there is still data in the FIFO.  Sending an extra 32 bits of 0 bits ensures that all useful data in the 32-bit FIFO has been drained.
Prior to this fix, my Neopixel LED was randomly producing incorrect colors, and the LED was entirely black for any color consisting of just single "1" in the entire bit pattern (other than the very first bit).  With this fix, I get reliable and correct colors.