### PR TITLE
ESP32 mishandling of string BLE UUIDs in NRF.setServices()

### DIFF
--- a/libs/bluetooth/bluetooth_utils.c
+++ b/libs/bluetooth/bluetooth_utils.c
@@ -185,9 +185,15 @@ const char *bleVarToUUID(ble_uuid_t *uuid, JsVar *v) {
   }
   return err_code ? "BLE device error adding UUID" : 0;
 #else
-  uuid->uuid = ((data[13]<<8) | data[12]);
-  for(int i = 0; i < 16; i++){
-	uuid->uuid128[i] = data[i];
+  if (expectedLength == 2) {
+    uuid->type = BLE_UUID_TYPE_BLE;
+    uuid->uuid = ((data[1]<<8) | data[0]);
+  } else {
+    uuid->type = BLE_UUID_TYPE_128;
+    uuid->uuid = ((data[13]<<8) | data[12]);
+    for(int i = 0; i < 16; i++){
+      uuid->uuid128[i] = data[i];
+    }
   }
   return 0;
 #endif


### PR DESCRIPTION
Fixes #1723

Note that, in the `BLE_UUID_TYPE_128` branch, the patch preserves this questionable assignment setting the `uuid` field:

```c
uuid->uuid = ((data[13]<<8) | data[12]);
```

With this patch, you can emperically see that 16-byte UUID characteristics are not yet properly honored on the ESP32, with the UUID depending on the 2-byte value assigned above.

My hunch is that, if the BLE characteristic [initialization code](https://github.com/espruino/Espruino/blob/3251c043d6afad2e44f219b6c003ed4555faa4c9/targets/esp32/BLE/esp32_gatts_func.c#L438) on the ESP32 is fixed to address this (so that 16-byte characteristic UUIDs work), then the preserved assignment mentioned above should be removed.

(On the other hand, service UUIDs empirically appear to be [properly initialized](https://github.com/espruino/Espruino/blob/3251c043d6afad2e44f219b6c003ed4555faa4c9/targets/esp32/BLE/esp32_gatts_func.c#L495) on the ESP32 and can handle 16-byte UUIDs.)

