### PR TITLE
Feature characteristic security

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -1078,7 +1078,21 @@ NRF.setServices({
       writable : true,   // optional, default is false
       notify : true,   // optional, default is false
       indicate : true,   // optional, default is false
-      description: "My Characteristic",  // optional, default is null
+      description: "My Characteristic",  // optional, default is null,
+      security: { // optional
+        read: { // optional
+          encrypted: false, // optional, default is false
+          mitm: false, // optional, default is false
+          lesc: false, // optional, default is false
+          signed: false // optional, default is false
+        },
+        write: { // optional
+          encrypted: true, // optional, default is false
+          mitm: false, // optional, default is false
+          lesc: false, // optional, default is false
+          signed: false // optional, default is false
+        }
+      },
       onWrite : function(evt) { // optional
         console.log("Got ", evt.data); // an ArrayBuffer
       }
@@ -1138,6 +1152,9 @@ no device connected to it as it requires a restart of the Bluetooth stack.
 NRF Connect may incorrectly display the old services even after you 
 have modified them. To fix this, disable and re-enable Bluetooth on your
 iOS device, or use an Android device to run NRF Connect.
+
+**Note:** Not all combinations of security configuration values are valid, the valid combinations are: encrypted,
+encrypted + mitm, lesc, signed, signed + mitm.
 */
 void jswrap_ble_setServices(JsVar *data, JsVar *options) {
   if (!(jsvIsObject(data) || jsvIsUndefined(data))) {

--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -2459,24 +2459,20 @@ uint32_t jsble_set_central_rssi_scan(bool enabled) {
 /** Sets security mode for a characteristic configuration */
 void set_security_mode(ble_gap_conn_sec_mode_t *perm, JsVar *configVar) {
   if (jsvGetBoolAndUnLock(jsvObjectGetChild(configVar, "signed", 0))) {
-    perm->sm = 2; // signed
     if (jsvGetBoolAndUnLock(jsvObjectGetChild(configVar, "mitm", 0))) {
-      perm->lv = 2; // signed with mitm
+      BLE_GAP_CONN_SEC_MODE_SET_SIGNED_WITH_MITM(perm);
     } else {
-      perm->lv = 1; // signed without mitm
+      BLE_GAP_CONN_SEC_MODE_SET_SIGNED_NO_MITM(perm);
     }
   } else {
-    perm->sm = 1; // not signed; default
     if (jsvGetBoolAndUnLock(jsvObjectGetChild(configVar, "lesc", 0))) {
-      perm->lv = 4; // lesc
+      BLE_GAP_CONN_SEC_MODE_SET_LESC_ENC_WITH_MITM(perm);
     } else if (jsvGetBoolAndUnLock(jsvObjectGetChild(configVar, "encrypted", 0))) {
       if (jsvGetBoolAndUnLock(jsvObjectGetChild(configVar, "mitm", 0))) {
-        perm->lv = 3; // encrypted with mitm
+        BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(perm);
       } else {
-        perm->lv = 2; // encrypted without mitm
+        BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(perm);
       }
-    } else {
-      perm->lv = 1; // open; default
     }
   }
 }
@@ -2557,19 +2553,22 @@ void jsble_set_services(JsVar *data) {
         jsvUnLock(charDescriptionVar);
 
         memset(&attr_md, 0, sizeof(attr_md));
-
+        // init access with default values
+        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+        // set up access with user configs
         JsVar *securityVar = jsvObjectGetChild(charVar, "security", 0);
-        if (securityVar) {
+        if (securityVar != NULL) {
           JsVar *readVar = jsvObjectGetChild(securityVar, "read", 0);
-          set_security_mode(&attr_md.read_perm, readVar);
-          jsvUnLock(readVar);
-
+          if (readVar != NULL) {
+            set_security_mode(&attr_md.read_perm, readVar);
+            jsvUnLock(readVar);
+          }
           JsVar *writeVar = jsvObjectGetChild(securityVar, "write", 0);
-          set_security_mode(&attr_md.write_perm, writeVar);
-          jsvUnLock(writeVar);
-        } else {
-          BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
-          BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+          if (writeVar != NULL) {
+            set_security_mode(&attr_md.write_perm, writeVar);
+            jsvUnLock(writeVar);
+          }
         }
         jsvUnLock(securityVar);
 


### PR DESCRIPTION
This PR is to add support for configuring security attributes for characteristics. NRF5X devices only as I don't have any ESP device handy (although it is possible to add support for ESP as well).

I've tested this with a BT sniffer, works ok. Once you marked a characteristic rear/write with a security attribute, a secure links gets established automatically when you are trying to read/write for android (I assume for ios as well) and Bluez with generic USB adapters. Bluegiga serial adapter does not establish secure link automatically, a separate pairing procedure has to be run before reading/writing protected characteristics.