### PR TITLE
Remove insecure (redundant) jQuery reference

### DIFF
--- a/scripts/build_board_docs.py
+++ b/scripts/build_board_docs.py
@@ -265,7 +265,7 @@ writeHTML("""  <STYLE>
 }
 
 """);
-writeHTML("  </STYLE>"+'<script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>')
+writeHTML("  </STYLE>")
 writeHTML("""
   <SCRIPT type="text/javascript">
     function showTT(ttid) {


### PR DESCRIPTION
I've been getting a 'Mixed Content' error in the Chrome console where jQuery was trying to be loaded over HTTP when the page was loaded over HTTPS. jQuery is already getting loaded on espruino.com pages from a local copy - there's two references in fact, one in `<head>` and the other at the bottom of the page - so we can get rid of this part all together. (I couldn't find the page template that is doubling-up the jQuery request but I'd expect the browser cache to handle that well enough.)