### PR TITLE
Don't allow expressions on the left side of assignments

### DIFF
--- a/src/jsparse.c
+++ b/src/jsparse.c
@@ -1942,28 +1942,29 @@ NO_INLINE JsVar *__jspeBinaryExpression(JsVar *a, unsigned int lastPrecedence) {
     // we don't bother to execute the other op. Even if not
     // we need to tell mathsOp it's an & or |
     if (op==LEX_ANDAND || op==LEX_OROR) {
-      bool aValue = jsvGetBoolAndUnLock(jsvSkipName(a));
+      JsVar *av = jsvSkipNameAndUnLock(a);
+      bool aValue = jsvGetBool(av);
       if ((!aValue && op==LEX_ANDAND) ||
           (aValue && op==LEX_OROR)) {
         // use first argument (A)
+        a = av;
         JSP_SAVE_EXECUTE();
         jspSetNoExecute();
         jsvUnLock(__jspeBinaryExpression(jspeUnaryExpression(),precedence));
         JSP_RESTORE_EXECUTE();
       } else {
         // use second argument (B)
-        jsvUnLock(a);
+        jsvUnLock(av);
         a = __jspeBinaryExpression(jspeUnaryExpression(),precedence);
       }
     } else if (op==LEX_NULLISH){
-      JsVar* value = jsvSkipName(a);
+      JsVar* value = jsvSkipNameAndUnLock(a);
       if (jsvIsNull(value) || jsvIsUndefined(value)) {
         // use second argument (B)
         if(!jsvIsUndefined(value)) jsvUnLock(value);
-        jsvUnLock(a);
         a = __jspeBinaryExpression(jspeUnaryExpression(),precedence);
       } else {
-        jsvUnLock(value);
+        a = value;
         // use first argument (A)
         JSP_SAVE_EXECUTE();
         jspSetNoExecute();
@@ -2063,7 +2064,7 @@ NO_INLINE JsVar *__jspeConditionalExpression(JsVar *lhs) {
       bool first = jsvGetBoolAndUnLock(jsvSkipName(lhs));
       jsvUnLock(lhs);
       if (first) {
-        lhs = jspeAssignmentExpression();
+        lhs = jsvSkipNameAndUnLock(jspeAssignmentExpression());
         JSP_MATCH(':');
         JSP_SAVE_EXECUTE();
         jspSetNoExecute();
@@ -2075,7 +2076,7 @@ NO_INLINE JsVar *__jspeConditionalExpression(JsVar *lhs) {
         jsvUnLock(jspeAssignmentExpression());
         JSP_RESTORE_EXECUTE();
         JSP_MATCH(':');
-        lhs = jspeAssignmentExpression();
+        lhs = jsvSkipNameAndUnLock(jspeAssignmentExpression());
       }
     }
   }

--- a/tests/test_lvalue.js
+++ b/tests/test_lvalue.js
@@ -1,0 +1,20 @@
+// Testing proper lvalue support
+
+// test left hand fall through
+
+var a = 5;
+var b = 7;
+var c = 0;
+
+result = a || b;
+result |= !(c && b);
+result |= a ?? b;
+result |= a ? b : c;
+
+
+// test right hand side
+
+result |= c || b;
+result |= a && b;
+result |= null ?? b;
+result |= c ? b : a;

--- a/tests/test_lvalue_throws.js
+++ b/tests/test_lvalue_throws.js
@@ -1,0 +1,30 @@
+// Test that lvalue cannot be assigned to
+
+var a = 0, b = 0;
+try {
+  (true ? a : b) = 5;
+  result = false;
+}catch(e){
+  result = true;
+}
+
+try {
+  (a && b) = 5;
+  result = false;
+}catch(e){
+  result |= true;
+}
+
+try {
+  (a || b) = 5;
+  result = false;
+}catch(e){
+  result |= true;
+}
+
+try {
+  (a ?? b) = 5;
+  result = false;
+}catch(e){
+  result |= true;
+}

--- a/tests/test_nullish.js
+++ b/tests/test_nullish.js
@@ -20,6 +20,9 @@ result &= (d ?? 1) === 0;
 var e = false;
 result &= (e ?? 1) === false;
 
+var e = null;
+result &= (e ?? c);
+
 // Check token is handled correctly by the internal pretokeniser
 E.setFlags({pretokenise:1})
 function a(a) { return  a??5 }


### PR DESCRIPTION
Make sure that the results of expressions like `||`, `&&` and `a?b:c` are values and not variable references

This fixes #2214 