### PR TITLE
Exit on Ctrl-D (#2032)

### DIFF
--- a/targets/linux/jshardware.c
+++ b/targets/linux/jshardware.c
@@ -264,6 +264,7 @@ void jshInputThread() {
     while (kbhit() && (jshGetEventsUsed()<IOBUFFERMASK/2)) {
       int ch = getch();
       if (ch<0) break;
+      if (ch==4) exit(0); // exit on Ctrl-D
       jshPushIOCharEvent(EV_USBSERIAL, (char)ch);
     }
     // Read from any open devices - if we have space


### PR DESCRIPTION
This makes the REPL exit as soon as you type Ctrl-D, as per #2032.

Making it look for end-of-file is more annoying than expected since it puts the terminal in raw mode, and `getch()` currently does the wrong thing if `read()` returns 0.

I thought the simplest fix was just to explicitly check for Ctrl-D, but maybe something else is better?