### PR TITLE
Fixed 'undefined reference to ESP32_Get_NVS_Status' build error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,6 +501,7 @@ endif
    targets/esp32/jswrap_esp32.c
  INCLUDE += -I$(ROOT)/libs/network/esp32
  SOURCES +=  libs/network/esp32/network_esp32.c \
+  targets/esp32/jshardwareESP32.c \
   targets/esp32/jshardwareI2c.c \
   targets/esp32/jshardwareSpi.c \
   targets/esp32/jshardwareUart.c \


### PR DESCRIPTION
targets/esp32/jshardwareESP32.c is required by every ESP32 build as main.c uses the functions it contains.

https://github.com/espruino/Espruino/blob/c91f7156a9e402bfe1d5b1659b811d8293e562e7/targets/esp32/main.c#L68

Without this change, removing libraries from ESP32.py may result in a build error.


```python
   'libraries' : [
     'ESP32',
     'NET',
     # 'GRAPHICS',
     'CRYPTO','SHA256','SHA512',
     # 'TLS',
     # 'TELNET',
     # 'NEOPIXEL',
     # 'FILESYSTEM',
     'FLASHFS'
     # 'BLUETOOTH'
   ],
```