### PR TITLE
Extend setWatch to allow buffering

### DIFF
--- a/src/jsinteractive.c
+++ b/src/jsinteractive.c
@@ -2031,7 +2031,10 @@ void jsiIdle() {
                 if (jshIsPinValid(dataPin))
                   jsvObjectSetChildAndUnLock(data, "data", jsvNewFromBool((event.flags&EV_EXTI_DATA_PIN_HIGH)!=0));
               }
-              if (!jsiExecuteEventCallback(0, watchCallback, 1, &data) && watchRecurring) {
+              if (jsvIsArray(watchCallback)) {
+                // add this event to supplied array instead of using callback
+                jsvArrayAddToEnd(watchCallback, data, 1);
+              } else if (!jsiExecuteEventCallback(0, watchCallback, 1, &data) && watchRecurring) {
                 jsError("Ctrl-C while processing watch - removing it.");
                 jsErrorFlags |= JSERR_CALLBACK;
                 watchRecurring = false;

--- a/src/jswrap_io.c
+++ b/src/jswrap_io.c
@@ -729,8 +729,8 @@ JsVar *jswrap_interface_setWatch(
     repeat = jsvGetBool(repeatOrObject);
 
   JsVarInt itemIndex = -1;
-  if (!jsvIsFunction(func) && !jsvIsString(func)) {
-    jsExceptionHere(JSET_ERROR, "Function or String not supplied!");
+  if (!jsvIsFunction(func) && !jsvIsString(func) && !jsvIsArray(func)) {
+    jsExceptionHere(JSET_ERROR, "Function, String, or Array not supplied!");
   } else {
     JsVar *watchPtr = jsvNewObject();
     if (watchPtr) {


### PR DESCRIPTION
Hi. When receiving many interruptions on a pin, the ESP8266 can't handle it. More often than not, it will fire an exception FIFO_FULL. The callback can't do anything useful in the short time available, not even adding the value to an array or print it to screen.

 I have tried increasing the `bufferSizeIO` in `scripts/build_platform_config.py` to 512. That works for a while, but then random errors start happening. I'm guessing there's some overlap issue.

So I resolved to attack this problem from another angle. Changing the signature of setWatch to avoid having to go into javascript:

```
setWatch(Array, Pin, options)
```

Instead of executing a JS callback, just add the event to the provided array. This should work, I think. But I'm having some issues with the code. I get `Execution Interrupted` on the first interruption, and then the chip is broken until I re-flash it.

First guess is that there needs to be some locking, or unlocking, whatever that is? I see it all over the code... Any help on this code would be appreciated. Thanks!
