### PR TITLE
Fix link to donation page in README (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Work on Espruino is supported by [sales of our boards](http://www.espruino.com/O
 
 **If your board isn't made by us but came pre-installed with Espruino then you should contact the manufacturers.**
 
-We try and support users of the boards we sell, but if you bought a non-official board your issue may not get addressed. In this case, please consider [donating](http://www.espruino.com/Download) to help cover the time it takes to fix problems (even so, we can't guarantee to fix every problem).
+We try and support users of the boards we sell, but if you bought a non-official board your issue may not get addressed. In this case, please consider [donating](http://www.espruino.com/Donate) to help cover the time it takes to fix problems (even so, we can't guarantee to fix every problem).
 
 
 License


### PR DESCRIPTION
Similar to https://github.com/espruino/Espruino/pull/2064 :)


@gfwilliams
While looking through the README file i saw that all links to http://www.espruino.com are non-https links. Shouldn't we change that?