### PR TITLE
increase TX buffer to 256 for boards with RAM > 128KB

### DIFF
--- a/scripts/build_platform_config.py
+++ b/scripts/build_platform_config.py
@@ -344,6 +344,7 @@ else:
   # TX buffer - for print/write/etc
   bufferSizeTX = 32 
   if board.chip["ram"]>=20: bufferSizeTX = 128
+  if board.chip["ram"]>=128: bufferSizeTX = 256
   bufferSizeTimer = 4 if board.chip["ram"]<20 else 16
 
 if 'util_timer_tasks' in board.info:


### PR DESCRIPTION
This helps on 52840 boards with figuring out MTU over 127 bytes. With current MTU 131 and 127 byte TX buffer the process.env is sent in two chunks, first having 127 bytes due to TX buffer limit so the MTU is guessed to be smaller by 1 byte (see WebIDE console log). With this patch it is guessed as 131-3=128 instead of 127. Not sure whether it is worth it but maybe yes?
