### PR TITLE
fix src/jsvar.c:1859:5 warning

### DIFF
--- a/src/jsvar.c
+++ b/src/jsvar.c
@@ -1854,7 +1854,7 @@ bool jsvGetBool(const JsVar *v) {
   if (jsvIsString(v))
     return jsvGetStringLength((JsVar*)v)!=0;
   if (jsvIsPin(v))
-    return jshIsPinValid(jshGetPinFromVar(v));
+    return jshIsPinValid(jshGetPinFromVar((JsVar*)v));
   if (jsvIsFunction(v) || jsvIsArray(v) || jsvIsObject(v) || jsvIsArrayBuffer(v))
     return true;
   if (jsvIsFloat(v)) {


### PR DESCRIPTION
src/jsvar.c:1859:5: warning: passing argument 1 of 'jshGetPinFromVar' discards 'const' qualifier from pointer target type [enabled by default]
     return (bool)jshIsPinValid(jshGetPinFromVar(v));
     ^
In file included from src/jsdevices.h:168:0,
                 from src/jshardware.h:25,
                 from src/jsinteractive.h:18,
                 from src/jsvar.c:18: