### PR TITLE
Exit if Ctrl+D on empty input line

### DIFF
--- a/src/jsdevices.c
+++ b/src/jsdevices.c
@@ -411,10 +411,16 @@ static bool jshPushIOCharEventAppend(IOEventFlags channel, char charData) {
 
 /// Try and handle events in the IRQ itself. true if handled and shouldn't go in queue
 static bool jshPushIOCharEventHandler(IOEventFlags channel, char charData) {
-  // Check for a CTRL+C
-  if (charData==3 && channel==jsiGetConsoleDevice()) {
-    jsiCtrlC(); // Ctrl-C - force interrupt of execution
-    return true;
+  // Check for a CTRL+C or CTRL+D
+  if (channel==jsiGetConsoleDevice()) {
+    switch (charData) {
+    case 3:
+      jsiCtrlC(); // Ctrl-C - force interrupt of execution
+      return true;
+    case 4:
+      jsiCtrlD();
+      return true;
+    }
   }
   return jswOnCharEvent(channel, charData);
 }

--- a/src/jsinteractive.c
+++ b/src/jsinteractive.c
@@ -1809,6 +1809,10 @@ void jsiCtrlC() {
   execInfo.execute |= EXEC_CTRL_C;
 }
 
+void jsiCtrlD() {
+  execInfo.execute |= EXEC_CTRL_D;
+}
+
 /** Grab as many characters as possible from the event queue for the given event
    and return a JsVar containing them. 'eventsHandled' is set to the number of
    extra events (not characters) is returned */
@@ -2310,6 +2314,15 @@ bool jsiLoop() {
       jsiTimeSinceCtrlC = 0;
     }
     jsiClearInputLine(true);
+  }
+
+  if (execInfo.execute & EXEC_CTRL_D) {
+    execInfo.execute = execInfo.execute & (JsExecFlags)~EXEC_CTRL_D;
+#ifndef EMBEDDED
+    if (jsvIsEmptyString(inputLine)) {
+      exit(0); // exit if ctrl-d on empty input line
+    }
+#endif
   }
 
   // return console (if it was gone!)

--- a/src/jsinteractive.h
+++ b/src/jsinteractive.h
@@ -46,6 +46,7 @@ bool jsiHasTimers(); // are there timers still left to run?
 bool jsiIsWatchingPin(Pin pin); // are there any watches for the given pin?
 
 void jsiCtrlC(); // Ctrl-C - force interrupt of execution
+void jsiCtrlD();
 
 /// Queue a function, string, or array (of funcs/strings) to be executed next time around the idle loop
 void jsiQueueEvents(JsVar *object, JsVar *callback, JsVar **args, int argCount);

--- a/src/jsparse.h
+++ b/src/jsparse.h
@@ -120,6 +120,8 @@ typedef enum  {
   EXEC_DEBUGGER_MASK = EXEC_DEBUGGER_NEXT_LINE | EXEC_DEBUGGER_STEP_INTO | EXEC_DEBUGGER_FINISH_FUNCTION,
 #endif
 
+  EXEC_CTRL_D = 65536,
+
   EXEC_RUN_MASK = EXEC_YES|EXEC_BREAK|EXEC_CONTINUE|EXEC_RETURN|EXEC_INTERRUPTED|EXEC_EXCEPTION,
   EXEC_ERROR_MASK = EXEC_INTERRUPTED|EXEC_ERROR|EXEC_EXCEPTION, ///< here, we have an error, but unless EXEC_NO_PARSE, we should continue parsing but not executing
   EXEC_NO_PARSE_MASK = EXEC_INTERRUPTED|EXEC_ERROR, ///< in these cases we should exit as fast as possible - skipping out of parsing


### PR DESCRIPTION
(REPLs such as `node`, `python`, and `irb` support exiting by <kbd>Ctrl</kbd> + <kbd>D</kbd> on empty input line)