### PR TITLE
add check for LD_SRAM_SIZE symbol to nrf52_ble_espruino linker script, define for MICROBIT2 as 128KB

### DIFF
--- a/boards/MICROBIT2.py
+++ b/boards/MICROBIT2.py
@@ -30,7 +30,7 @@ info = {
  'default_console_tx' : "H1",
  'default_console_rx' : "H0",
  'default_console_baudrate' : "9600",
- 'variables' : 2050, # How many variables are allocated for Espruino to use. RAM will be overflowed if this number is too high and code won't compile.
+ 'variables' : 2050+4096, # How many variables are allocated for Espruino to use. RAM will be overflowed if this number is too high and code won't compile.
  'binary_name' : 'espruino_%v_microbit2.hex',
  'build' : {
    'optimizeflags' : '-Os',
@@ -47,7 +47,8 @@ info = {
      'DEFINES += -DMICROBIT', # enable microbit-specific stuff
      'INCLUDE += -I$(ROOT)/libs/microbit',
      'WRAPPERSOURCES += libs/microbit/jswrap_microbit.c',
-     'DEFINES+=-DNEOPIXEL_SCK_PIN=27' # an unused pin
+     'DEFINES+=-DNEOPIXEL_SCK_PIN=27', # an unused pin
+     'LDFLAGS += -Xlinker --defsym=LD_SRAM_SIZE=0x20000' #
    ]
  }
 };

--- a/targetlibs/nrf5x_12/nrf5x_linkers/linker_nrf52_ble_espruino.ld
+++ b/targetlibs/nrf5x_12/nrf5x_linkers/linker_nrf52_ble_espruino.ld
@@ -3,10 +3,13 @@
 SEARCH_DIR(.)
 GROUP(-lgcc -lc -lnosys)
 
+MEM_SRAM_SIZE = DEFINED( LD_SRAM_SIZE ) ? LD_SRAM_SIZE : 0x10000 ;
+MEM_SRAM_SD_OFFSET = 0x2c40; /* memory allocated for SoftDevice */
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x1f000, LENGTH = 0x60000
-  RAM (rwx) :  ORIGIN = 0x20002c40, LENGTH = 0xd3c0
+  RAM (rwx) :  ORIGIN = 0x20000000 + MEM_SRAM_SD_OFFSET, LENGTH = MEM_SRAM_SIZE - MEM_SRAM_SD_OFFSET /*0xd3c0*/
 }
 
 SECTIONS


### PR DESCRIPTION
I was trying if I can push some parameters from board file to linker script and looks like it works. Could be used also for bootloader starting address in future so there can be e.g. same linker script for banglejs and others.

I can only see that resulting hex and binary looks like it has enlarged RAM (top of stack points to 0x20020000) but cannot test it in real device now. Also blindly enlarged variables by 64k/16=4096.

if not defined it goes to 0x20010000 so other devices should be fine as 0x20002c40+0xd3c0 = 0x20010000.

Can you eventually test it on yours? if not then no need to merge it for now.
I'll be getting my microbit v2 soon or maybe can borrow one from someone tomorrow.
