### PR TITLE
Add Graphics.transformVertices

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,7 @@
             Bangle.js: Improve SPI flash speed by with specific function for reading and keeping CS asserted (fix #1849)
             Bangle.js: Ensure BTN3 exits debug mode (fix #1842)
             Bangle.js: Now warn if GPS data overflows (fix #1847)
+            Add Graphics.transformVertices()
 
      2v05 : Add Array.includes
             Fix (Number.toFixed) rounding, eg (1234.505).toFixed(2)

--- a/libs/graphics/jswrap_graphics.h
+++ b/libs/graphics/jswrap_graphics.h
@@ -87,3 +87,4 @@ JsVar *jswrap_graphics_asBMP(JsVar *parent);
 JsVar *jswrap_graphics_asURL(JsVar *parent);
 void jswrap_graphics_dump(JsVar *parent);
 JsVar *jswrap_graphics_quadraticBezier(JsVar *parent, JsVar * arr, JsVar *options);
+JsVar *jswrap_graphics_transformVertices(JsVar *parent, JsVar *verts, JsVar *transformation);


### PR DESCRIPTION
Adds a method to the graphics class for applying a transformation to a
list of vertices. This method can be used alongside drawPoly to translate,
rotate and scale complex polygons in real time.

When I modify my original svg2bangle demo to use this, it stops looking like a slideshow and starts looking like an actual animation :)