### PR TITLE
WIP: a better dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@
 
 FROM python:3
 
-COPY . /espruino
-WORKDIR /espruino
+COPY ./scripts/provision.sh provision.sh
+COPY ./targetlibs /targetlibs
 
 # Workaround add some stuff that the provision script uses
 # in here so it doesn't have to use sudo
@@ -33,8 +33,11 @@ RUN pip install pyserial
 RUN pip install nrfutil
 
 # This ensures ALL dependencies are installed beforehand
-RUN bash -c "source scripts/provision.sh ALL"
+RUN bash -c "source provision.sh ALL"
+
+COPY . /espruino
+RUN bash -c "mv targetlibs espruino/targetlibs"
+WORKDIR /espruino
 
 ENV RELEASE 1
-CMD ["bash", "-c", "source scripts/provision.sh ALL && make"]
-
+CMD "make"


### PR DESCRIPTION
Hi, there is still a lot of improvements to be made with the Dockerfile. Currently, it is not cache-friendly and container image rebuild takes a lot of time. We should run the `provision.sh` script first and then copy all the source code into the container. This way docker will only re-run the last steps of the Dockerfile and save a lot of time. 

I tried to do this, and also I changed the last line to
```Dockerfile
CMD "make"
```
instead of
```Dockerfile
CMD ["bash", "-c", "source scripts/provision.sh ALL && make"]
```

and when I try to run the container I get this error:
```
make: arm-none-eabi-gcc: Command not found
```

Why is that happening? `arm-none-eabi-gcc` should already be installed during the build of a docker image, isn't it?