### PR TITLE
make jsfCreateFile consistent with jsfFindFile

### DIFF
--- a/src/jsflash.c
+++ b/src/jsflash.c
@@ -478,8 +478,8 @@ static uint32_t jsfCreateFile(JsfFileName name, uint32_t size, JsfFileFlags flag
       bankStartAddress = JSF_START_ADDRESS;
       memmove(name.c, name.c+2, sizeof(name)-2); // shift back
     }
-#endif
   }
+#endif
 
   uint32_t requiredSize = jsfAlignAddress(size)+(uint32_t)sizeof(JsfFileHeader);
   bool compacted = false;


### PR DESCRIPTION
only 'C:' is stripped and only when second bank is defined

as per comment https://github.com/espruino/Espruino/pull/2079#issuecomment-953956888
disregard if you prefer otherwise