### PR TITLE
jshFlashRead - restart  read command also if someone pulled CS pin high

### DIFF
--- a/targets/nrf5x/jshardware.c
+++ b/targets/nrf5x/jshardware.c
@@ -2082,10 +2082,13 @@ void jshFlashRead(void * buf, uint32_t addr, uint32_t len) {
     addr &= 0xFFFFFF;
     //jsiConsolePrintf("SPI Read %d %d\n",addr,len);
     if (
-        spiFlashLastAddress==0 || spiFlashLastAddress!=addr
+        spiFlashLastAddress!=addr
 #ifdef SPIFLASH_SHARED_SPI
-        /* with shared SPI someone might interrupt us and pull our CS pin high */
+        /* with shared SPI someone might interrupt us and pull our CS pin high (also jshFlashWrite/Erase does this too) */
         || (nrf_gpio_pin_out_read((uint32_t)pinInfo[SPIFLASH_PIN_CS].pin))
+#else
+        /* our internal state that no read is pending = CS is high */
+        || spiFlashLastAddress==0 
 #endif
        ) {
       nrf_gpio_pin_set((uint32_t)pinInfo[SPIFLASH_PIN_CS].pin);

--- a/targets/nrf5x/jshardware.c
+++ b/targets/nrf5x/jshardware.c
@@ -2081,7 +2081,7 @@ void jshFlashRead(void * buf, uint32_t addr, uint32_t len) {
   if ((addr >= SPIFLASH_BASE) && (addr < (SPIFLASH_BASE+SPIFLASH_LENGTH))) {
     addr &= 0xFFFFFF;
     //jsiConsolePrintf("SPI Read %d %d\n",addr,len);
-    if (spiFlashLastAddress==0 || spiFlashLastAddress!=addr) {
+    if (spiFlashLastAddress==0 || spiFlashLastAddress!=addr || (nrf_gpio_pin_out_read((uint32_t)pinInfo[SPIFLASH_PIN_CS].pin))) {
       nrf_gpio_pin_set((uint32_t)pinInfo[SPIFLASH_PIN_CS].pin);
       unsigned char b[4];
       // Read

--- a/targets/nrf5x/jshardware.c
+++ b/targets/nrf5x/jshardware.c
@@ -2081,7 +2081,13 @@ void jshFlashRead(void * buf, uint32_t addr, uint32_t len) {
   if ((addr >= SPIFLASH_BASE) && (addr < (SPIFLASH_BASE+SPIFLASH_LENGTH))) {
     addr &= 0xFFFFFF;
     //jsiConsolePrintf("SPI Read %d %d\n",addr,len);
-    if (spiFlashLastAddress==0 || spiFlashLastAddress!=addr || (nrf_gpio_pin_out_read((uint32_t)pinInfo[SPIFLASH_PIN_CS].pin))) {
+    if (
+        spiFlashLastAddress==0 || spiFlashLastAddress!=addr
+#ifdef SPIFLASH_SHARED_SPI
+        /* with shared SPI someone might interrupt us and pull our CS pin high */
+        || (nrf_gpio_pin_out_read((uint32_t)pinInfo[SPIFLASH_PIN_CS].pin))
+#endif
+       ) {
       nrf_gpio_pin_set((uint32_t)pinInfo[SPIFLASH_PIN_CS].pin);
       unsigned char b[4];
       // Read


### PR DESCRIPTION
This makes the code a bit more robust - if CS is already high for some reason it should for sure start another read command.

Also it helps another code to work on device with shared SPI pins. With this I can have SPI display driver working on P8 and other DaFit watches like Pinetime and still have storage in SPI flash. In the LCD driver I pull flash CS high before puling LCD CS low and then keep flash CS high when exiting from driver back into javascript. This patch allows espruino to restart and continue executing code from SPI flash.

My driver is in InlineC so setting spiFlashLastAddress to 0 instead would be very tricky but even if it was fully native in libs/graphics it would still be not so nice to access jshardware.c internal variable from other unrelated code.

Maybe with this patch similar code in jshFlash write end erase methods could also just leave CS pin high so the test and setting this variable to zero could be removed from all places. 

EDIT:
If you think using just CS pin is way to go I can update the patch to remove `spiFlashLastAddress = 0;` in jshFlashErase and jshFlashWrite and also the extra test for zero here. then it will really just test the CS pin to know that CS pin is high :-)