### PR TITLE
ESP_FLASH_MAX for ESP8266_4MB is wrong  (fix 1551)

### DIFF
--- a/boards/ESP8266_4MB.py
+++ b/boards/ESP8266_4MB.py
@@ -33,7 +33,7 @@ info = {
    ],
    'makefile' : [
      'FLASH_4MB=1',
-     'ESP_FLASH_MAX=962560',
+     'ESP_FLASH_MAX=831488',
      'FLASH_BAUD=460800'    
     ]
  }


### PR DESCRIPTION
in boards/ESP8266_4MB.py

will update ChangeLog later