### PR TITLE
Docs/dump docs clarification

### DIFF
--- a/src/jswrap_interactive.c
+++ b/src/jswrap_interactive.c
@@ -139,6 +139,8 @@ void jswrap_interface_trace(JsVar *root) {
 }
 Output current interpreter state in a text form such that it can be copied to a new device
 
+Espruino keeps its current state in RAM (even if the function code is stored in Flash). When you type `dump()` it dumps the current state of code in RAM plus the hardware state, then if there's code saved in flash it writes "// Code saved with E.setBootCode" and dumps that too.
+
 **Note:** 'Internal' functions are currently not handled correctly. You will need to recreate these in the `onInit` function.
  */
 /*JSON{

--- a/src/jswrap_interactive.c
+++ b/src/jswrap_interactive.c
@@ -139,7 +139,7 @@ void jswrap_interface_trace(JsVar *root) {
 }
 Output current interpreter state in a text form such that it can be copied to a new device
 
-Note: 'Internal' functions are currently not handled correctly. You will need to recreate these in the `onInit` function.
+**Note:** 'Internal' functions are currently not handled correctly. You will need to recreate these in the `onInit` function.
  */
 /*JSON{
   "type" : "function",


### PR DESCRIPTION
The `dump()`-command was discussed [here](http://forum.espruino.com/comments/15531283/), and I suggested to clarify the docs a little.