### PR TITLE
allow different board name than board filename

### DIFF
--- a/scripts/build_platform_config.py
+++ b/scripts/build_platform_config.py
@@ -46,6 +46,9 @@ print("BOARD "+boardname)
 board = importlib.import_module(boardname)
 pins = board.get_pins()
 # -----------------------------------------------------------------------------------------
+if "boardname" in board.info:
+  boardname = board.info["boardname"]
+  print("BOARDNAME "+boardname)
 
 LINUX = board.chip["family"]=="LINUX"
 EMSCRIPTEN = board.chip["family"]=="EMSCRIPTEN"


### PR DESCRIPTION
this allows multiple board files for same board with different build options (like e.g. different SDK version or build options)
so now I can have e.g. P8SDK11.py and P8SDK14.py with 
```
info = {
 'name' : "P8 DaFit smartwatch",
 'boardname' : 'P8', # visible in process.env.BOARD
 'default_console' : "EV_BLUETOOTH",
```
and both builds will have proccess.env.BOARD set to P8

BTW the $(BOARD) for makefile is still the board file name since it is build like
```
make -j BOARD=P8SDK14 RELEASE=1
```
but it is OK and expected and does not cause issues.