### PR TITLE
Make Bangle.showLauncher() use less ram

### DIFF
--- a/libs/js/banglejs/Bangle_showLauncher.js
+++ b/libs/js/banglejs/Bangle_showLauncher.js
@@ -1,7 +1,8 @@
 (function() {
-  var l = require("Storage").list(/\.info$/).map(app=>{
-    try { return require("Storage").readJSON(app); } catch (e) {}
-  }).find(app=>app.type=="launch");
+  var l = require("Storage").list(/\.info$/).map(file => {
+    var app = require("Storage").readJSON(file,1);
+    if (app && app.type == "launch") return app;
+  }).find(x=>x);
   if (l) load(l.src);
   else E.showMessage("Launcher\nnot found");
 })

--- a/libs/js/banglejs/Bangle_showLauncher.min.js
+++ b/libs/js/banglejs/Bangle_showLauncher.min.js
@@ -1,7 +1,1 @@
-(function() {
-  var l = require("Storage").list(/\.info$/).map(app=>{
-    try { return require("Storage").readJSON(app); } catch (e) {}
-  }).find(app=>app.type=="launch");
-  if (l) load(l.src);
-  else E.showMessage("Launcher\nnot found");
-})
+(function(){var b=require("Storage").list(/\.info$/).map(function(a){if((a=require("Storage").readJSON(a,1))&&"launch"==a.type)return a}).find(function(a){return a});b?load(b.src):E.showMessage("Launcher\nnot found")})


### PR DESCRIPTION
I have a lot of apps installed, and I noticed the loading the launcher was failing with `MEMORY` errors even when memory utilization was only at ~65%. This change solves that problem.