### PR TITLE
Adjust setLCDPower for SAMQ3 always on display - again

### DIFF
--- a/boards/SMAQ3.py
+++ b/boards/SMAQ3.py
@@ -81,7 +81,7 @@ chip = {
   'address' : 0x60000000, # put this in external spiflash (see below)
   'page_size' : 4096,
   'pages' : 2048, # Entire 8MB of external flash
-  'flash_available' : 1024 - ((31 + 8 + 2)*4) # Softdevice uses 31 pages of flash, bootloader 8, FS 2, code 10. Each page is 4 kb.
+  'flash_available' : 1024 - ((38 + 8 + 2)*4) # Softdevice uses 31 pages of flash, bootloader 8, FS 2, code 10. Each page is 4 kb.
   },
 };
 

--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -643,8 +643,8 @@ void lcd_flip(JsVar *parent, bool all) {
     // LCD was turned off, turn it back on
     jswrap_banglejs_setLCDPower(1);
   }
-  flipTimer = 0;
 #endif
+  flipTimer = 0;
 
 #ifdef LCD_CONTROLLER_LPM013M126
   lcdMemLCD_flip(&gfx);

--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -638,11 +638,13 @@ void lcd_flip(JsVar *parent, bool all) {
     gfx.data.modMaxX = LCD_WIDTH-1;
     gfx.data.modMaxY = LCD_HEIGHT-1;
   }
+#ifndef LCD_CONTROLLER_LPM013M126
   if (lcdPowerTimeout && !lcdPowerOn) {
     // LCD was turned off, turn it back on
     jswrap_banglejs_setLCDPower(1);
   }
   flipTimer = 0;
+#endif
 
 #ifdef LCD_CONTROLLER_LPM013M126
   lcdMemLCD_flip(&gfx);
@@ -1261,7 +1263,6 @@ When brightness using `Bange.setLCDBrightness`.
 */
 void jswrap_banglejs_setLCDPower(bool isOn) {
 #ifdef LCD_CONTROLLER_LPM013M126
-  jshPinSetState(LCD_DISP, isOn);
 #endif
 #ifdef LCD_CONTROLLER_ST7789_8BIT
   if (isOn) { // wake
@@ -2771,7 +2772,6 @@ bool jswrap_banglejs_idle() {
 #endif
 #ifdef LCD_CONTROLLER_LPM013M126
   // toggle EXTCOMIN to avoid burn-in
-  if (lcdPowerOn)
     lcdMemLCD_extcomin();
 #endif
 


### PR DESCRIPTION
Some simple changes so that setLCDPower only controls touch and backlight. g.flip() does not turn on display as it is always on and you do not want to turn on the backlight every time a minute hand moves in an always on display. To avoid burn in, the toggle of extcomm_in is not disabled by setLCDPower(0).

The pull also fixes the minor bug in the SMAQ3 board file 31->38.