### PR TITLE
fix NRF.restart() on SDK14 and up

### DIFF
--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -2442,7 +2442,11 @@ void jsble_kill() {
 
   uint32_t err_code;
 
+#if NRF_SD_BLE_API_VERSION < 5
   err_code = sd_softdevice_disable();
+#else
+  err_code = nrf_sdh_disable_request();
+#endif
   APP_ERROR_CHECK(err_code);
 }
 


### PR DESCRIPTION
fix for
```
>NRF.restart()
NRF ERROR 0x8 at targets/nrf5x/bluetooth.c:2219
REBOOTING.
```
this is caused by unmatched proper nrf_sdh_disable_request()  call and triggering this 
```
    if (m_nrf_sdh_enabled)
    {
        return NRF_ERROR_INVALID_STATE;
    }
```
in nrf_sdh_enable_request() in targetlibs/nrf5x_14/components/softdevice/common/nrf_sdh.c

This helps me on SDK14 and bluetooth seems to be working after restart.


BTW I tried adding hook to run JS code when softdevice is disabled (to e.g. erase/rewrite UICR to relocate bootloader or write to other protected registers) and it works! I have added quick hack like
```
 jsble_kill();
  jsvUnLock(jspEvaluate("if(typeof(NRF.onRestart)=='function')NRF.onRestart();",true));
  jsble_init();
```
to jsble_restart_softdevice() and can do basically anything there while softdevice is temporarily disabled :-)
