### PR TITLE
nRF5x: shutdown util timer if not needed

### DIFF
--- a/targets/nrf5x/jshardware.c
+++ b/targets/nrf5x/jshardware.c
@@ -1397,6 +1397,7 @@ void jshUtilTimerStart(JsSysTime period) {
 void jshUtilTimerDisable() {
   utilTimerActive = false;
   nrf_timer_task_trigger(NRF_TIMER1, NRF_TIMER_TASK_STOP);
+  nrf_timer_task_trigger(NRF_TIMER1, NRF_TIMER_TASK_SHUTDOWN);
 }
 
 // the temperature from the internal temperature sensor


### PR DESCRIPTION
After using the util timer, the current consumption is about 10 times higher then before.

This can be reproduced:
1. power on the NRF52 board
2. check current consumption
3. connect via Bluethooth to device and run:
```javascript
digitalPulse(D6, 1, 50);
digitalPulse(D6, 1, 0);
pinMode(D6, "input", true);
```
4. disconnect from Bluethooth
5. check current consumption is higher then in point 2

Tested with a nRF52832 based board (not an official one from espruino) with NRF52832DK 2v01 firmware.

According to Nordic, this is a know issue:
https://www.nordicsemi.com/DocLib/Content/Errata/nRF52840_Rev1/latest/ERR/nRF52840/Rev1/latest/anomaly_840_78

This pull request will shutdown the util timer after usage. My tests show that with this patch, the current consumption will return to the previous (before using the util timer) value. Repeated usage of `digitalPulse()` is still possible.

Maybe, a similar workaround is require for [cap sense](https://github.com/espruino/Espruino/blob/master/targets/nrf5x/nrf5x_utils.c#L137), but I can not test it.

PS: Thank you for this amazing project! Using espruino is really fun.
