### PR TITLE
Bangle.js2: don't make setUI go "back" on button press

### DIFF
--- a/libs/js/banglejs/Bangle_setUI_Q3.js
+++ b/libs/js/banglejs/Bangle_setUI_Q3.js
@@ -102,15 +102,11 @@
     var touchHandler = (_,e) => {
       if (e.y<24 && e.x<48) options.back();
     };
-    Bangle.on("touch", touchHandler);    
-    var btnWatch = setWatch(function() {
-      options.back();
-    }, BTN1, {edge:"falling"});
+    Bangle.on("touch", touchHandler);
     WIDGETS = Object.assign({back:{ 
       area:"tl", width:24, 
       draw:e=>g.reset().setColor("#f00").drawImage(atob("GBiBAAAYAAH/gAf/4A//8B//+D///D///H/P/n+H/n8P/n4f/vwAP/wAP34f/n8P/n+H/n/P/j///D///B//+A//8Af/4AH/gAAYAA=="),e.x,e.y),
       remove:()=>{
-        clearWatch(btnWatch);
         Bangle.removeListener("touch", touchHandler);
         g.reset().clearRect({x:WIDGETS.back.x, y:WIDGETS.back.y, w:24,h:24});
         delete WIDGETS.back;


### PR DESCRIPTION
Not sure if this was the intended behavior, but I think it works better without it: I like having the "back" widget, but do want to use the button for something else.