### PR TITLE
move exportPtrs to flash

### DIFF
--- a/src/jswrap_process.c
+++ b/src/jswrap_process.c
@@ -71,7 +71,7 @@ Returns the version of Espruino as a String
 #ifndef SAVE_ON_FLASH
 /* NOTE: The order of these is very important, as 
 the online compiler has its own copy of this table */
-const void *exportPtrs[] = {
+const void * const exportPtrs[] = {
     jsvLockAgainSafe,
     jsvUnLock,
     jsvSkipName,


### PR DESCRIPTION
can be seen that `process.env.EXPTR.toString(16)` now points to ram, with this patch it points to flash area. currently it saves 0x48 bytes of RAM. In flash it is free to grow in future.

I hope this stuff is supposed to be read only (?) as the entries itself point to flash anyway  - as seen e.g. on  peek32(process.env.EXPTR).toString(16)

