### PR TITLE
Revert "fix STM32 neopixel timing"

### DIFF
--- a/libs/neopixel/jswrap_neopixel.c
+++ b/libs/neopixel/jswrap_neopixel.c
@@ -162,9 +162,7 @@ bool neopixelWrite(Pin pin, unsigned char *rgbData, size_t rgbSize) {
   jshSPISetReceive(device, false);
   jshInterruptOff();
   for (i=0;i<rgbSize;i++)
-    jsspiSend4bit(device, rgbData[i], 8, 12);
-  // make sure all useful data has been flushed from 32-bit fifo
-  jsspiSend4bit(device, 0, 0, 0);
+    jsspiSend4bit(device, rgbData[i], 1, 3);
   jshInterruptOn();
   jshSPIWait(device); // wait until SPI send finished and clear the RX buffer
   jshSPISet16(device, false); // back to 8 bit


### PR DESCRIPTION
Reverts espruino/Espruino#1459

Turns out this *does* break neopixel functionality that worked fine before. Sounds like the original author had only used a single neopixel so might not have tested that the chaining of them worked - should have checked with all the stuff here before I merged this :(