### PR TITLE
fix sign compare waring

### DIFF
--- a/src/jswrap_dataview.c
+++ b/src/jswrap_dataview.c
@@ -63,7 +63,7 @@ JsVar *jswrap_dataview_constructor(JsVar *buffer, int byteOffset, int byteLength
     jsvObjectSetChild(dataview, "buffer", buffer);
     jsvObjectSetChildAndUnLock(dataview, "byteOffset", jsvNewFromInteger(byteOffset));
     jsvObjectSetChildAndUnLock(dataview, "byteLength", jsvNewFromInteger(
-        byteLength?byteLength:jsvGetArrayBufferLength(buffer)));
+        byteLength?(unsigned int)byteLength:jsvGetArrayBufferLength(buffer)));
   }
   return dataview;
 }


### PR DESCRIPTION
src/jswrap_dataview.c:66:33: warning: signed and unsigned type in conditional expression [-Wsign-compare]
         byteLength ? byteLength : (unsigned) jsvGetArrayBufferLength(buffer)));