### PR TITLE
Disable TIME_WAIT socket state for Linux

### DIFF
--- a/libs/network/linux/network_linux.c
+++ b/libs/network/linux/network_linux.c
@@ -192,6 +192,13 @@ int net_linux_createsocket(JsNetwork *net, SocketType socketType, uint32_t host,
   if (setsockopt(sckt,SOL_SOCKET,SO_NOSIGPIPE,(const char *)&optval,sizeof(optval))<0)
     jsWarn("setsockopt(SO_NOSIGPIPE) failed\n");
 #endif
+#ifdef SO_LINGER
+  struct linger lngr;
+  lngr.l_onoff = 1;
+  lngr.l_linger = 0;
+  if (setsockopt(sckt, SOL_SOCKET, SO_LINGER, (const char *)&lngr, sizeof(lngr))<0)
+    jsWarn("setsockopt(SO_LINGER) failed\n");
+#endif
 
   return sckt;
 }


### PR DESCRIPTION
Linux sockets to set SO_LINGER sockopt to 0.

This allowes running the network tests immediately
one after another without blocking the listening port
after process exit.