### PR TITLE
No exception on clearTimeout(invalidTimeoutId)

### DIFF
--- a/src/jswrap_interactive.c
+++ b/src/jswrap_interactive.c
@@ -555,14 +555,8 @@ void _jswrap_interface_clearTimeoutOrInterval(JsVar *idVar, bool isTimeout) {
   } else {
     JsVar *child = jsvIsBasic(idVar) ? jsvFindChildFromVar(timerArrayPtr, idVar, false) : 0;
     if (child) {
-      JsVar *timerArrayPtr = jsvLock(timerArray);
       jsvRemoveChild(timerArrayPtr, child);
-      jsvUnLock2(child, timerArrayPtr);
-    } else {
-      if (isTimeout)
-        jsExceptionHere(JSET_ERROR, "Unknown Timeout");
-      else
-        jsExceptionHere(JSET_ERROR, "Unknown Interval");
+      jsvUnLock(child);
     }
   }
   jsvUnLock(timerArrayPtr);

--- a/tests/test_settimeout_cleartimeout.js
+++ b/tests/test_settimeout_cleartimeout.js
@@ -1,3 +1,14 @@
 // timer again
 
-var foo = setTimeout("result=1",50);setTimeout("clearTimeout(foo)",100) ;
+var foo = setTimeout("result=1",50);
+
+function clearAlreadyTriggeredTimeout() {
+  try {
+    clearTimeout(foo);
+  } catch(e) {
+    // should not throw when the `foo` timeout was already executed
+    result=0
+  }
+}
+
+setTimeout(clearAlreadyTriggeredTimeout, 100);


### PR DESCRIPTION
Make `clearTimeout/Interval()` behave closer to other JS environments where it doesn't throw exceptions on invalid or stale timeout id is passed.