### PR TITLE
Add custom TypeScript declarations in comments

### DIFF
--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -4828,6 +4828,7 @@ to select an application to launch.
       ["menu","JsVar","An object containing name->function mappings to to be used in a menu"]
     ],
     "return" : ["JsVar", "A menu object with `draw`, `move` and `select` functions" ],
+    "typescript": "showMenu(menu: Menu): MenuInstance;",
     "ifdef" : "BANGLEJS"
 }
 Display a menu on the screen, and set up the buttons to navigate through it.

--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -74,6 +74,18 @@
 #include "unistroke.h"
 #endif
 
+/*TYPESCRIPT
+declare const g: Graphics;
+
+type WidgetArea = "tl" | "tr" | "bl" | "br";
+type Widget = {
+  area: WidgetArea;
+  width: number;
+  draw: (this: { x: number; y: number }) => void;
+};
+declare const WIDGETS: { [key: string]: Widget };
+*/
+
 /*JSON{
   "type": "class",
   "class" : "Bangle",

--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -343,7 +343,7 @@ void jswrap_ble_dumpBluetoothInitialisation(vcbprintf_callback user_callback, vo
 // ------------------------------------------------------------------------------
 
 /*JSON{
-    "type": "class",
+    "type" : "class",
     "class" : "NRF"
 }
 The NRF class is for controlling functionality of the Nordic nRF51/nRF52 chips.
@@ -1974,8 +1974,9 @@ JsVar *jswrap_ble_filterDevices(JsVar *devices, JsVar *filters) {
     "generate" : "jswrap_ble_findDevices",
     "params" : [
       ["callback","JsVar","The callback to call with received advertising packets (as `BluetoothDevice`), or undefined to stop"],
-      ["options","JsVar","A time in milliseconds to scan for (defaults to 2000), Or an optional object `{filters: ..., timeout : ..., active: bool}` (as would be passed to `NRF.requestDevice`) to filter devices by"]
-    ]
+      ["options","JsVar","[optional] A time in milliseconds to scan for (defaults to 2000), Or an optional object `{filters: ..., timeout : ..., active: bool}` (as would be passed to `NRF.requestDevice`) to filter devices by"]
+    ],
+    "typescript" : "findDevices(callback: (devices: BluetoothDevice[]) => void, options?: number | { filters?: NRFFilters, timeout?: number, active?: boolean }): void;"
 }
 Utility function to return a list of BLE devices detected in range. Behind the scenes,
 this uses `NRF.setScan(...)` and collates the results.
@@ -1991,7 +1992,7 @@ prints something like:
 ```
 [
   BluetoothDevice {
-    "id": "e7:e0:57:ad:36:a2 random",
+    "id" : "e7:e0:57:ad:36:a2 random",
     "rssi": -45,
     "services": [ "4567" ],
     "serviceData" : { "0123" : [ 1 ] },
@@ -2961,6 +2962,17 @@ void jswrap_ble_amsCommand(JsVar *id) {
 #endif
 }
 
+/*TYPESCRIPT
+type NRFFilters = {
+  services?: string[];
+  name?: string;
+  namePrefix?: string;
+  id?: string;
+  serviceData?: object;
+  manufacturerData?: object;
+};
+*/
+
 /*JSON{
     "type" : "staticmethod",
     "class" : "NRF",
@@ -2970,6 +2982,7 @@ void jswrap_ble_amsCommand(JsVar *id) {
     "params" : [
       ["options","JsVar","Options used to filter the device to use"]
     ],
+    "typescript" : "requestDevice(options?: { filters?: NRFFilters, timeout?: number, active?: boolean, phy?: string, extended?: boolean }): Promise<any>;",
     "return" : ["JsVar", "A `Promise` that is resolved (or rejected) when the connection is complete" ],
     "return_object" : "Promise"
 }

--- a/libs/pixljs/jswrap_pixljs.c
+++ b/libs/pixljs/jswrap_pixljs.c
@@ -495,6 +495,70 @@ Display a menu on Pixl.js's screen, and set up the buttons to navigate through i
 DEPRECATED: Use `E.showMenu`
 */
 
+/*TYPESCRIPT
+/**
+ * Menu item that holds a boolean value.
+ *\/
+type MenuBooleanItem = {
+  value: boolean;
+  format?: (value: boolean) => string;
+  onchange?: (value: boolean) => void;
+};
+
+/**
+ * Menu item that holds a numerical value.
+ *\/
+type MenuNumberItem = {
+  value: number;
+  format?: (value: number) => string;
+  onchange?: (value: number) => void;
+  step?: number;
+  min?: number;
+  max?: number;
+  wrap?: boolean;
+};
+
+/**
+ * Options passed to a menu.
+ *\/
+type MenuOptions = {
+  title?: string;
+  back?: () => void;
+  selected?: number;
+  fontHeight?: number;
+  x?: number;
+  y?: number;
+  x2?: number;
+  y2?: number;
+  cB?: number;
+  cF?: number;
+  cHB?: number;
+  cHF?: number;
+  predraw?: (g: Graphics) => void;
+  preflip?: (g: Graphics, less: boolean, more: boolean) => void;
+};
+
+/**
+ * Object containing data about a menu to pass to `E.showMenu`.
+ *\/
+type Menu = {
+  [key: string]:
+    | MenuOptions
+    | (() => void)
+    | MenuBooleanItem
+    | MenuNumberItem
+    | undefined;
+};
+
+/**
+ * Menu instance.
+ *\/
+type MenuInstance = {
+  draw: () => void;
+  move: (n: number) => void;
+  select: () => void;
+};
+*/
 
 /*JSON{
     "type" : "staticmethod",
@@ -504,7 +568,8 @@ DEPRECATED: Use `E.showMenu`
     "params" : [
       ["menu","JsVar","An object containing name->function mappings to to be used in a menu"]
     ],
-    "return" : ["JsVar", "A menu object with `draw`, `move` and `select` functions" ]
+    "return" : ["JsVar", "A menu object with `draw`, `move` and `select` functions" ],
+    "typescript": "showMenu(menu: Menu): MenuInstance;"
 }
 Display a menu on the screen, and set up the buttons to navigate through it.
 

--- a/scripts/build_types.js
+++ b/scripts/build_types.js
@@ -32,9 +32,9 @@ function getDocumentation(object) {
         object.type === "event"
           ? [
               "@param {string} event - The event to listen to.",
-              `@param {(${getArguments(
+              `@param {${getArguments(
                 object
-              )}) => void} callback - A function that is executed when the event occurs.${
+              )} => void} callback - A function that is executed when the event occurs.${
                 object.params ? " Its arguments are:" : ""
               }`,
             ].concat(

--- a/scripts/build_types.js
+++ b/scripts/build_types.js
@@ -279,7 +279,18 @@ require("./common.js").readAllWrapperFiles(function (objects, types) {
       .join("\n\n") +
     "\n\n// GLOBALS\n\n" +
     globals
-      .map((global) => `${getDocumentation(global)}\n${getDeclaration(global)}`)
+      .map((global) =>
+        global.name === "global"
+          ? `declare const global: {\n` +
+            indent(
+              globals
+                .map((global) => `${global.name}: typeof ${global.name};`)
+                .concat("[key: string]: any;")
+                .join("\n")
+            ) +
+            "\n}"
+          : `${getDocumentation(global)}\n${getDeclaration(global)}`
+      )
       .join("\n\n") +
     "\n\n// LIBRARIES\n\ntype Libraries = {\n" +
     indent(

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -79,6 +79,7 @@ exports.getWrapperFiles = function (callback) {
 exports.readWrapperFile = function(filename) {
   var contents = fs.readFileSync(filename).toString();
   var builtins = [];
+  var types = [];
   var comments = contents.match( /\/\*JSON(?:(?!\*\/).|[\n\r])*\*\//g );
   if (comments) comments.forEach(function(comment) {
     comment = comment.slice(6,-2); // pull off /*JSON ... */ bit
@@ -90,17 +91,25 @@ exports.readWrapperFile = function(filename) {
     j.implementation = filename;
     builtins.push(j);
   });
-  return builtins;
+  var comments = contents.match( /\/\*TYPESCRIPT(?:(?!\*\/).|[\n\r])*\*\//g );
+  if (comments) comments.forEach(function(comment) {
+    comment = comment.slice(12,-2);
+    types.push(comment);
+  });
+  return [builtins, types];
 }
 
 /// Extract all parsed /*JSON ... */ comments from all files
 exports.readAllWrapperFiles = function(callback) {
   exports.getWrapperFiles(function(files) {
     var builtins = [];
+    var types = [];
     files.forEach(function(filename) {
-      builtins = builtins.concat(exports.readWrapperFile(filename));
+      var [b, t] = exports.readWrapperFile(filename);
+      builtins = builtins.concat(b);
+      types = types.concat(t);
     });
-    callback(builtins);
+    callback(builtins, types);
   });
 }
 

--- a/src/jswrap_array.c
+++ b/src/jswrap_array.c
@@ -24,7 +24,8 @@
 /*JSON{
   "type" : "class",
   "class" : "Array",
-  "check" : "jsvIsArray(var)"
+  "check" : "jsvIsArray(var)",
+  "typescript": "interface Array<T>"
 }
 This is the built-in JavaScript class for arrays.
 
@@ -41,7 +42,7 @@ Arrays can be defined with ```[]```, ```new Array()```, or ```new Array(length)`
   ],
   "return" : ["JsVar","An Array"]
 }
-Create an Array. Either give it one integer argument (>=0) which is the length of the array, or any number of arguments 
+Create an Array. Either give it one integer argument (>=0) which is the length of the array, or any number of arguments
  */
 JsVar *jswrap_array_constructor(JsVar *args) {
   assert(args);
@@ -341,8 +342,9 @@ JsVar *jswrap_array_map(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   "generate" : "jswrap_array_forEach",
   "params" : [
     ["function","JsVar","Function to be executed"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
-  ]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg (optional)"]
+  ],
+  "typescript": "forEach(callback: (item: T, index: number, array: T[]) => void, thisArg?: any): void;"
 }
 Executes a provided function once per array element.
  */

--- a/src/jswrap_modules.c
+++ b/src/jswrap_modules.c
@@ -42,7 +42,11 @@ static JsVar *jswrap_modules_getModuleList() {
   "params" : [
     ["moduleName","JsVar","A String containing the name of the given module"]
   ],
-  "return" : ["JsVar","The result of evaluating the string"]
+  "return" : ["JsVar","The result of evaluating the string"],
+  "typescript": [
+    "declare function require<T extends keyof Libraries>(moduleName: T): Libraries[T];",
+    "declare function require<T extends Exclude<string, keyof Libraries>>(moduleName: T): any;"
+  ]
 }
 Load the given module, and return the exported functions and variables.
 

--- a/src/jswrap_promise.c
+++ b/src/jswrap_promise.c
@@ -28,6 +28,7 @@
 /*JSON{
   "type" : "class",
   "class" : "Promise",
+  "typescript": "interface Promise<T>",
   "ifndef" : "SAVE_ON_FLASH"
 }
 This is the built-in class for ES6 Promises
@@ -203,7 +204,8 @@ void jspromise_reject(JsVar *promise, JsVar *data) {
   "params" : [
     ["executor","JsVar","A function of the form `function (resolve, reject)`"]
   ],
-  "return" : ["JsVar","A Promise"]
+  "return" : ["JsVar","A Promise"],
+  "typescript": "new<T>(executor: (resolve: (value: T) => void, reject: (reason?: any) => void) => void): Promise<T>;"
 }
 Create a new Promise. The executor function is executed immediately (before the constructor even returns)
 and
@@ -242,7 +244,8 @@ JsVar *jswrap_promise_constructor(JsVar *executor) {
   "params" : [
     ["promises","JsVar","An array of promises"]
   ],
-  "return" : ["JsVar","A new Promise"]
+  "return" : ["JsVar","A new Promise"],
+  "typescript": "all(promises: Promise<any>[]): Promise<void>;"
 }
 Return a new promise that is resolved when all promises in the supplied
 array are resolved.
@@ -299,7 +302,8 @@ JsVar *jswrap_promise_all(JsVar *arr) {
   "params" : [
     ["promises","JsVar","Data to pass to the `.then` handler"]
   ],
-  "return" : ["JsVar","A new Promise"]
+  "return" : ["JsVar","A new Promise"],
+  "typescript": "resolve<T extends any>(promises: T): Promise<T>;"
 }
 Return a new promise that is already resolved (at idle it'll
 call `.then`)
@@ -406,9 +410,10 @@ static JsVar *jswrap_promise_get_chained_promise(JsVar *parent) {
   "generate" : "jswrap_promise_then",
   "params" : [
     ["onFulfilled","JsVar","A callback that is called when this promise is resolved"],
-    ["onRejected","JsVar","A callback that is called when this promise is rejected (or nothing)"]
+    ["onRejected","JsVar","[optional] A callback that is called when this promise is rejected (or nothing)"]
   ],
-  "return" : ["JsVar","The original Promise"]
+  "return" : ["JsVar","The original Promise"],
+  "typescript": "then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | Promise<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | Promise<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;"
 }
  */
 JsVar *jswrap_promise_then(JsVar *parent, JsVar *onFulfilled, JsVar *onRejected) {


### PR DESCRIPTION
You can now define custom types like this:
```c
/*TYPESCRIPT
type NRFFilters = {
  services?: string[];
  name?: string;
  namePrefix?: string;
  id?: string;
  serviceData?: object;
  manufacturerData?: object;
};
*/
```
And custom function types:
```js
{
  ...
  "typescript": [
    "declare function require<T extends keyof Libraries>(moduleName: T): Libraries[T];",
    "declare function require<T extends Exclude<string, keyof Libraries>>(moduleName: T): any;"
  ]
}
```
Finally you can also declare generic classes:
```js
{
  ...
  "typescript": "interface Array<T>"
}
```