### PR TITLE
TypeScript: Document using JSDoc format

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -25,7 +25,7 @@ Builtin.prototype.getDescription = function() {
 };
 
 Builtin.prototype.getURL = function() {
-  if (this.type == "class")
+  if (this.type == "class" || this.type == "library")
     anchor = this.class;
   else if ("class" in this)
     anchor = "l_"+this.class+"_"+this.name;


### PR DESCRIPTION
Automatically adds [JSDoc](https://jsdoc.app/) tags (`@param`, `@returns`, and `@constructor`) to give info about each function. See the result: https://github.com/qucchia/BangleApps/blob/master/typescript/types/main.d.ts.