### PR TITLE
fix error String.length value for native string

### DIFF
--- a/src/jsvar.c
+++ b/src/jsvar.c
@@ -1001,7 +1001,7 @@ JsVar *jsvNewNativeString(char *ptr, size_t len) {
   JsVar *str = jsvNewWithFlags(JSV_NATIVE_STRING);
   if (!str) return 0;
   str->varData.nativeStr.ptr = ptr;
-  str->varData.nativeStr.len = (uint16_t)len;
+  str->varData.nativeStr.len = len;
   return str;
 }
 


### PR DESCRIPTION
If a native string size greater than 65535B, the String.length was wrong.