### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/scripts/intelhex/__main__.py
+++ b/scripts/intelhex/__main__.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2016-2018, Alexander Belchenko
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
+# that the following conditions are met:
+#
+# * Redistributions of source code must retain
+#   the above copyright notice, this list of conditions
+#   and the following disclaimer.
+# * Redistributions in binary form must reproduce
+#   the above copyright notice, this list of conditions
+#   and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the author nor the names
+#   of its contributors may be used to endorse
+#   or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if __name__ == '__main__':
+    print("Welcome to IntelHex Python library.")
+    print()
+    print("The intelhex package has some executable points:")
+    print("  python -m intelhex.test  -- easy way to run unit tests.")
+    print("  python -m intelhex.bench -- run benchmarks.")

--- a/scripts/intelhex/__version__.py
+++ b/scripts/intelhex/__version__.py
@@ -1,0 +1,3 @@
+# IntelHex library version information 
+version_info = (2, 3, 0)
+version_str = '.'.join([str(i) for i in version_info])

--- a/scripts/intelhex/bench.py
+++ b/scripts/intelhex/bench.py
@@ -27,13 +27,12 @@ If resulting value is ``q <= 1.0`` it's the best possible result,
 i.e. time increase proportionally to array size.
 """
 
-from cStringIO import StringIO
 import gc
 import sys
 import time
 
 import intelhex
-
+from intelhex.compat import StringIO, range_g
 
 def median(values):
     """Return median value for the list of values.
@@ -68,7 +67,7 @@ def run_readtest_N_times(func, hexstr, n):
     """
     assert n > 0
     times = []
-    for i in xrange(n):
+    for i in range_g(n):
         sio = StringIO(hexstr)
         times.append(run_test(func, sio))
         sio.close()
@@ -83,7 +82,7 @@ def run_writetest_N_times(func, n):
     """
     assert n > 0
     times = []
-    for i in xrange(n):
+    for i in range_g(n):
         sio = StringIO()
         times.append(run_test(func, sio))
         sio.close()
@@ -115,11 +114,11 @@ def get_test_data(n1, offset, n2):
     # make IntelHex object
     ih = intelhex.IntelHex()
     addr = 0
-    for i in xrange(n1):
+    for i in range_g(n1):
         ih[addr] = addr % 256
         addr += 1
     addr += offset
-    for i in xrange(n2):
+    for i in range_g(n2):
         ih[addr] = addr % 256
         addr += 1
     # make hex file
@@ -130,12 +129,11 @@ def get_test_data(n1, offset, n2):
     #
     return n1+n2, hexstr, ih
 
-def get_base_10K():
-    """Base 10K"""
-    return get_test_data(10000, 0, 0)
+def get_base_50K():
+    return get_test_data(50000, 0, 0)
 
-def get_100K():
-    return get_test_data(100000, 0, 0)
+def get_250K():
+    return get_test_data(250000, 0, 0)
 
 def get_100K_100K():
     return get_test_data(100000, 1000000, 100000)
@@ -152,8 +150,8 @@ class Measure(object):
 
     data_set = [
         # (data name, getter)
-        ('base 10K', get_base_10K),     # first should be base numbers
-        ('100K', get_100K),
+        ('base 50K', get_base_50K),     # first should be base numbers
+        ('250K', get_250K),
         ('1M', get_1M),
         ('100K+100K', get_100K_100K),
         ('0+100K', get_0_100K),

--- a/scripts/intelhex/getsizeof.py
+++ b/scripts/intelhex/getsizeof.py
@@ -1,0 +1,64 @@
+# Recursive version sys.getsizeof(). Extendable with custom handlers.
+# Code from http://code.activestate.com/recipes/577504/
+# Created by Raymond Hettinger on Fri, 17 Dec 2010 (MIT)
+
+import sys
+from itertools import chain
+from collections import deque
+try:
+    from reprlib import repr
+except ImportError:
+    pass
+
+def total_size(o, handlers={}, verbose=False):
+    """ Returns the approximate memory footprint an object and all of its contents.
+
+    Automatically finds the contents of the following builtin containers and
+    their subclasses:  tuple, list, deque, dict, set and frozenset.
+    To search other containers, add handlers to iterate over their contents:
+
+        handlers = {SomeContainerClass: iter,
+                    OtherContainerClass: OtherContainerClass.get_elements}
+
+    """
+    dict_handler = lambda d: chain.from_iterable(d.items())
+    all_handlers = {tuple: iter,
+                    list: iter,
+                    deque: iter,
+                    dict: dict_handler,
+                    set: iter,
+                    frozenset: iter,
+                   }
+    all_handlers.update(handlers)     # user handlers take precedence
+    seen = set()                      # track which object id's have already been seen
+    default_size = sys.getsizeof(0)       # estimate sizeof object without __sizeof__
+
+    def sizeof(o):
+        if id(o) in seen:       # do not double count the same object
+            return 0
+        seen.add(id(o))
+        s = sys.getsizeof(o, default_size)
+
+        if verbose:
+            print(s, type(o), repr(o))#, file=stderr)
+
+        for typ, handler in all_handlers.items():
+            if isinstance(o, typ):
+                s += sum(map(sizeof, handler(o)))
+                break
+        return s
+
+    return sizeof(o)
+
+
+##### Example call #####
+
+if __name__ == '__main__':
+    #d = dict(a=1, b=2, c=3, d=[4,5,6,7], e='a string of chars')
+    print("dict 3 elements")
+    d = {0:0xFF, 1:0xEE, 2:0xCC}
+    print(total_size(d, verbose=True))
+
+    #print("array 3 elements")
+    #import array
+    #print(total_size(array.array('B', b'\x01\x02\x03')))

--- a/scripts/intelhex/test.py
+++ b/scripts/intelhex/test.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-# Copyright (c) 2005-2015, Alexander Belchenko
+# Copyright (c) 2005-2018, Alexander Belchenko
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms,
@@ -33,7 +31,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Test suite for IntelHex class."""
+"""Test suite for IntelHex library."""
 
 import array
 import os
@@ -70,13 +68,14 @@ from intelhex.compat import (
     BytesIO,
     StringIO,
     UnicodeType,
+    array_tobytes,
     asbytes,
     asstr,
     dict_items_g,
     range_g,
     range_l,
     )
-
+from intelhex.__version__ import version_str
 
 __docformat__ = 'restructuredtext'
 
@@ -415,7 +414,7 @@ class TestIntelHexBase(unittest.TestCase):
                 )
 
     def assertEqualWrittenData(self, a, b):
-        return self.assertEquals(a, b, """Written data is incorrect
+        return self.assertEqual(a, b, """Written data is incorrect
 Should be:
 %s
 
@@ -495,7 +494,7 @@ class TestIntelHex(TestIntelHexBase):
     def test_tobinstr(self):
         ih = IntelHex(self.f)
         s1 = ih.tobinstr()
-        s2 = asbytes(bin8.tostring())
+        s2 = array_tobytes(bin8)
         self.assertEqual(s2, s1, "data not equal\n%s\n\n%s" % (s1, s2))
 
     def test_tobinfile(self):
@@ -504,14 +503,14 @@ class TestIntelHex(TestIntelHexBase):
         ih.tobinfile(sio)
         s1 = sio.getvalue()
         sio.close()
-        s2 = asbytes(bin8.tostring())
+        s2 = array_tobytes(bin8)
         self.assertEqual(s2, s1, "data not equal\n%s\n\n%s" % (s1, s2))
         # new API: .tofile universal method
         sio = BytesIO()
         ih.tofile(sio, format='bin')
         s1 = sio.getvalue()
         sio.close()
-        s2 = asbytes(bin8.tostring())
+        s2 = array_tobytes(bin8)
         self.assertEqual(s2, s1, "data not equal\n%s\n\n%s" % (s1, s2))
 
     def test_tobinfile_realfile(self):
@@ -521,6 +520,14 @@ class TestIntelHex(TestIntelHexBase):
             ih.tobinfile(tf)
         finally:
             tf.close()
+
+    def test__get_eol_textfile(self):
+        self.assertEqual('\n', IntelHex._get_eol_textfile('native', 'win32'))
+        self.assertEqual('\n', IntelHex._get_eol_textfile('native', 'linux'))
+        self.assertEqual('\n', IntelHex._get_eol_textfile('CRLF', 'win32'))
+        self.assertEqual('\r\n', IntelHex._get_eol_textfile('CRLF', 'linux'))
+        self.assertRaisesMsg(ValueError, "wrong eolstyle 'LF'",
+            IntelHex._get_eol_textfile, 'LF', 'win32')
 
     def test_write_empty_hexfile(self):
         ih = intelhex.IntelHex()
@@ -573,61 +580,61 @@ class TestIntelHex(TestIntelHexBase):
 
     def test_todict(self):
         ih = IntelHex()
-        self.assertEquals({}, ih.todict())
+        self.assertEqual({}, ih.todict())
         ih = IntelHex(StringIO(hex64k))
-        self.assertEquals(data64k, ih.todict())
+        self.assertEqual(data64k, ih.todict())
         ih = IntelHex()
         ih[1] = 2
         ih.start_addr = {'EIP': 1234}
-        self.assertEquals({1: 2, 'start_addr': {'EIP': 1234}}, ih.todict())
+        self.assertEqual({1: 2, 'start_addr': {'EIP': 1234}}, ih.todict())
 
     def test_fromdict(self):
         ih = IntelHex()
         ih.fromdict({1:2, 3:4})
-        self.assertEquals({1:2, 3:4}, ih.todict())
+        self.assertEqual({1:2, 3:4}, ih.todict())
         ih.fromdict({1:5, 6:7})
-        self.assertEquals({1:5, 3:4, 6:7}, ih.todict())
+        self.assertEqual({1:5, 3:4, 6:7}, ih.todict())
         ih = IntelHex()
         ih.fromdict({1: 2, 'start_addr': {'EIP': 1234}})
-        self.assertEquals({1: 2, 'start_addr': {'EIP': 1234}}, ih.todict())
+        self.assertEqual({1: 2, 'start_addr': {'EIP': 1234}}, ih.todict())
         # bad dict
         self.assertRaises(ValueError, ih.fromdict, {'EIP': 1234})
         self.assertRaises(ValueError, ih.fromdict, {-1: 1234})
 
     def test_init_from_obj(self):
         ih = IntelHex({1:2, 3:4})
-        self.assertEquals({1:2, 3:4}, ih.todict())
+        self.assertEqual({1:2, 3:4}, ih.todict())
         ih.start_addr = {'EIP': 1234}
         ih2 = IntelHex(ih)
         ih[1] = 5
         ih.start_addr = {'EIP': 5678}
-        self.assertEquals({1:2, 3:4, 'start_addr': {'EIP': 1234}}, ih2.todict())
+        self.assertEqual({1:2, 3:4, 'start_addr': {'EIP': 1234}}, ih2.todict())
         self.assertNotEqual(id(ih), id(ih2))
 
     def test_dict_interface(self):
         ih = IntelHex()
-        self.assertEquals(0xFF, ih[0])  # padding byte substitution
+        self.assertEqual(0xFF, ih[0])  # padding byte substitution
         ih[0] = 1
-        self.assertEquals(1, ih[0])
+        self.assertEqual(1, ih[0])
         del ih[0]
-        self.assertEquals({}, ih.todict())  # padding byte substitution
+        self.assertEqual({}, ih.todict())  # padding byte substitution
 
     def test_len(self):
         ih = IntelHex()
-        self.assertEquals(0, len(ih))
+        self.assertEqual(0, len(ih))
         ih[2] = 1
-        self.assertEquals(1, len(ih))
+        self.assertEqual(1, len(ih))
         ih[1000] = 2
-        self.assertEquals(2, len(ih))
+        self.assertEqual(2, len(ih))
 
     def test__getitem__(self):
         ih = IntelHex()
         # simple cases
-        self.assertEquals(0xFF, ih[0])
+        self.assertEqual(0xFF, ih[0])
         ih[0] = 1
-        self.assertEquals(1, ih[0])
+        self.assertEqual(1, ih[0])
         # big address
-        self.assertEquals(0xFF, ih[2**32-1])
+        self.assertEqual(0xFF, ih[2**32-1])
         # wrong addr type/value for indexing operations
         def getitem(index):
             return ih[index]
@@ -646,20 +653,20 @@ class TestIntelHex(TestIntelHexBase):
         # full copy via slicing
         ih2 = ih[:]
         self.assertTrue(isinstance(ih2, IntelHex))
-        self.assertEquals({0:1, 1:2, 2:3, 10:4}, ih2.todict())
+        self.assertEqual({0:1, 1:2, 2:3, 10:4}, ih2.todict())
         # other slice operations
-        self.assertEquals({}, ih[3:8].todict())
-        self.assertEquals({0:1, 1:2}, ih[0:2].todict())
-        self.assertEquals({0:1, 1:2}, ih[:2].todict())
-        self.assertEquals({2:3, 10:4}, ih[2:].todict())
-        self.assertEquals({0:1, 2:3, 10:4}, ih[::2].todict())
-        self.assertEquals({10:4}, ih[3:11].todict())
+        self.assertEqual({}, ih[3:8].todict())
+        self.assertEqual({0:1, 1:2}, ih[0:2].todict())
+        self.assertEqual({0:1, 1:2}, ih[:2].todict())
+        self.assertEqual({2:3, 10:4}, ih[2:].todict())
+        self.assertEqual({0:1, 2:3, 10:4}, ih[::2].todict())
+        self.assertEqual({10:4}, ih[3:11].todict())
 
     def test__setitem__(self):
         ih = IntelHex()
         # simple indexing operation
         ih[0] = 1
-        self.assertEquals({0:1}, ih.todict())
+        self.assertEqual({0:1}, ih.todict())
         # errors
         def setitem(a,b):
             ih[a] = b
@@ -671,15 +678,15 @@ class TestIntelHex(TestIntelHexBase):
             setitem, 'foo', 0)
         # slice operations
         ih[0:4] = range_l(4)
-        self.assertEquals({0:0, 1:1, 2:2, 3:3}, ih.todict())
+        self.assertEqual({0:0, 1:1, 2:2, 3:3}, ih.todict())
         ih[0:] = range_l(5,9)
-        self.assertEquals({0:5, 1:6, 2:7, 3:8}, ih.todict())
+        self.assertEqual({0:5, 1:6, 2:7, 3:8}, ih.todict())
         ih[:4] = range_l(9,13)
-        self.assertEquals({0:9, 1:10, 2:11, 3:12}, ih.todict())
+        self.assertEqual({0:9, 1:10, 2:11, 3:12}, ih.todict())
         # with step
         ih = IntelHex()
         ih[0:8:2] = range_l(4)
-        self.assertEquals({0:0, 2:1, 4:2, 6:3}, ih.todict())
+        self.assertEqual({0:0, 2:1, 4:2, 6:3}, ih.todict())
         # errors in slice operations
         # ih[1:2] = 'a'
         self.assertRaisesMsg(ValueError,
@@ -706,7 +713,7 @@ class TestIntelHex(TestIntelHexBase):
         ih = IntelHex()
         ih[0] = 1
         del ih[0]
-        self.assertEquals({}, ih.todict())
+        self.assertEqual({}, ih.todict())
         # errors
         def delitem(addr):
             del ih[addr]
@@ -727,25 +734,25 @@ class TestIntelHex(TestIntelHexBase):
             return ih
         ih = ihex(8)
         del ih[:]       # delete all data
-        self.assertEquals({}, ih.todict())
+        self.assertEqual({}, ih.todict())
         ih = ihex(8)
         del ih[2:6]
-        self.assertEquals({0:0, 1:1, 6:6, 7:7}, ih.todict())
+        self.assertEqual({0:0, 1:1, 6:6, 7:7}, ih.todict())
         ih = ihex(8)
         del ih[::2]
-        self.assertEquals({1:1, 3:3, 5:5, 7:7}, ih.todict())
+        self.assertEqual({1:1, 3:3, 5:5, 7:7}, ih.todict())
 
     def test_addresses(self):
         # empty object
         ih = IntelHex()
-        self.assertEquals([], ih.addresses())
-        self.assertEquals(None, ih.minaddr())
-        self.assertEquals(None, ih.maxaddr())
+        self.assertEqual([], ih.addresses())
+        self.assertEqual(None, ih.minaddr())
+        self.assertEqual(None, ih.maxaddr())
         # normal object
         ih = IntelHex({1:2, 7:8, 10:0})
-        self.assertEquals([1,7,10], ih.addresses())
-        self.assertEquals(1, ih.minaddr())
-        self.assertEquals(10, ih.maxaddr())
+        self.assertEqual([1,7,10], ih.addresses())
+        self.assertEqual(1, ih.minaddr())
+        self.assertEqual(10, ih.maxaddr())
 
     def test__get_start_end(self):
         # test for private method _get_start_end
@@ -753,15 +760,63 @@ class TestIntelHex(TestIntelHexBase):
         ih = IntelHex()
         self.assertRaises(intelhex.EmptyIntelHexError, ih._get_start_end)
         self.assertRaises(intelhex.EmptyIntelHexError, ih._get_start_end, size=10)
-        self.assertEquals((0,9), ih._get_start_end(start=0, size=10))
-        self.assertEquals((1,10), ih._get_start_end(end=10, size=10))
+        self.assertEqual((0,9), ih._get_start_end(start=0, size=10))
+        self.assertEqual((1,10), ih._get_start_end(end=10, size=10))
         # normal object
         ih = IntelHex({1:2, 7:8, 10:0})
-        self.assertEquals((1,10), ih._get_start_end())
-        self.assertEquals((1,10), ih._get_start_end(size=10))        
-        self.assertEquals((0,9), ih._get_start_end(start=0, size=10))
-        self.assertEquals((1,10), ih._get_start_end(end=10, size=10))
+        self.assertEqual((1,10), ih._get_start_end())
+        self.assertEqual((1,10), ih._get_start_end(size=10))        
+        self.assertEqual((0,9), ih._get_start_end(start=0, size=10))
+        self.assertEqual((1,10), ih._get_start_end(end=10, size=10))
 
+    def test_segments(self):
+        # test that address segments are correctly summarized
+        ih = IntelHex()
+        sg = ih.segments()
+        self.assertTrue(isinstance(sg, list))
+        self.assertEqual(len(sg), 0)
+        ih[0x100] = 0
+        sg = ih.segments()
+        self.assertTrue(isinstance(sg, list))
+        self.assertEqual(len(sg), 1)
+        self.assertTrue(isinstance(sg[0], tuple))
+        self.assertTrue(len(sg[0]) == 2)
+        self.assertTrue(sg[0][0] < sg[0][1])
+        self.assertEqual(min(sg[0]), 0x100)
+        self.assertEqual(max(sg[0]), 0x101)
+        ih[0x101] = 1
+        sg = ih.segments()
+        self.assertTrue(isinstance(sg, list))
+        self.assertEqual(len(sg), 1)
+        self.assertTrue(isinstance(sg[0], tuple))
+        self.assertTrue(len(sg[0]) == 2)
+        self.assertTrue(sg[0][0] < sg[0][1])
+        self.assertEqual(min(sg[0]), 0x100)
+        self.assertEqual(max(sg[0]), 0x102)
+        ih[0x200] = 2
+        ih[0x201] = 3
+        ih[0x202] = 4
+        sg = ih.segments()
+        self.assertTrue(isinstance(sg, list))
+        self.assertEqual(len(sg), 2)
+        self.assertTrue(isinstance(sg[0], tuple))
+        self.assertTrue(len(sg[0]) == 2)
+        self.assertTrue(sg[0][0] < sg[0][1])
+        self.assertTrue(isinstance(sg[1], tuple))
+        self.assertTrue(len(sg[1]) == 2)
+        self.assertTrue(sg[1][0] < sg[1][1])
+        self.assertEqual(min(sg[0]), 0x100)
+        self.assertEqual(max(sg[0]), 0x102)
+        self.assertEqual(min(sg[1]), 0x200)
+        self.assertEqual(max(sg[1]), 0x203)
+        ih[0x204] = 5
+        sg = ih.segments()
+        self.assertEqual(len(sg), 3)
+        sg = ih.segments(min_gap=2)
+        self.assertEqual(len(sg), 2)
+        self.assertEqual(min(sg[1]), 0x200)
+        self.assertEqual(max(sg[1]), 0x205)
+        pass
 
 class TestIntelHexLoadBin(TestIntelHexBase):
 
@@ -871,7 +926,7 @@ class TestIntelHex_big_files(TestIntelHexBase):
         ih = intelhex.IntelHex(self.f)
         for addr, byte in dict_items_g(data64k):
             readed = ih[addr]
-            self.assertEquals(byte, readed,
+            self.assertEqual(byte, readed,
                               "data not equal at addr %X "
                               "(%X != %X)" % (addr, byte, readed))
 
@@ -892,29 +947,73 @@ class TestIntelHexGetPutString(TestIntelHexBase):
             self.ih[i] = i
 
     def test_gets(self):
-        self.assertEquals('\x00\x01\x02\x03\x04\x05\x06\x07', self.ih.gets(0, 8))
-        self.assertEquals('\x07\x08\x09', self.ih.gets(7, 3))
+        self.assertEqual(asbytes('\x00\x01\x02\x03\x04\x05\x06\x07'), self.ih.gets(0, 8))
+        self.assertEqual(asbytes('\x07\x08\x09'), self.ih.gets(7, 3))
         self.assertRaisesMsg(intelhex.NotEnoughDataError,
             'Bad access at 0x1: '
             'not enough data to read 10 contiguous bytes',
             self.ih.gets, 1, 10)
 
     def test_puts(self):
-        self.ih.puts(0x03, 'hello')
-        self.assertEquals('\x00\x01\x02hello\x08\x09', self.ih.gets(0, 10))
+        self.ih.puts(0x03, asbytes('hello'))
+        self.assertEqual(asbytes('\x00\x01\x02hello\x08\x09'), self.ih.gets(0, 10))
 
     def test_getsz(self):
-        self.assertEquals('', self.ih.getsz(0))
+        self.assertEqual(asbytes(''), self.ih.getsz(0))
         self.assertRaisesMsg(intelhex.NotEnoughDataError,
             'Bad access at 0x1: '
             'not enough data to read zero-terminated string',
             self.ih.getsz, 1)
         self.ih[4] = 0
-        self.assertEquals('\x01\x02\x03', self.ih.getsz(1))
+        self.assertEqual(asbytes('\x01\x02\x03'), self.ih.getsz(1))
 
     def test_putsz(self):
-        self.ih.putsz(0x03, 'hello')
-        self.assertEquals('\x00\x01\x02hello\x00\x09', self.ih.gets(0, 10))
+        self.ih.putsz(0x03, asbytes('hello'))
+        self.assertEqual(asbytes('\x00\x01\x02hello\x00\x09'), self.ih.gets(0, 10))
+
+    def test_find(self):
+        self.assertEqual(0, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06')))
+        self.assertEqual(0, self.ih.find(asbytes('\x00')))
+        self.assertEqual(3, self.ih.find(asbytes('\x03\x04\x05\x06')))
+        self.assertEqual(3, self.ih.find(asbytes('\x03')))
+        self.assertEqual(7, self.ih.find(asbytes('\x07\x08\x09')))
+        self.assertEqual(7, self.ih.find(asbytes('\x07')))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a')))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01')))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07')))
+
+    def test_find_start(self):
+        self.assertEqual(-1, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x00'), start=3))
+        self.assertEqual(3, self.ih.find(asbytes('\x03\x04\x05\x06'), start=3))
+        self.assertEqual(3, self.ih.find(asbytes('\x03'), start=3))
+        self.assertEqual(7, self.ih.find(asbytes('\x07\x08\x09'), start=3))
+        self.assertEqual(7, self.ih.find(asbytes('\x07'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07'), start=3))
+
+    def test_find_end(self):
+        self.assertEqual(-1, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06'), end=4))
+        self.assertEqual(0, self.ih.find(asbytes('\x00'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x03\x04\x05\x06'), end=4))
+        self.assertEqual(3, self.ih.find(asbytes('\x03'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07\x08\x09'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07'), end=4))
+
+    def test_find_start_end(self):
+        self.assertEqual(-1, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x00'), start=3, end=7))
+        self.assertEqual(3, self.ih.find(asbytes('\x03\x04\x05\x06'), start=3, end=7))
+        self.assertEqual(3, self.ih.find(asbytes('\x03'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07\x08\x09'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07'), start=3, end=7))
 
 
 class TestIntelHexDump(TestIntelHexBase):
@@ -923,7 +1022,7 @@ class TestIntelHexDump(TestIntelHexBase):
         ih = IntelHex()
         sio = StringIO()
         ih.dump(sio)
-        self.assertEquals('', sio.getvalue())
+        self.assertEqual('', sio.getvalue())
 
     def test_simple(self):
         ih = IntelHex()
@@ -931,14 +1030,14 @@ class TestIntelHexDump(TestIntelHexBase):
         ih[1] = 0x34
         sio = StringIO()
         ih.dump(sio)
-        self.assertEquals(
+        self.assertEqual(
             '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n',
             sio.getvalue())
         ih[16] = 0x56
         ih[30] = 0x98
         sio = StringIO()
         ih.dump(sio)
-        self.assertEquals(
+        self.assertEqual(
             '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n'
             '0010  56 -- -- -- -- -- -- -- -- -- -- -- -- -- 98 --  |V             . |\n',
             sio.getvalue())
@@ -949,7 +1048,7 @@ class TestIntelHexDump(TestIntelHexBase):
         ih[30] = 0x98
         sio = StringIO()
         ih.dump(sio)
-        self.assertEquals(
+        self.assertEqual(
             '0010  56 -- -- -- -- -- -- -- -- -- -- -- -- -- 98 --  |V             . |\n',
             sio.getvalue())
 
@@ -960,16 +1059,71 @@ class TestIntelHexDump(TestIntelHexBase):
         ih.start_addr = {'CS': 0x1234, 'IP': 0x5678}
         sio = StringIO()
         ih.dump(sio)
-        self.assertEquals(
+        self.assertEqual(
             'CS = 0x1234, IP = 0x5678\n'
             '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n',
             sio.getvalue())
         ih.start_addr = {'EIP': 0x12345678}
         sio = StringIO()
         ih.dump(sio)
-        self.assertEquals(
+        self.assertEqual(
             'EIP = 0x12345678\n'
             '0000  12 34 -- -- -- -- -- -- -- -- -- -- -- -- -- --  |.4              |\n',
+            sio.getvalue())
+
+    def test_bad_width(self):
+        ih = IntelHex()
+        sio = StringIO()
+        badwidths = [0, -1, -10.5, 2.5]
+        for bw in badwidths:
+            self.assertRaisesMsg(ValueError, "width must be a positive integer.",
+                ih.dump, sio, bw)
+        badwidthtypes = ['', {}, [], sio]
+        for bwt in badwidthtypes:
+            self.assertRaisesMsg(ValueError, "width must be a positive integer.",
+                ih.dump, sio, bwt)
+
+    def test_simple_width3(self):
+        ih = IntelHex()
+        ih[0] = 0x12
+        ih[1] = 0x34
+        sio = StringIO()
+        ih.dump(tofile=sio, width=3)
+        self.assertEqual(
+            '0000  12 34 --  |.4 |\n',
+            sio.getvalue())
+            
+        ih[16] = 0x56
+        ih[30] = 0x98
+        sio = StringIO()
+        ih.dump(tofile=sio, width=3)
+        self.assertEqual(
+            '0000  12 34 --  |.4 |\n'
+            '0003  -- -- --  |   |\n'
+            '0006  -- -- --  |   |\n'
+            '0009  -- -- --  |   |\n'
+            '000C  -- -- --  |   |\n'
+            '000F  -- 56 --  | V |\n'
+            '0012  -- -- --  |   |\n'
+            '0015  -- -- --  |   |\n'
+            '0018  -- -- --  |   |\n'
+            '001B  -- -- --  |   |\n'
+            '001E  98 -- --  |.  |\n',
+            sio.getvalue())
+
+    def test_minaddr_not_zero_width3_padding(self):
+        ih = IntelHex()
+        ih[17] = 0x56
+        ih[30] = 0x98
+        sio = StringIO()
+        ih.dump(tofile=sio, width=3, withpadding=True)
+        self.assertEqual(
+            '000F  FF FF 56  |..V|\n'
+            '0012  FF FF FF  |...|\n'
+            '0015  FF FF FF  |...|\n'
+            '0018  FF FF FF  |...|\n'
+            '001B  FF FF FF  |...|\n'
+            '001E  98 FF FF  |...|\n',
             sio.getvalue())
 
 
@@ -979,13 +1133,13 @@ class TestIntelHexMerge(TestIntelHexBase):
         ih1 = IntelHex()
         ih2 = IntelHex()
         ih1.merge(ih2)
-        self.assertEquals({}, ih1.todict())
+        self.assertEqual({}, ih1.todict())
 
     def test_merge_simple(self):
         ih1 = IntelHex({0:1, 1:2, 2:3})
         ih2 = IntelHex({3:4, 4:5, 5:6})
         ih1.merge(ih2)
-        self.assertEquals({0:1, 1:2, 2:3, 3:4, 4:5, 5:6}, ih1.todict())
+        self.assertEqual({0:1, 1:2, 2:3, 3:4, 4:5, 5:6}, ih1.todict())
 
     def test_merge_wrong_args(self):
         ih1 = IntelHex()
@@ -1009,29 +1163,29 @@ class TestIntelHexMerge(TestIntelHexBase):
         ih1 = IntelHex({0:1})
         ih2 = IntelHex({0:2})
         ih1.merge(ih2, overlap='ignore')
-        self.assertEquals({0:1}, ih1.todict())
+        self.assertEqual({0:1}, ih1.todict())
         # replace
         ih1 = IntelHex({0:1})
         ih2 = IntelHex({0:2})
         ih1.merge(ih2, overlap='replace')
-        self.assertEquals({0:2}, ih1.todict())
+        self.assertEqual({0:2}, ih1.todict())
 
     def test_merge_start_addr(self):
         # this, None
         ih1 = IntelHex({'start_addr': {'EIP': 0x12345678}})
         ih2 = IntelHex()
         ih1.merge(ih2)
-        self.assertEquals({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
+        self.assertEqual({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
         # None, other
         ih1 = IntelHex()
         ih2 = IntelHex({'start_addr': {'EIP': 0x12345678}})
         ih1.merge(ih2)
-        self.assertEquals({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
+        self.assertEqual({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
         # this == other: no conflict
         ih1 = IntelHex({'start_addr': {'EIP': 0x12345678}})
         ih2 = IntelHex({'start_addr': {'EIP': 0x12345678}})
         ih1.merge(ih2)
-        self.assertEquals({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
+        self.assertEqual({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
         # this != other: conflict
         ## overlap=error
         ih1 = IntelHex({'start_addr': {'EIP': 0x12345678}})
@@ -1043,12 +1197,12 @@ class TestIntelHexMerge(TestIntelHexBase):
         ih1 = IntelHex({'start_addr': {'EIP': 0x12345678}})
         ih2 = IntelHex({'start_addr': {'EIP': 0x87654321}})
         ih1.merge(ih2, overlap='ignore')
-        self.assertEquals({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
+        self.assertEqual({'start_addr': {'EIP': 0x12345678}}, ih1.todict())
         ## overlap=replace
         ih1 = IntelHex({'start_addr': {'EIP': 0x12345678}})
         ih2 = IntelHex({'start_addr': {'EIP': 0x87654321}})
         ih1.merge(ih2, overlap='replace')
-        self.assertEquals({'start_addr': {'EIP': 0x87654321}}, ih1.todict())
+        self.assertEqual({'start_addr': {'EIP': 0x87654321}}, ih1.todict())
 
 
 class TestIntelHex16bit(TestIntelHexBase):
@@ -1428,7 +1582,7 @@ class TestDiffDumps(unittest.TestCase):
             "+0010  -- -- -- -- 32 -- -- -- -- -- -- -- -- -- -- --  |    2           |\n"
             " 0020  -- -- -- -- -- -- -- -- 33 -- -- -- -- -- -- --  |        3       |\n"
             ) % dict(extra=extra)
-        self.assertEquals(shouldbe, result)
+        self.assertEqual(shouldbe, result)
 
 
 class TestBuildRecords(TestIntelHexBase):
@@ -1504,7 +1658,7 @@ class TestXrangeLongInt(unittest.TestCase):
     def test_xrange_longint(self):
         # Bug #1408934: xrange(longint) blows with OverflowError:
         if compat.Python == 2:
-            self.assertRaises(OverflowError, xrange, 2684625744, 2684625747)
+            self.assertRaises(OverflowError, xrange, sys.maxint, sys.maxint+3)
         #
         upr = compat.range_g(2684625744, 2684625747)
         self.assertEqual([2684625744, 2684625745, 2684625746], list(upr))
@@ -1535,7 +1689,7 @@ class TestInSubprocess(unittest.TestCase):
     def versionChecker(self, cmdline_template):
         cmdline = cmdline_template % sys.executable
         retcode, output = self.runProcessAndGetAsciiStdoutOrStderr(cmdline)
-        self.assertEqual(intelhex.__version__, output.rstrip())
+        self.assertEqual(version_str, output.rstrip())
         self.assertEqual(0, retcode)
 
     def test_setup_version(self):
@@ -1555,6 +1709,89 @@ class TestInSubprocess(unittest.TestCase):
 
     def test_sripts_hexmerge_version(self):
         self.versionChecker('%s scripts/hexmerge.py --version')
+
+
+class TestWriteHexFileByteCount(unittest.TestCase):
+
+    def setUp(self):
+        self.f = StringIO(hex8)
+
+    def tearDown(self):
+        self.f.close()
+        del self.f
+
+    def test_write_hex_file_bad_byte_count(self):
+        ih = intelhex.IntelHex(self.f)
+        sio = StringIO()
+        self.assertRaises(ValueError, ih.write_hex_file, sio, byte_count=0)
+        self.assertRaises(ValueError, ih.write_hex_file, sio, byte_count=-1)
+        self.assertRaises(ValueError, ih.write_hex_file, sio, byte_count=256)
+
+    def test_write_hex_file_byte_count_1(self):
+        ih = intelhex.IntelHex(self.f)
+        ih1 = ih[:4]
+        sio = StringIO()
+        ih1.write_hex_file(sio, byte_count=1)
+        s = sio.getvalue()
+        sio.close()
+        # check that we have all data records with data length == 1
+        self.assertEqual((
+            ':0100000002FD\n'
+            ':0100010005F9\n'
+            ':01000200A25B\n'
+            ':01000300E517\n'
+            ':00000001FF\n'
+            ), s,
+            "Written hex is not in byte count 1")
+        # read back and check content
+        fin = StringIO(s)
+        ih2 = intelhex.IntelHex(fin)
+        self.assertEqual(ih1.tobinstr(), ih2.tobinstr(),
+                         "Written hex file does not equal with original")
+
+    def test_write_hex_file_byte_count_13(self):
+        ih = intelhex.IntelHex(self.f)
+        sio = StringIO()
+        ih.write_hex_file(sio, byte_count=13)
+        s = sio.getvalue()
+        # control written hex first line to check that byte count is 13
+        sio.seek(0)
+        self.assertEqual(sio.readline(), 
+            ':0D0000000205A2E576246AF8E6057622786E\n',
+            "Written hex is not in byte count 13")
+        sio.close()
+
+        fin = StringIO(s)
+        ih2 = intelhex.IntelHex(fin)
+
+        self.assertEqual(ih.tobinstr(), ih2.tobinstr(),
+                         "Written hex file does not equal with original")
+
+    def test_write_hex_file_byte_count_255(self):
+        ih = intelhex.IntelHex(self.f)
+        sio = StringIO()
+        ih.write_hex_file(sio, byte_count=255)
+        s = sio.getvalue()
+        # control written hex first line to check that byte count is 255
+        sio.seek(0)
+        self.assertEqual(sio.readline(), 
+            (':FF0000000205A2E576246AF8E60576227867300702786AE475F0011204AD02'
+              '04552000EB7F2ED2008018EF540F2490D43440D4FF30040BEF24BFB41A0050'
+              '032461FFE57760021577057AE57A7002057930070D7867E475F0011204ADEF'
+              '02049B02057B7403D2078003E4C207F5768B678A688969E4F577F579F57AE5'
+              '7760077F2012003E80F57578FFC201C200C202C203C205C206C20812000CFF'
+              '700D3007057F0012004FAF7AAE7922B4255FC2D5C20412000CFF24D0B40A00'
+              '501A75F00A787730D50508B6FF0106C6A426F620D5047002D20380D924CFB4'
+              '1A00EF5004C2E5D20402024FD20180C6D20080C0D20280BCD2D580BAD20580'
+              'B47F2012003E20020774010E\n'),
+            "Written hex is not in byte count 255")
+        sio.close()
+
+        fin = StringIO(s)
+        ih2 = intelhex.IntelHex(fin)
+
+        self.assertEqual(ih.tobinstr(), ih2.tobinstr(),
+                         "Written hex file does not equal with original")
 
 ##
 # MAIN


### PR DESCRIPTION
When trying to build a project, after calling `python scripts/hexmerge.py ...` an error like this appeared:

```bash
File ".../Espruino/scripts/intelhex/__init__.py", line 593, in write_hex_file
asstr(hexlify(bin.tostring()).translate(table)) +
AttributeError: 'array.array' object has no attribute 'tostring'
```
I just updated `intelhex` to version `2.3.0`, they already fixed that
https://github.com/python-intelhex/intelhex/commit/4125dce5b174401d38cc0fcf9d2e1aad07997f5e