### PR TITLE
stm32 allow no HW uart,spi,i2c

### DIFF
--- a/targets/stm32/jshardware.c
+++ b/targets/stm32/jshardware.c
@@ -83,16 +83,23 @@ BITFIELD_DECL(jshPinSoftPWM, JSH_PIN_COUNT);
 BITFIELD_DECL(jshPinOpendrainPullup, JSH_PIN_COUNT);
 #endif
 
+#define SPI_ENABLED (SPI_COUNT>0)
+#define I2C_ENABLED (I2C_COUNT>0)
+#define USART_ENABLED (USART_COUNT>0)
+
+#if SPI_ENABLED
 // simple 4 byte buffers for SPI
 #define JSH_SPIBUF_MASK 3 // 4 bytes
 volatile unsigned char jshSPIBufHead[SPI_COUNT];
 volatile unsigned char jshSPIBufTail[SPI_COUNT];
 volatile unsigned char jshSPIBuf[SPI_COUNT][4]; // 4 bytes packed into an int
+#endif
 
 #ifdef USB
 JsSysTime jshLastWokenByUSB = 0;
 #endif
 
+#if USART_ENABLED
 /* On STM32 there's no 7 bit UART mode, so
  * we much just fake it by using an 8 bit UART
  * and then masking off the top bit */
@@ -106,6 +113,7 @@ void jshSetIsSerial7Bit(IOEventFlags device, bool is7Bit) {
   if (is7Bit) jsh7BitUART |= (1<<(device-EV_SERIAL1));
   else  jsh7BitUART &= ~(1<<(device-EV_SERIAL1));
 }
+#endif
 
 // ----------------------------------------------------------------------------
 //                                                                        PINS
@@ -366,12 +374,17 @@ void jshSetDeviceInitialised(IOEventFlags device, bool isInit) {
 void *setDeviceClockCmd(JshPinFunction device, FunctionalState cmd) {
   device = device&JSH_MASK_TYPE;
   void *ptr = 0;
-  if (device == JSH_USART1) {
+  if (0){
+#if defined(USART1) && USART_COUNT>=1
+  } else if (device == JSH_USART1) {
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1, cmd);
     ptr = USART1;
+#endif
+#if defined(USART2) && USART_COUNT>=2
   } else if (device == JSH_USART2) {
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, cmd);
     ptr = USART2;
+#endif
 #if defined(USART3) && USART_COUNT>=3
   } else if (device == JSH_USART3) {
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART3, cmd);
@@ -581,10 +594,13 @@ TIM_TypeDef* getTimerFromPinFunction(JshPinFunction device) {
   return 0;
 }
 
+#if USART_ENABLED
 USART_TypeDef* getUsartFromDevice(IOEventFlags device) {
  switch (device) {
    case EV_SERIAL1 : return USART1;
+#if USART_COUNT>=2 && defined(USART2)
    case EV_SERIAL2 : return USART2;
+#endif
 #if USART_COUNT>=3 && defined(USART3)
    case EV_SERIAL3 : return USART3;
 #endif
@@ -600,7 +616,9 @@ USART_TypeDef* getUsartFromDevice(IOEventFlags device) {
    default: return 0;
  }
 }
+#endif
 
+#if SPI_ENABLED
 SPI_TypeDef* getSPIFromDevice(IOEventFlags device) {
  switch (device) {
    case EV_SPI1 : return SPI1;
@@ -613,17 +631,22 @@ SPI_TypeDef* getSPIFromDevice(IOEventFlags device) {
    default: return 0;
  }
 }
+#endif
 
+#if I2C_ENABLED
 I2C_TypeDef* getI2CFromDevice(IOEventFlags device) {
  switch (device) {
    case EV_I2C1 : return I2C1;
+#if I2C_COUNT>=2
    case EV_I2C2 : return I2C2;
+#endif
 #if I2C_COUNT>=3
    case EV_I2C3 : return I2C3;
 #endif
    default: return 0;
  }
 }
+#endif
 
 unsigned int jshGetTimerFreq(TIM_TypeDef *TIMx) {
   // TIM2-7, 12-14  on APB1, everything else is on APB2
@@ -660,12 +683,14 @@ unsigned int jshGetTimerFreq(TIM_TypeDef *TIMx) {
   return freq*2;
 }
 
+#ifdef SPI_ENABLED
 static unsigned int jshGetSPIFreq(SPI_TypeDef *SPIx) {
   RCC_ClocksTypeDef clocks;
   RCC_GetClocksFreq(&clocks);
   bool APB2 = SPIx == SPI1;
   return APB2 ? clocks.PCLK2_Frequency : clocks.PCLK1_Frequency;
 }
+#endif
 
 static ALWAYS_INLINE unsigned int getSystemTimerFreq() {
   return SystemCoreClock;
@@ -1019,16 +1044,27 @@ static NO_INLINE void jshPinSetFunction(Pin pin, JshPinFunction func) {
       GPIO_PinRemapConfig( GPIO_FullRemap_TIM3, remap );
   } else if ((func&JSH_MASK_TYPE)==JSH_TIMER4)  GPIO_PinRemapConfig( GPIO_Remap_TIM4, remap );
   else if ((func&JSH_MASK_TYPE)==JSH_TIMER15) GPIO_PinRemapConfig( GPIO_Remap_TIM15, remap );
+#if I2C_ENABLED
   else if ((func&JSH_MASK_TYPE)==JSH_I2C1) GPIO_PinRemapConfig( GPIO_Remap_I2C1, remap );
+#endif
+#if SPI_ENABLED
   else if ((func&JSH_MASK_TYPE)==JSH_SPI1) GPIO_PinRemapConfig( GPIO_Remap_SPI1, remap );
   else if ((func&JSH_MASK_TYPE)==JSH_SPI3) GPIO_PinRemapConfig( GPIO_Remap_SPI3, remap );
+#endif
+#if USART_COUNT>0
   else if ((func&JSH_MASK_TYPE)==JSH_USART1) GPIO_PinRemapConfig( GPIO_Remap_USART1, remap );
+#endif
+#if USART_COUNT>1
   else if ((func&JSH_MASK_TYPE)==JSH_USART2) GPIO_PinRemapConfig( GPIO_Remap_USART2, remap );
+#endif
+#if USART_COUNT>2
   else if ((func&JSH_MASK_TYPE)==JSH_USART3) {
     // nasty hack because USART3 actuall has 2 different remap states
     bool fullRemap = (JSH_PORTD_COUNT>9) && (pin==jshGetPinFromString("D8") || pin==jshGetPinFromString("D9"));
     GPIO_PinRemapConfig( fullRemap ? GPIO_FullRemap_USART3 : GPIO_PartialRemap_USART3, remap );
-  } else if (remap) jsError("(internal) Remap needed, but unknown device %d", func&JSH_MASK_TYPE);
+  }
+#endif
+  else if (remap) jsError("(internal) Remap needed, but unknown device %d", func&JSH_MASK_TYPE);
 
 #endif
 }
@@ -1110,7 +1146,9 @@ void jshInit() {
 #ifdef STM32F1
   BITFIELD_CLEAR(jshPinOpendrainPullup);
 #endif
+#if USART_ENABLED
   jsh7BitUART = 0;
+#endif
 
   // enable clocks
  #if defined(STM32F3)
@@ -1362,11 +1400,13 @@ void jshInit() {
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
 
+#if SPI_ENABLED
   // reset SPI buffers
   for (i=0;i<SPI_COUNT;i++) {
     jshSPIBufHead[i] = 0;
     jshSPIBufTail[i] = 0;
   }
+#endif
 
 #ifdef LED1_PININDEX
   // now hardware is initialised, turn led off
@@ -2036,6 +2076,7 @@ void *NO_INLINE checkPinsForDevice(JshPinFunction device, int count, Pin *pins, 
   return ptr;
 }
 
+#if USART_ENABLED
 void jshUSARTSetup(IOEventFlags device, JshUSARTInfo *inf) {
   assert(DEVICE_IS_USART(device));
 
@@ -2058,8 +2099,10 @@ void jshUSARTSetup(IOEventFlags device, JshUSARTInfo *inf) {
   IRQn_Type usartIRQ;
   if (device == EV_SERIAL1) {
     usartIRQ = USART1_IRQn;
+#if defined(USART2) && USART_COUNT>=2
   } else if (device == EV_SERIAL2) {
     usartIRQ = USART2_IRQn;
+#endif
 #if defined(USART3) && USART_COUNT>=3
   } else if (device == EV_SERIAL3) {
     usartIRQ = USART3_IRQn;
@@ -2155,11 +2198,12 @@ void jshUSARTSetup(IOEventFlags device, JshUSARTInfo *inf) {
   // Enable USART
   USART_Cmd(USARTx, ENABLE);
 }
-
+#endif
 
 /** Kick a device into action (if required). For instance we may need
  * to set up interrupts */
 void jshUSARTKick(IOEventFlags device) {
+#if USART_ENABLED
   USART_TypeDef *uart = getUsartFromDevice(device);
   if (uart && !jshIsDeviceInitialised(device)) {
     JshUSARTInfo inf;
@@ -2168,8 +2212,10 @@ void jshUSARTKick(IOEventFlags device) {
   }
 
   if (uart) USART_ITConfig(uart, USART_IT_TXE, ENABLE);
+#endif
 }
 
+#if SPI_ENABLED
 /** Set up SPI, if pins are -1 they will be guessed */
 void jshSPISetup(IOEventFlags device, JshSPIInfo *inf) {
   jshSetDeviceInitialised(device, true);
@@ -2217,7 +2263,9 @@ void jshSPISetup(IOEventFlags device, JshSPIInfo *inf) {
   uint8_t spiIRQ;
   switch (device) {
     case EV_SPI1: spiIRQ = SPI1_IRQn; break;
+#if SPI_COUNT>=2
     case EV_SPI2: spiIRQ = SPI2_IRQn; break;
+#endif
 #if SPI_COUNT>=3
     case EV_SPI3: spiIRQ = SPI3_IRQn; break;
 #endif
@@ -2318,7 +2366,9 @@ void jshSPIWait(IOEventFlags device) {
   /* Just in case we didn't have IRQs, and the register was full... */
   SPI_I2S_ReceiveData(SPI);
 }
+#endif // SPI_ENABLED
 
+#if I2C_ENABLED
 /** Set up I2S, if pins are -1 they will be guessed */
 void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
   jshSetDeviceInitialised(device, true);
@@ -2443,6 +2493,7 @@ void jshI2CRead(IOEventFlags device, unsigned char address, int nBytes, unsigned
 
 #endif
 }
+#endif //I2C_ENABLED
 
 #ifdef USB
 

--- a/targets/stm32/stm32_it.c
+++ b/targets/stm32/stm32_it.c
@@ -280,6 +280,7 @@ void RTC_WKUP_IRQHandler(void)
 }
 #endif
 
+#if USART_COUNT>0
 NO_INLINE static void USART_IRQHandler(USART_TypeDef *USART, IOEventFlags device) {
   if (USART_GetFlagStatus(USART, USART_FLAG_FE) != RESET) {
     // If we have a framing error, push status info onto the event queue
@@ -318,14 +319,18 @@ NO_INLINE static void USART_IRQHandler(USART_TypeDef *USART, IOEventFlags device
       USART_ITConfig(USART, USART_IT_TXE, DISABLE);
   }
 }
+#endif
 
+#if defined(USART1) && USART_COUNT>=1
 void USART1_IRQHandler(void) {
   USART_IRQHandler(USART1, EV_SERIAL1);
 }
-
+#endif
+#if defined(USART2) && USART_COUNT>=2
 void USART2_IRQHandler(void) {
   USART_IRQHandler(USART2, EV_SERIAL2);
 }
+#endif
 
 #if defined(USART3) && USART_COUNT>=3
 void USART3_IRQHandler(void) {


### PR DESCRIPTION
allow STM32 uart,spi,i2c count to be configurable including 0
tested on STM32F103 ($2 STLink V2 clone dongle with F103 inside)

BTW what is targets/stm32_ll ? looks like more or less a copy of targets/stm32 , is it still used?