### PR TITLE
Use Dockerfile layers to cache dependency install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@
 # 2: Run container image so it builds espruino
 #
 #   docker run -e BOARD='PICO_R1_3' --name container_name img_name
+# or
+#   docker run -e BOARD='BANGLEJS' -e DFU_UPDATE_BUILD=1 --name container_name img_name
 #
 # This will run the container and save build results into the container's filesystem.
 # Near the end of the build the filename will be displayed, for example espruino_2v00_pico_1r3.bin 
@@ -22,7 +24,6 @@
 
 FROM python:3
 
-COPY . /espruino
 WORKDIR /espruino
 
 # Workaround add some stuff that the provision script uses
@@ -32,8 +33,15 @@ RUN apt-get install -qq -y python3-pip
 RUN pip install pyserial
 RUN pip install nrfutil
 
+COPY ./scripts /espruino/scripts
+COPY ./targets /espruino/targets
+COPY ./targetlibs /espruino/targetlibs
+COPY ./boards /espruino/boards
+
 # This ensures ALL dependencies are installed beforehand
 RUN bash -c "source scripts/provision.sh ALL"
+
+COPY . /espruino
 
 ENV RELEASE 1
 CMD ["bash", "-c", "source scripts/provision.sh ALL && make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ RUN pip install pyserial
 RUN pip install nrfutil
 
 COPY ./scripts /espruino/scripts
-COPY ./targets /espruino/targets
 COPY ./targetlibs /espruino/targetlibs
 COPY ./boards /espruino/boards
 


### PR DESCRIPTION
Before dependency install (provision.sh ALL), copy only required files.
Only after that, copy rest of the source code (COPY . /espruino) that
changes more often.
This way usually only lines starting from COPY . /espruino will
be executed.