### PR TITLE
fail build if initialized data+code does not fit ito bootloader area

### DIFF
--- a/targetlibs/nrf5x_12/nrf5x_linkers/banglejs_dfu.ld
+++ b/targetlibs/nrf5x_12/nrf5x_linkers/banglejs_dfu.ld
@@ -97,3 +97,5 @@ SECTIONS
 } INSERT AFTER .data
 
 INCLUDE "../components/toolchain/gcc/nrf52_common.ld"
+
+ASSERT((__data_end__ - __data_start__) + __etext <= (ORIGIN(FLASH) + LENGTH(FLASH)),"region FLASH overflowed")


### PR DESCRIPTION
Initialized data is stored after code into FLASH  memory and is copied to RAM at startup, so testing only for code size is not enough.
Taken basically from https://stackoverflow.com/questions/23017522/deteaction-of-memory-section-overflow-in-ld