### PR TITLE
ESP32 'speed' was wrong

### DIFF
--- a/boards/ESP32.py
+++ b/boards/ESP32.py
@@ -48,7 +48,7 @@ chip = {
   'package' : "",
   'ram'     : 512,
   'flash'   : 0,
-  'speed'   : 160,
+  'speed'   : 240,
   'usart'   : 3,
   'spi'     : 2,
   'i2c'     : 2,


### PR DESCRIPTION
Is this used anywhere in the code or build, or just docs?

The sdkconfig in ESP32's directory says 240:
```
CONFIG_ESP32_DEFAULT_CPU_FREQ_80=
CONFIG_ESP32_DEFAULT_CPU_FREQ_160=
CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ=240
```