### PR TITLE
Nullish coalescing operator

### DIFF
--- a/src/jslex.c
+++ b/src/jslex.c
@@ -112,6 +112,7 @@ typedef enum {
   JSLJT_NUMBER,
   JSLJT_STRING,
 
+  JSJLT_QUESTION,
   JSLJT_EXCLAMATION,
   JSLJT_PLUS,
   JSLJT_MINUS,
@@ -196,7 +197,7 @@ const jslJumpTableEnum jslJumpTable[jslJumpTableEnd+2] = {
     JSLJT_LESSTHAN, // <
     JSLJT_EQUAL, // =
     JSLJT_GREATERTHAN, // >
-    JSLJT_SINGLE_CHAR, // ?
+    JSJLT_QUESTION, // ?
     // 64
     JSLJT_SINGLE_CHAR, // @
     JSLJT_ID, // A
@@ -580,45 +581,50 @@ void jslGetNextToken() {
         }
       } break;
       case JSLJT_PLUS: jslSingleChar();
-      if (lex->currCh=='=') {
+      if (lex->currCh=='=') { // +=
         lex->tk = LEX_PLUSEQUAL;
         jslGetNextCh();
-      } else if (lex->currCh=='+') {
+      } else if (lex->currCh=='+') { // ++
         lex->tk = LEX_PLUSPLUS;
         jslGetNextCh();
       } break;
       case JSLJT_MINUS: jslSingleChar();
-      if (lex->currCh=='=') {
+      if (lex->currCh=='=') { // -=
         lex->tk = LEX_MINUSEQUAL;
         jslGetNextCh();
-      } else if (lex->currCh=='-') {
+      } else if (lex->currCh=='-') { // --
         lex->tk = LEX_MINUSMINUS;
         jslGetNextCh();
       } break;
       case JSLJT_AND: jslSingleChar();
-      if (lex->currCh=='=') {
+      if (lex->currCh=='=') { // &=
         lex->tk = LEX_ANDEQUAL;
         jslGetNextCh();
-      } else if (lex->currCh=='&') {
+      } else if (lex->currCh=='&') { // &&
         lex->tk = LEX_ANDAND;
         jslGetNextCh();
       } break;
       case JSLJT_OR: jslSingleChar();
-      if (lex->currCh=='=') {
+      if (lex->currCh=='=') { // |=
         lex->tk = LEX_OREQUAL;
         jslGetNextCh();
-      } else if (lex->currCh=='|') {
+      } else if (lex->currCh=='|') { // ||
         lex->tk = LEX_OROR;
         jslGetNextCh();
       } break;
       case JSLJT_TOPHAT: jslSingleChar();
-      if (lex->currCh=='=') {
+      if (lex->currCh=='=') { // ^=
         lex->tk = LEX_XOREQUAL;
         jslGetNextCh();
       } break;
       case JSLJT_STAR: jslSingleChar();
-      if (lex->currCh=='=') {
+      if (lex->currCh=='=') { // *=
         lex->tk = LEX_MULEQUAL;
+        jslGetNextCh();
+      } break;
+      case JSJLT_QUESTION: jslSingleChar();
+      if(lex->currCh=='?'){ // ??
+        lex->tk = LEX_NULLISH;
         jslGetNextCh();
       } break;
       case JSLJT_FORWARDSLASH:
@@ -811,6 +817,7 @@ const char* jslReservedWordAsString(int token) {
       /* LEX_ANDAND :       */ "&&\0"
       /* LEX_OREQUAL :      */ "|=\0"
       /* LEX_OROR :         */ "||\0"
+      /* LEX_NULLISH :      */ "??\0"
       /* LEX_XOREQUAL :     */ "^=\0"
       /* LEX_ARROW_FUNCTION */ "=>\0"
 

--- a/src/jslex.h
+++ b/src/jslex.h
@@ -56,6 +56,7 @@ _LEX_OPERATOR_START,
     LEX_ANDAND,
     LEX_OREQUAL,
     LEX_OROR,
+    LEX_NULLISH,
     LEX_XOREQUAL,
     // Note: single character operators are represented by themselves
 _LEX_OPERATOR_END = LEX_XOREQUAL,

--- a/src/jsparse.c
+++ b/src/jsparse.c
@@ -1877,6 +1877,7 @@ NO_INLINE JsVar *jspeUnaryExpression() {
 // Get the precedence of a BinaryExpression - or return 0 if not one
 unsigned int jspeGetBinaryExpressionPrecedence(int op) {
   switch (op) {
+  case LEX_NULLISH:
   case LEX_OROR: return 1; break;
   case LEX_ANDAND: return 2; break;
   case '|' : return 3; break;

--- a/src/jsparse.c
+++ b/src/jsparse.c
@@ -1935,6 +1935,20 @@ NO_INLINE JsVar *__jspeBinaryExpression(JsVar *a, unsigned int lastPrecedence) {
         jsvUnLock(a);
         a = __jspeBinaryExpression(jspeUnaryExpression(),precedence);
       }
+    } else if (op==LEX_NULLISH){
+      JsVar* value = jsvSkipName(a);
+      if (jsvIsNull(value) || jsvIsUndefined(value)) {
+        // use second argument (B)
+        if(!jsvIsUndefined(value)) jsvUnLock(value);
+        jsvUnLock(a);
+        a = __jspeBinaryExpression(jspeUnaryExpression(),precedence);
+      } else {
+        jsvUnLock(value);
+        // use first argument (A)
+        JSP_SAVE_EXECUTE();
+        jspSetNoExecute();
+        jsvUnLock(__jspeBinaryExpression(jspeUnaryExpression(),precedence));
+        JSP_RESTORE_EXECUTE();}
     } else { // else it's a more 'normal' logical expression - just use Maths
       JsVar *b = __jspeBinaryExpression(jspeUnaryExpression(),precedence);
       if (JSP_SHOULD_EXECUTE) {

--- a/tests/test_nullish.js
+++ b/tests/test_nullish.js
@@ -1,0 +1,21 @@
+// test the nullish coalescing operator
+
+result = true;
+
+result &= null ?? true;
+result &= undefined ?? true;
+
+var a = null;
+result &= a ?? true;
+
+var b = undefined;
+result &= b ?? true;
+
+var c = true;
+result &= c ?? true;
+
+var d = 0;
+result &= (d ?? 1) === 0;
+
+var e = false;
+result &= (e ?? 1) === false;


### PR DESCRIPTION
This adds support for the nullish coalescing operator:

```js
var a = (null ?? true);
```

It is similar to doing `a || b` but it only uses `b` if `a` is null or undefined.