### PR TITLE
Limit documentation comments to 80 characters (#2244)

### DIFF
--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -91,7 +91,8 @@ declare const WIDGETS: { [key: string]: Widget };
   "class" : "Bangle",
   "ifdef" : "BANGLEJS"
 }
-Class containing utility functions for the [Bangle.js Smart Watch](http://www.espruino.com/Bangle.js)
+Class containing utility functions for the [Bangle.js Smart
+Watch](http://www.espruino.com/Bangle.js)
 */
 /*TYPESCRIPT{
   "class" : "Bangle"
@@ -163,8 +164,8 @@ type HealthStatus = {
   "ifdef" : "BANGLEJS",
   "typescript" : "on(event: \"health\", callback: (info: HealthStatus) => void): void;"
 }
-See `Bangle.getHealthStatus()` for more information. This is used for health tracking to
-allow Bangle.js to record historical exercise data.
+See `Bangle.getHealthStatus()` for more information. This is used for health
+tracking to allow Bangle.js to record historical exercise data.
  */
 /*JSON{
   "type" : "event",
@@ -181,7 +182,8 @@ Has the watch been moved so that it is face-up, or not face up?
   "name" : "twist",
   "ifdef" : "BANGLEJS"
 }
-This event happens when the watch has been twisted around it's axis - for instance as if it was rotated so someone could look at the time.
+This event happens when the watch has been twisted around it's axis - for
+instance as if it was rotated so someone could look at the time.
 
 To tweak when this happens, see the `twist*` options in `Bangle.setOptions()`
  */
@@ -213,14 +215,15 @@ type CompassData = {
   "ifdef" : "BANGLEJS",
   "typescript" : "on(event: \"mag\", callback: (xyz: CompassData) => void): void;"
 }
-Magnetometer/Compass data available with `{x,y,z,dx,dy,dz,heading}` object as a parameter
+Magnetometer/Compass data available with `{x,y,z,dx,dy,dz,heading}` object as a
+parameter
 
 * `x/y/z` raw x,y,z magnetometer readings
 * `dx/dy/dz` readings based on calibration since magnetometer turned on
-* `heading` in degrees based on calibrated readings (will be NaN if magnetometer hasn't been rotated around 360 degrees)
+* `heading` in degrees based on calibrated readings (will be NaN if magnetometer
+  hasn't been rotated around 360 degrees)
 
-To get this event you must turn the compass on
-with `Bangle.setCompassPower(1)`.
+To get this event you must turn the compass on with `Bangle.setCompassPower(1)`.
 
 You can also retrieve the most recent reading with `Bangle.getCompass()`.
  */
@@ -237,8 +240,7 @@ You can also retrieve the most recent reading with `Bangle.getCompass()`.
 }
 Raw NMEA GPS / u-blox data messages received as a string
 
-To get this event you must turn the GPS on
-with `Bangle.setGPSPower(1)`.
+To get this event you must turn the GPS on with `Bangle.setGPSPower(1)`.
  */
 /*TYPESCRIPT
 type GPSFix = {
@@ -278,13 +280,12 @@ GPS data, as an object. Contains:
 
 If a value such as `lat` is not known because there is no fix, it'll be `NaN`.
 
-`hdop` is a value from the GPS receiver that gives a rough idea of accuracy
-of lat/lon based on the geometry of the satellites in range. Multiply by 5 to
-get a value in meters. This is just a ballpark estimation and should
-not be considered remotely accurate.
+`hdop` is a value from the GPS receiver that gives a rough idea of accuracy of
+lat/lon based on the geometry of the satellites in range. Multiply by 5 to get a
+value in meters. This is just a ballpark estimation and should not be considered
+remotely accurate.
 
-To get this event you must turn the GPS on
-with `Bangle.setGPSPower(1)`.
+To get this event you must turn the GPS on with `Bangle.setGPSPower(1)`.
  */
 /*JSON{
   "type" : "event",
@@ -303,8 +304,8 @@ Heat rate data, as an object. Contains:
 }
 ```
 
-To get this event you must turn the heart rate monitor on
-with `Bangle.setHRMPower(1)`.
+To get this event you must turn the heart rate monitor on with
+`Bangle.setHRMPower(1)`.
  */
 /*JSON{
   "type" : "event",
@@ -341,7 +342,8 @@ type PressureData = {
   "ifdef" : "BANGLEJS",
   "typescript" : "on(event: \"pressure\", callback: (e: PressureData) => void): void;"
 }
-When `Bangle.setBarometerPower(true)` is called, this event is fired containing barometer readings.
+When `Bangle.setBarometerPower(true)` is called, this event is fired containing
+barometer readings.
 
 Same format as `Bangle.getPressure()`
 */
@@ -352,7 +354,8 @@ Same format as `Bangle.getPressure()`
   "params" : [["on","bool","`true` if screen is on"]],
   "ifdef" : "BANGLEJS"
 }
-Has the screen been turned on or off? Can be used to stop tasks that are no longer useful if nothing is displayed.  Also see `Bangle.isLCDOn()`
+Has the screen been turned on or off? Can be used to stop tasks that are no
+longer useful if nothing is displayed. Also see `Bangle.isLCDOn()`
 */
 /*JSON{
   "type" : "event",
@@ -374,9 +377,11 @@ type TapAxis = -2 | -1 | 0 | 1 | 2;
   "ifdef" : "BANGLEJS",
   "typescript" : "on(event: \"tap\", callback: (data: { dir: \"left\" | \"right\" | \"top\" | \"bottom\" | \"front\" | \"back\", double: boolean, x: TapAxis, y: TapAxis, z: TapAxis }) => void): void;"
 }
-If the watch is tapped, this event contains information on the way it was tapped.
+If the watch is tapped, this event contains information on the way it was
+tapped.
 
-`dir` reports the side of the watch that was tapped (not the direction it was tapped in).
+`dir` reports the side of the watch that was tapped (not the direction it was
+tapped in).
 
 ```
 {
@@ -406,11 +411,11 @@ Emitted when a 'gesture' (fast movement) is detected
   "ifdef" : "BANGLEJS",
   "typescript" : "on(event: \"aiGesture\", callback: (gesture: string | undefined, weights: number[]) => void): void;"
 }
-Emitted when a 'gesture' (fast movement) is detected, and a Tensorflow model is in
-storage in the `".tfmodel"` file.
+Emitted when a 'gesture' (fast movement) is detected, and a Tensorflow model is
+in storage in the `".tfmodel"` file.
 
-If a `".tfnames"` file is specified as a comma-separated list of names, it will be used
-to decode `gesture` from a number into a string.
+If a `".tfnames"` file is specified as a comma-separated list of names, it will
+be used to decode `gesture` from a number into a string.
 */
 /*TYPESCRIPT
 type SwipeCallback = (directionLR: -1 | 0 | 1, directionUD?: -1 | 0 | 1) => void;
@@ -424,9 +429,11 @@ type SwipeCallback = (directionLR: -1 | 0 | 1, directionUD?: -1 | 0 | 1) => void
   "ifdef" : "BANGLEJS",
   "typescript" : "on(event: \"swipe\", callback: SwipeCallback): void;"
 }
-Emitted when a swipe on the touchscreen is detected (a movement from left->right, right->left, down->up or up->down) 
+Emitted when a swipe on the touchscreen is detected (a movement from
+left->right, right->left, down->up or up->down)
 
-Bangle.js 1 is only capable of detecting left/right swipes as it only contains a 2 zone touchscreen.
+Bangle.js 1 is only capable of detecting left/right swipes as it only contains a
+2 zone touchscreen.
 */
 /*TYPESCRIPT
 type TouchCallback = (button: number, xy?: { x: number, y: number }) => void;
@@ -463,11 +470,11 @@ type DragCallback = (event: {
 }
 Emitted when the touchscreen is dragged or released
 
-The touchscreen extends past the edge of the screen and while
-`x` and `y` coordinates are arranged such that they align with
-the LCD's pixels, if your finger goes towards the edge of the
-screen, `x` and `y` could end up larger than 175 (the screen's maximum pixel coordinates)
-or smaller than 0. Coordinates from the `touch` event are clipped.
+The touchscreen extends past the edge of the screen and while `x` and `y`
+coordinates are arranged such that they align with the LCD's pixels, if your
+finger goes towards the edge of the screen, `x` and `y` could end up larger than
+175 (the screen's maximum pixel coordinates) or smaller than 0. Coordinates from
+the `touch` event are clipped.
 */
 /*JSON{
   "type" : "event",
@@ -477,10 +484,12 @@ or smaller than 0. Coordinates from the `touch` event are clipped.
   "ifdef" : "BANGLEJS2",
   "typescript" : "on(event: \"stroke\", callback: (event: { xy: Uint8Array, stroke?: string }) => void): void;"
 }
-Emitted when the touchscreen is dragged for a large enough distance to count as a gesture.
+Emitted when the touchscreen is dragged for a large enough distance to count as
+a gesture.
 
-If Bangle.strokes is defined and populated with data from `Unistroke.new`, the `event` argument will also
-contain a `stroke` field containing the most closely matching stroke name.
+If Bangle.strokes is defined and populated with data from `Unistroke.new`, the
+`event` argument will also contain a `stroke` field containing the most closely
+matching stroke name.
 
 For example:
 
@@ -1820,13 +1829,12 @@ static void jswrap_banglejs_setLCDPowerBacklight(bool isOn) {
 }
 This function can be used to turn Bangle.js's LCD off or on.
 
-This function resets the Bangle's 'activity timer' (like
-pressing a button or the screen would) so after a time period
-of inactivity set by `Bangle.setLCDTimeout` the screen will
-turn off.
+This function resets the Bangle's 'activity timer' (like pressing a button or
+the screen would) so after a time period of inactivity set by
+`Bangle.setLCDTimeout` the screen will turn off.
 
-If you want to keep the screen on permanently (until apps
-are changed) you can do:
+If you want to keep the screen on permanently (until apps are changed) you can
+do:
 
 ```
 Bangle.setLCDTimeout(0); // turn off the timeout
@@ -1834,8 +1842,8 @@ Bangle.setLCDPower(1); // keep screen on
 ```
 
 
-**When on full, the LCD draws roughly 40mA.** You can adjust
-When brightness using `Bangle.setLCDBrightness`.
+**When on full, the LCD draws roughly 40mA.** You can adjust When brightness
+using `Bangle.setLCDBrightness`.
 */
 void jswrap_banglejs_setLCDPower(bool isOn) {
 #ifdef ESPR_BACKLIGHT_FADE
@@ -1876,9 +1884,9 @@ void jswrap_banglejs_setLCDPower(bool isOn) {
 This function can be used to adjust the brightness of Bangle.js's display, and
 hence prolong its battery life.
 
-Due to hardware design constraints, software PWM has to be used which
-means that the display may flicker slightly when Bluetooth is active
-and the display is not at full power.
+Due to hardware design constraints, software PWM has to be used which means that
+the display may flicker slightly when Bluetooth is active and the display is not
+at full power.
 
 **Power consumption**
 
@@ -1920,12 +1928,23 @@ This function can be used to change the way graphics is handled on Bangle.js.
 
 Available options for `Bangle.setLCDMode` are:
 
-* `Bangle.setLCDMode()` or `Bangle.setLCDMode("direct")` (the default) - The drawable area is 240x240 16 bit. Unbuffered, so draw calls take effect immediately. Terminal and vertical scrolling work (horizontal scrolling doesn't).
-* `Bangle.setLCDMode("doublebuffered")` - The drawable area is 240x160 16 bit, terminal and scrolling will not work. `g.flip()` must be called for draw operations to take effect.
-* `Bangle.setLCDMode("120x120")` - The drawable area is 120x120 8 bit, `g.getPixel`, terminal, and full scrolling work. Uses an offscreen buffer stored on Bangle.js, `g.flip()` must be called for draw operations to take effect.
-* `Bangle.setLCDMode("80x80")` - The drawable area is 80x80 8 bit, `g.getPixel`, terminal, and full scrolling work. Uses an offscreen buffer stored on Bangle.js, `g.flip()` must be called for draw operations to take effect.
+* `Bangle.setLCDMode()` or `Bangle.setLCDMode("direct")` (the default) - The
+  drawable area is 240x240 16 bit. Unbuffered, so draw calls take effect
+  immediately. Terminal and vertical scrolling work (horizontal scrolling
+  doesn't).
+* `Bangle.setLCDMode("doublebuffered")` - The drawable area is 240x160 16 bit,
+  terminal and scrolling will not work. `g.flip()` must be called for draw
+  operations to take effect.
+* `Bangle.setLCDMode("120x120")` - The drawable area is 120x120 8 bit,
+  `g.getPixel`, terminal, and full scrolling work. Uses an offscreen buffer
+  stored on Bangle.js, `g.flip()` must be called for draw operations to take
+  effect.
+* `Bangle.setLCDMode("80x80")` - The drawable area is 80x80 8 bit, `g.getPixel`,
+  terminal, and full scrolling work. Uses an offscreen buffer stored on
+  Bangle.js, `g.flip()` must be called for draw operations to take effect.
 
-You can also call `Bangle.setLCDMode()` to return to normal, unbuffered `"direct"` mode.
+You can also call `Bangle.setLCDMode()` to return to normal, unbuffered
+`"direct"` mode.
 */
 void jswrap_banglejs_setLCDMode(JsVar *mode) {
 #ifdef LCD_CONTROLLER_ST7789_8BIT
@@ -2065,11 +2084,16 @@ void jswrap_banglejs_setLCDOffset(int y) {
 }
 This function can be used to turn Bangle.js's LCD power saving on or off.
 
-With power saving off, the display will remain in the state you set it with `Bangle.setLCDPower`.
+With power saving off, the display will remain in the state you set it with
+`Bangle.setLCDPower`.
 
-With power saving on, the display will turn on if a button is pressed, the watch is turned face up, or the screen is updated (see `Bangle.setOptions` for configuration). It'll turn off automatically after the given timeout.
+With power saving on, the display will turn on if a button is pressed, the watch
+is turned face up, or the screen is updated (see `Bangle.setOptions` for
+configuration). It'll turn off automatically after the given timeout.
 
-**Note:** This function also sets the Backlight and Lock timeout (the time at which the touchscreen/buttons start being ignored). To set both separately, use `Bangle.setOptions`
+**Note:** This function also sets the Backlight and Lock timeout (the time at
+which the touchscreen/buttons start being ignored). To set both separately, use
+`Bangle.setOptions`
 */
 void jswrap_banglejs_setLCDTimeout(JsVarFloat timeout) {
   if (!isfinite(timeout))
@@ -2092,11 +2116,13 @@ void jswrap_banglejs_setLCDTimeout(JsVarFloat timeout) {
     ],
     "ifdef" : "BANGLEJS"
 }
-Set how often the watch should poll for new acceleration/gyro data and kick the Watchdog timer. It isn't
-recommended that you make this interval much larger than 1000ms, but values up to 4000ms are allowed.
+Set how often the watch should poll for new acceleration/gyro data and kick the
+Watchdog timer. It isn't recommended that you make this interval much larger
+than 1000ms, but values up to 4000ms are allowed.
 
-Calling this will set `Bangle.setOptions({powerSave: false})` - disabling the dynamic adjustment of
-poll interval to save battery power when Bangle.js is stationary.
+Calling this will set `Bangle.setOptions({powerSave: false})` - disabling the
+dynamic adjustment of poll interval to save battery power when Bangle.js is
+stationary.
 */
 void jswrap_banglejs_setPollInterval(JsVarFloat interval) {
   if (!isfinite(interval) || interval<10 || interval>ACCEL_POLL_INTERVAL_MAX) {
@@ -2142,28 +2168,50 @@ type BangleOptions = {
 Set internal options used for gestures, etc...
 
 * `wakeOnBTN1` should the LCD turn on when BTN1 is pressed? default = `true`
-* `wakeOnBTN2` (Bangle.js 1) should the LCD turn on when BTN2 is pressed? default = `true`
-* `wakeOnBTN3` (Bangle.js 1) should the LCD turn on when BTN3 is pressed? default = `true`
-* `wakeOnFaceUp` should the LCD turn on when the watch is turned face up? default = `false`
-* `wakeOnTouch` should the LCD turn on when the touchscreen is pressed? default = `false`
-* `wakeOnTwist` should the LCD turn on when the watch is twisted? default = `true`
-* `twistThreshold`  How much acceleration to register a twist of the watch strap? Can be negative for opposite direction. default = `800`
-* `twistMaxY` Maximum acceleration in Y to trigger a twist (low Y means watch is facing the right way up). default = `-800`
-* `twistTimeout`  How little time (in ms) must a twist take from low->high acceleration? default = `1000`
-* `gestureStartThresh` how big a difference before we consider a gesture started? default = `sqr(800)`
-* `gestureEndThresh` how small a difference before we consider a gesture ended? default = `sqr(2000)`
-* `gestureInactiveCount` how many samples do we keep after a gesture has ended? default = `4`
-* `gestureMinLength` how many samples must a gesture have before we notify about it? default = `10`
-* `powerSave` after a minute of not being moved, Bangle.js will change the accelerometer poll interval down to 800ms (10x accelerometer samples).
-   On movement it'll be raised to the default 80ms. If `Bangle.setPollInterval` is used this is disabled, and for it to work the poll interval
-   must be either 80ms or 800ms. default = `true`. Setting `powerSave:false` will disable this automatic power saving, but will **not** change
-   the poll interval from its current value. If you desire a specific interval (e.g. the default 80ms) you must set it manually with `Bangle.setPollInterval(80)`
-   after setting `powerSave:false`.
+* `wakeOnBTN2` (Bangle.js 1) should the LCD turn on when BTN2 is pressed?
+  default = `true`
+* `wakeOnBTN3` (Bangle.js 1) should the LCD turn on when BTN3 is pressed?
+  default = `true`
+* `wakeOnFaceUp` should the LCD turn on when the watch is turned face up?
+  default = `false`
+* `wakeOnTouch` should the LCD turn on when the touchscreen is pressed? default
+  = `false`
+* `wakeOnTwist` should the LCD turn on when the watch is twisted? default =
+  `true`
+* `twistThreshold` How much acceleration to register a twist of the watch strap?
+  Can be negative for opposite direction. default = `800`
+* `twistMaxY` Maximum acceleration in Y to trigger a twist (low Y means watch is
+  facing the right way up). default = `-800`
+* `twistTimeout` How little time (in ms) must a twist take from low->high
+  acceleration? default = `1000`
+* `gestureStartThresh` how big a difference before we consider a gesture
+  started? default = `sqr(800)`
+* `gestureEndThresh` how small a difference before we consider a gesture ended?
+  default = `sqr(2000)`
+* `gestureInactiveCount` how many samples do we keep after a gesture has ended?
+  default = `4`
+* `gestureMinLength` how many samples must a gesture have before we notify about
+  it? default = `10`
+* `powerSave` after a minute of not being moved, Bangle.js will change the
+   accelerometer poll interval down to 800ms (10x accelerometer samples). On
+   movement it'll be raised to the default 80ms. If `Bangle.setPollInterval` is
+   used this is disabled, and for it to work the poll interval must be either
+   80ms or 800ms. default = `true`. Setting `powerSave:false` will disable this
+   automatic power saving, but will **not** change the poll interval from its
+   current value. If you desire a specific interval (e.g. the default 80ms) you
+   must set it manually with `Bangle.setPollInterval(80)` after setting
+   `powerSave:false`.
 * `lockTimeout` how many milliseconds before the screen locks
 * `lcdPowerTimeout` how many milliseconds before the screen turns off
-* `backlightTimeout` how many milliseconds before the screen's backlight turns off
-* `hrmPollInterval` set the requested poll interval (in milliseconds) for the heart rate monitor. On Bangle.js 2 only 10,20,40,80,160,200 ms are supported, and polling rate may not be exact. The algorithm's filtering is tuned for 20-40ms poll intervals, so higher/lower intervals may effect the reliability of the BPM reading.
-* `seaLevelPressure` (Bangle.js 2) Normally 1013.25 millibars - this is used for calculating altitude with the pressure sensor
+* `backlightTimeout` how many milliseconds before the screen's backlight turns
+  off
+* `hrmPollInterval` set the requested poll interval (in milliseconds) for the
+  heart rate monitor. On Bangle.js 2 only 10,20,40,80,160,200 ms are supported,
+  and polling rate may not be exact. The algorithm's filtering is tuned for
+  20-40ms poll intervals, so higher/lower intervals may effect the reliability
+  of the BPM reading.
+* `seaLevelPressure` (Bangle.js 2) Normally 1013.25 millibars - this is used for
+  calculating altitude with the pressure sensor
 
 Where accelerations are used they are in internal units, where `8192 = 1g`
 
@@ -2274,8 +2322,8 @@ int jswrap_banglejs_isLCDOn() {
     ],
     "ifdef" : "BANGLEJS"
 }
-This function can be used to lock or unlock Bangle.js
-(e.g. whether buttons and touchscreen work or not)
+This function can be used to lock or unlock Bangle.js (e.g. whether buttons and
+touchscreen work or not)
 */
 void jswrap_banglejs_setLocked(bool isLocked) {
 #if defined(TOUCH_I2C)
@@ -2675,8 +2723,8 @@ void jswrap_banglejs_resetCompass() {
     "#if" : "defined(DTNO1_F5) || defined(BANGLEJS_Q3) || defined(DICKENS)",
     "typescript" : "setBarometerPower(isOn: boolean, appID: string): boolean;"
 }
-Set the power to the barometer IC. Once enabled, `Bangle.pressure` events
-are fired each time a new barometer reading is available.
+Set the power to the barometer IC. Once enabled, `Bangle.pressure` events are
+fired each time a new barometer reading is available.
 
 When on, the barometer draws roughly 50uA
 */
@@ -2806,16 +2854,17 @@ void jswrap_banglejs_setStepCount(JsVarInt count) {
     "ifdef" : "BANGLEJS",
     "typescript" : "getCompass(): CompassData;"
 }
-Get the most recent Magnetometer/Compass reading. Data is in the same format as the `Bangle.on('mag',` event.
+Get the most recent Magnetometer/Compass reading. Data is in the same format as
+the `Bangle.on('mag',` event.
 
 Returns an `{x,y,z,dx,dy,dz,heading}` object
 
 * `x/y/z` raw x,y,z magnetometer readings
 * `dx/dy/dz` readings based on calibration since magnetometer turned on
-* `heading` in degrees based on calibrated readings (will be NaN if magnetometer hasn't been rotated around 360 degrees)
+* `heading` in degrees based on calibrated readings (will be NaN if magnetometer
+  hasn't been rotated around 360 degrees)
 
-To get this event you must turn the compass on
-with `Bangle.setCompassPower(1)`.*/
+To get this event you must turn the compass on with `Bangle.setCompassPower(1)`.*/
 JsVar *jswrap_banglejs_getCompass() {
 #ifdef MAG_I2C
   JsVar *o = jsvNewObject();
@@ -2854,12 +2903,14 @@ JsVar *jswrap_banglejs_getCompass() {
     "ifdef" : "BANGLEJS",
     "typescript" : "getAccel(): AccelData & { td: number };"
 }
-Get the most recent accelerometer reading. Data is in the same format as the `Bangle.on('accel',` event.
+Get the most recent accelerometer reading. Data is in the same format as the
+`Bangle.on('accel',` event.
 
 * `x` is X axis (left-right) in `g`
 * `y` is Y axis (up-down) in `g`
 * `z` is Z axis (in-out) in `g`
-* `diff` is difference between this and the last reading in `g` (calculated by comparing vectors, not magnitudes)
+* `diff` is difference between this and the last reading in `g` (calculated by
+  comparing vectors, not magnitudes)
 * `td` is the elapsed
 * `mag` is the magnitude of the acceleration in `g`
 */
@@ -2890,14 +2941,16 @@ JsVar *jswrap_banglejs_getAccel() {
 
 `range` is one of:
 
-* `undefined` or `'current'` - health data so far in the last 10 minutes is returned,
+* `undefined` or `'current'` - health data so far in the last 10 minutes is
+  returned,
 * `'last'` - health data during the last 10 minutes
 * `'day'` - the health data so far for the day
 
 
 `getHealthStatus` returns an object containing:
 
-* `movement` is the 32 bit sum of all `acc.diff` readings since power on (and rolls over). It is the difference in accelerometer values as `g*8192`
+* `movement` is the 32 bit sum of all `acc.diff` readings since power on (and
+  rolls over). It is the difference in accelerometer values as `g*8192`
 * `steps` is the number of steps during this period
 * `bpm` the best BPM reading from HRM sensor during this period
 * `bpmConfidence` best BPM confidence (0-100%) during this period
@@ -4031,8 +4084,8 @@ bool jswrap_banglejs_gps_character(char ch) {
     "ifdef" : "BANGLEJS"
 }
 Feature flag - If true, this Bangle.js firmware reads `setting.json` and
-modifies beep & buzz behaviour accordingly (the bootloader
-doesn't need to do it).
+modifies beep & buzz behaviour accordingly (the bootloader doesn't need to do
+it).
 */
 
 // TODO Improve TypeScript declaration
@@ -4120,7 +4173,8 @@ void jswrap_banglejs_accelWr(JsVarInt reg, JsVarInt data) {
 }
 Reads a register from the accelerometer
 
-**Note:** On Espruino 2v06 and before this function only returns a number (`cnt` is ignored).
+**Note:** On Espruino 2v06 and before this function only returns a number (`cnt`
+is ignored).
 */
 
 
@@ -4304,12 +4358,12 @@ void jswrap_banglejs_ioWr(JsVarInt mask, bool on) {
     "#if" : "defined(DTNO1_F5) || defined(BANGLEJS_Q3) || defined(DICKENS)",
     "typescript" : "getPressure(): PressureData;"
 }
-Read temperature, pressure and altitude data. A promise is returned
-which will be resolved with `{temperature, pressure, altitude}`.
+Read temperature, pressure and altitude data. A promise is returned which will
+be resolved with `{temperature, pressure, altitude}`.
 
-If the Barometer has been turned on with `Bangle.setBarometerPower` then this will
-return almost immediately with the reading. If the Barometer is off, conversions take
-between 500-750ms.
+If the Barometer has been turned on with `Bangle.setBarometerPower` then this
+will return almost immediately with the reading. If the Barometer is off,
+conversions take between 500-750ms.
 
 Altitude assumes a sea-level pressure of 1013.25 hPa
 
@@ -4513,12 +4567,13 @@ JsVar *jswrap_banglejs_getPressure() {
     "ifdef" : "BANGLEJS",
     "typescript" : "project(latlong: { lat: number, lon: number }): { x: number, y: number };"
 }
-Perform a Spherical [Web Mercator projection](https://en.wikipedia.org/wiki/Web_Mercator_projection)
-of latitude and longitude into `x` and `y` coordinates, which are roughly
-equivalent to meters from `{lat:0,lon:0}`.
+Perform a Spherical [Web Mercator
+projection](https://en.wikipedia.org/wiki/Web_Mercator_projection) of latitude
+and longitude into `x` and `y` coordinates, which are roughly equivalent to
+meters from `{lat:0,lon:0}`.
 
-This is the formula used for most online mapping and is a good way
-to compare GPS coordinates to work out the distance between them.
+This is the formula used for most online mapping and is a good way to compare
+GPS coordinates to work out the distance between them.
 */
 JsVar *jswrap_banglejs_project(JsVar *latlong) {
   const double degToRad = PI / 180; // degree to radian conversion
@@ -4753,8 +4808,8 @@ void jswrap_banglejs_off() {
     "generate" : "jswrap_banglejs_softOff",
     "ifdef" : "BANGLEJS"
 }
-Turn Bangle.js (mostly) off, but keep the CPU in sleep
-mode until BTN1 is pressed to preserve the RTC (current time).
+Turn Bangle.js (mostly) off, but keep the CPU in sleep mode until BTN1 is
+pressed to preserve the RTC (current time).
 */
 void jswrap_banglejs_softOff() {
 #ifndef EMULATED
@@ -4941,11 +4996,11 @@ JsVar *jswrap_banglejs_getLogo() {
     "generate_js" : "libs/js/banglejs/Bangle_loadWidgets.min.js",
     "ifdef" : "BANGLEJS"
 }
-Load all widgets from flash Storage. Call this once at the beginning
-of your application if you want any on-screen widgets to be loaded.
+Load all widgets from flash Storage. Call this once at the beginning of your
+application if you want any on-screen widgets to be loaded.
 
-They will be loaded into a global `WIDGETS` array, and
-can be rendered with `Bangle.drawWidgets`.
+They will be loaded into a global `WIDGETS` array, and can be rendered with
+`Bangle.drawWidgets`.
 */
 /*JSON{
     "type" : "staticmethod",
@@ -4956,9 +5011,8 @@ can be rendered with `Bangle.drawWidgets`.
 }
 Draw any onscreen widgets that were loaded with `Bangle.loadWidgets()`.
 
-Widgets should redraw themselves when something changes - you'll only
-need to call drawWidgets if you decide to clear the entire screen
-with `g.clear()`.
+Widgets should redraw themselves when something changes - you'll only need to
+call drawWidgets if you decide to clear the entire screen with `g.clear()`.
 */
 /*JSON{
     "type" : "staticmethod", "class" : "Bangle", "name" : "drawWidgets", "patch":true,
@@ -4974,8 +5028,8 @@ with `g.clear()`.
     "generate_js" : "libs/js/banglejs/Bangle_showLauncher.min.js",
     "ifdef" : "BANGLEJS"
 }
-Load the Bangle.js app launcher, which will allow the user
-to select an application to launch.
+Load the Bangle.js app launcher, which will allow the user to select an
+application to launch.
 */
 
 /*JSON{
@@ -4995,8 +5049,8 @@ to select an application to launch.
 }
 Display a menu on the screen, and set up the buttons to navigate through it.
 
-Supply an object containing menu items. When an item is selected, the
-function it references will be executed. For example:
+Supply an object containing menu items. When an item is selected, the function
+it references will be executed. For example:
 
 ```
 var boolean = false;
@@ -5030,24 +5084,29 @@ var submenu = {
 E.showMenu(mainmenu);
 ```
 
-The menu will stay onscreen and active until explicitly removed,
-which you can do by calling `E.showMenu()` without arguments.
+The menu will stay onscreen and active until explicitly removed, which you can
+do by calling `E.showMenu()` without arguments.
 
 See http://www.espruino.com/graphical_menu for more detailed information.
 
 On Bangle.js there are a few additions over the standard `graphical_menu`:
 
 * The options object can contain:
-  * `back : function() { }` - add a 'back' button, with the function called when it is pressed
-  * (Bangle.js 2) `scroll : int` - an integer specifying how much the initial menu should be scrolled by
+  * `back : function() { }` - add a 'back' button, with the function called when
+    it is pressed
+  * (Bangle.js 2) `scroll : int` - an integer specifying how much the initial
+    menu should be scrolled by
 * The object returned by `E.showMenu` contains:
-  * (Bangle.js 2) `scroller` - the object returned by `E.showScroller` - `scroller.scroll` returns the amount the menu is currently scrolled by
+  * (Bangle.js 2) `scroller` - the object returned by `E.showScroller` -
+    `scroller.scroll` returns the amount the menu is currently scrolled by
 * In the object specified for editable numbers:
-  * (Bangle.js 2) the `format` function is called with `format(value)` in the main menu, `format(value,1)` when in a scrollable list, or `format(value,2)` when in a popup window.
+  * (Bangle.js 2) the `format` function is called with `format(value)` in the
+    main menu, `format(value,1)` when in a scrollable list, or `format(value,2)`
+    when in a popup window.
 
-You can also specify menu items as an array (rather than an Object). This can be useful
-if you have menu items with the same title, or you want to `push` menu items onto an
-array:
+You can also specify menu items as an array (rather than an Object). This can be
+useful if you have menu items with the same title, or you want to `push` menu
+items onto an array:
 
 ```
 var menu = [
@@ -5110,12 +5169,11 @@ E.showMessage("Lots of text will wrap automatically",{
     ]
 }
 
-Displays a full screen prompt on the screen, with the buttons
-requested (or `Yes` and `No` for defaults).
+Displays a full screen prompt on the screen, with the buttons requested (or
+`Yes` and `No` for defaults).
 
-When the button is pressed the promise is resolved with the
-requested values (for the `Yes` and `No` defaults, `true` and `false`
-are returned).
+When the button is pressed the promise is resolved with the requested values
+(for the `Yes` and `No` defaults, `true` and `false` are returned).
 
 ```
 E.showPrompt("Do you like fish?").then(function(v) {
@@ -5166,8 +5224,8 @@ The second `options` argument can contain:
       "showScroller(): void;"
     ]
 }
-Display a scrollable menu on the screen, and set up the buttons/touchscreen to navigate through it
-and select items.
+Display a scrollable menu on the screen, and set up the buttons/touchscreen to
+navigate through it and select items.
 
 Supply an object containing:
 
@@ -5264,11 +5322,12 @@ To remove the window, call `E.showAlert()` with no arguments.
     "ifdef" : "BANGLEJS", "no_docs":1
 }
 
-On most Espruino board there are LEDs, in which case `LED` will be an actual Pin.
+On most Espruino board there are LEDs, in which case `LED` will be an actual
+Pin.
 
-On Bangle.js there are no LEDs, so to remain compatible with example code that might
-expect an LED, this is an object that behaves like a pin, but which just displays
-a circle on the display
+On Bangle.js there are no LEDs, so to remain compatible with example code that
+might expect an LED, this is an object that behaves like a pin, but which just
+displays a circle on the display
 */
 /*JSON{
     "type" : "variable",
@@ -5278,11 +5337,12 @@ a circle on the display
     "ifdef" : "BANGLEJS", "no_docs":1
 }
 
-On most Espruino board there are LEDs, in which case `LED1` will be an actual Pin.
+On most Espruino board there are LEDs, in which case `LED1` will be an actual
+Pin.
 
-On Bangle.js there are no LEDs, so to remain compatible with example code that might
-expect an LED, this is an object that behaves like a pin, but which just displays
-a circle on the display
+On Bangle.js there are no LEDs, so to remain compatible with example code that
+might expect an LED, this is an object that behaves like a pin, but which just
+displays a circle on the display
 */
 /*JSON{
     "type" : "variable",
@@ -5292,11 +5352,12 @@ a circle on the display
     "ifdef" : "BANGLEJS", "no_docs":1
 }
 
-On most Espruino board there are LEDs, in which case `LED2` will be an actual Pin.
+On most Espruino board there are LEDs, in which case `LED2` will be an actual
+Pin.
 
-On Bangle.js there are no LEDs, so to remain compatible with example code that might
-expect an LED, this is an object that behaves like a pin, but which just displays
-a circle on the display
+On Bangle.js there are no LEDs, so to remain compatible with example code that
+might expect an LED, this is an object that behaves like a pin, but which just
+displays a circle on the display
 */
 
 /*JSON{
@@ -5311,30 +5372,39 @@ a circle on the display
     "ifdef" : "BANGLEJS",
     "typescript" : "setUI(type?: \"updown\" | \"leftright\" | \"clock\" | \"clockupdown\" | { mode: \"custom\"; back?: () => void; touch?: TouchCallback; swipe?: SwipeCallback; drag?: DragCallback; btn?: (n: number) => void, clock?: boolean }, callback?: (direction?: -1 | 1) => void): void;"
 }
-This puts Bangle.js into the specified UI input mode, and calls the callback provided when there is user input.
+This puts Bangle.js into the specified UI input mode, and calls the callback
+provided when there is user input.
 
 Currently supported interface types are:
 
-* 'updown' - UI input with upwards motion `cb(-1)`, downwards motion `cb(1)`, and select `cb()`
+* 'updown' - UI input with upwards motion `cb(-1)`, downwards motion `cb(1)`,
+  and select `cb()`
   * Bangle.js 1 uses BTN1/3 for up/down and BTN2 for select
   * Bangle.js 2 uses touchscreen swipe up/down and tap
-* 'leftright' - UI input with left motion `cb(-1)`, right motion `cb(1)`, and select `cb()`
+* 'leftright' - UI input with left motion `cb(-1)`, right motion `cb(1)`, and
+  select `cb()`
   * Bangle.js 1 uses BTN1/3 for left/right and BTN2 for select
   * Bangle.js 2 uses touchscreen swipe left/right and tap/BTN1 for select
-* 'clock' - called for clocks. Sets `Bangle.CLOCK=1` and allows a button to start the launcher
+* 'clock' - called for clocks. Sets `Bangle.CLOCK=1` and allows a button to
+  start the launcher
   * Bangle.js 1 BTN2 starts the launcher
   * Bangle.js 2 BTN1 starts the launcher
-* 'clockupdown' - called for clocks. Sets `Bangle.CLOCK=1`, allows a button to start the launcher, but also provides up/down functionality
+* 'clockupdown' - called for clocks. Sets `Bangle.CLOCK=1`, allows a button to
+  start the launcher, but also provides up/down functionality
   * Bangle.js 1 BTN2 starts the launcher, BTN1/BTN3 call `cb(-1)` and `cb(1)`
-  * Bangle.js 2 BTN1 starts the launcher, touchscreen tap in top/bottom right hand side calls `cb(-1)` and `cb(1)`
-* `{mode:"custom", ...}` allows you to specify custom handlers for different interactions. See below.
+  * Bangle.js 2 BTN1 starts the launcher, touchscreen tap in top/bottom right
+    hand side calls `cb(-1)` and `cb(1)`
+* `{mode:"custom", ...}` allows you to specify custom handlers for different
+  interactions. See below.
 * `undefined` removes all user interaction code
 
-While you could use setWatch/etc manually, the benefit here is that you don't end up with multiple `setWatch` instances, and
-the actual input method (touch, or buttons) is implemented dependent on the watch (Bangle.js 1 or 2)
+While you could use setWatch/etc manually, the benefit here is that you don't
+end up with multiple `setWatch` instances, and the actual input method (touch,
+or buttons) is implemented dependent on the watch (Bangle.js 1 or 2)
 
-**Note:** You can override this function in boot code to change the interaction mode with the watch. For instance
-you could make all clocks start the launcher with a swipe by using:
+**Note:** You can override this function in boot code to change the interaction
+mode with the watch. For instance you could make all clocks start the launcher
+with a swipe by using:
 
 ```
 (function() {
@@ -5349,7 +5419,8 @@ you could make all clocks start the launcher with a swipe by using:
 })();
 ```
 
-The first argument can also be an object, in which case more options can be specified:
+The first argument can also be an object, in which case more options can be
+specified:
 
 ```
 Bangle.setUI({
@@ -5378,12 +5449,10 @@ Bangle.setUI({
     "#if" : "defined(BANGLEJS_Q3) || defined(EMULATED)"
 }
 
-Erase all storage and reload it with the default
-contents.
+Erase all storage and reload it with the default contents.
 
-This is only available on Bangle.js 2.0. On Bangle.js 1.0
-you need to use `Install Default Apps` under the `More...` tab
-of http://banglejs.com/apps
+This is only available on Bangle.js 2.0. On Bangle.js 1.0 you need to use
+`Install Default Apps` under the `More...` tab of http://banglejs.com/apps
 */
 extern void ble_app_error_handler(uint32_t error_code, uint32_t line_num, const uint8_t * p_file_name);
 void jswrap_banglejs_factoryReset() {
@@ -5400,8 +5469,7 @@ void jswrap_banglejs_factoryReset() {
     "ifdef" : "BANGLEJS",
     "typescript" : "appRect: { x: number, y: number, w: number, h: number, x2: number, y2: number };"
 }
-Returns the rectangle on the screen that is currently
-reserved for the app.
+Returns the rectangle on the screen that is currently reserved for the app.
 */
 JsVar *jswrap_banglejs_appRect() {
   JsVar *o = jsvNewObject();

--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -348,7 +348,8 @@ void jswrap_ble_dumpBluetoothInitialisation(vcbprintf_callback user_callback, vo
 }
 The NRF class is for controlling functionality of the Nordic nRF51/nRF52 chips.
 
-Most functionality is related to Bluetooth Low Energy, however there are also some functions related to NFC that apply to NRF52-based devices.
+Most functionality is related to Bluetooth Low Energy, however there are also
+some functions related to NFC that apply to NRF52-based devices.
 
 */
 
@@ -363,7 +364,8 @@ Most functionality is related to Bluetooth Low Energy, however there are also so
     ["addr","JsVar","The address of the device that has connected"]
   ]
 }
-Called when a host device connects to Espruino. The first argument contains the address.
+Called when a host device connects to Espruino. The first argument contains the
+address.
  */
 /*JSON{
   "type" : "event",
@@ -397,10 +399,9 @@ See Nordic's `ble_gap_evt_auth_status_t` structure for more information.
   "name" : "HID",
   "#if" : "defined(NRF52_SERIES)"
 }
-Called with a single byte value when Espruino is set up as
-a HID device and the computer it is connected to sends a
-HID report back to Espruino. This is usually used for handling
-indications such as the Caps Lock LED.
+Called with a single byte value when Espruino is set up as a HID device and the
+computer it is connected to sends a HID report back to Espruino. This is usually
+used for handling indications such as the Caps Lock LED.
  */
 
 /*JSON{
@@ -446,9 +447,9 @@ Called when an NFC field is no longer detected
   ],
   "#if" : "defined(NRF52_SERIES) && defined(USE_NFC)"
 }
-When NFC is started with `NRF.nfcStart`, this is fired
-when NFC data is received. It doesn't get called if
-NFC is started with `NRF.nfcURL` or `NRF.nfcRaw`
+When NFC is started with `NRF.nfcStart`, this is fired when NFC data is
+received. It doesn't get called if NFC is started with `NRF.nfcURL` or
+`NRF.nfcRaw`
  */
 /*JSON{
   "type" : "event",
@@ -461,8 +462,8 @@ NFC is started with `NRF.nfcURL` or `NRF.nfcRaw`
 }
 Called when the device gets disconnected.
 
-To connect and then print `Disconnected` when the device is
-disconnected, just do the following:
+To connect and then print `Disconnected` when the device is disconnected, just
+do the following:
 
 ```
 var gatt;
@@ -490,7 +491,8 @@ NRF.requestDevice(...).then(function(device) {
   "name" : "characteristicvaluechanged",
   "ifdef" : "NRF52_SERIES"
 }
-Called when a characteristic's value changes, *after* `BluetoothRemoteGATTCharacteristic.startNotifications` has been called.
+Called when a characteristic's value changes, *after*
+`BluetoothRemoteGATTCharacteristic.startNotifications` has been called.
 
 ```
   ...
@@ -503,8 +505,10 @@ Called when a characteristic's value changes, *after* `BluetoothRemoteGATTCharac
 }).then(...
 ```
 
-The first argument is of the form `{target : BluetoothRemoteGATTCharacteristic}`, and `BluetoothRemoteGATTCharacteristic.value`
-will then contain the new value (as a DataView).
+The first argument is of the form `{target :
+BluetoothRemoteGATTCharacteristic}`, and
+`BluetoothRemoteGATTCharacteristic.value` will then contain the new value (as a
+DataView).
  */
 
 /*JSON{
@@ -513,7 +517,8 @@ will then contain the new value (as a DataView).
   "instanceof" : "Serial",
   "ifdef" : "BLUETOOTH"
 }
-The Bluetooth Serial port - used when data is sent or received over Bluetooth Smart on nRF51/nRF52 chips.
+The Bluetooth Serial port - used when data is sent or received over Bluetooth
+Smart on nRF51/nRF52 chips.
  */
 
 /*JSON{
@@ -538,9 +543,9 @@ void jswrap_ble_disconnect() {
     "name" : "sleep",
     "generate" : "jswrap_ble_sleep"
 }
-Disable Bluetooth advertising and disconnect from any device that
-connected to Puck.js as a peripheral (this won't affect any devices
-that Puck.js initiated connections to).
+Disable Bluetooth advertising and disconnect from any device that connected to
+Puck.js as a peripheral (this won't affect any devices that Puck.js initiated
+connections to).
 
 This makes Puck.js undiscoverable, so it can't be connected to.
 
@@ -562,8 +567,8 @@ void jswrap_ble_sleep() {
     "name" : "wake",
     "generate" : "jswrap_ble_wake"
 }
-Enable Bluetooth advertising (this is enabled by default), which
-allows other devices to discover and connect to Puck.js.
+Enable Bluetooth advertising (this is enabled by default), which allows other
+devices to discover and connect to Puck.js.
 
 Use `NRF.sleep()` to disable advertising.
 */
@@ -581,13 +586,13 @@ void jswrap_ble_wake() {
       ["callback","JsVar","An optional function to be called while the softdevice is uninitialised. Use with caution - accessing console/bluetooth will almost certainly result in a crash."]
     ]
 }
-Restart the Bluetooth softdevice (if there is currently a BLE connection,
-it will queue a restart to be done when the connection closes).
+Restart the Bluetooth softdevice (if there is currently a BLE connection, it
+will queue a restart to be done when the connection closes).
 
-You shouldn't need to call this function in normal usage. However, Nordic's
-BLE softdevice has some settings that cannot be reset. For example there
-are only a certain number of unique UUIDs. Once these are all used the
-only option is to restart the softdevice to clear them all out.
+You shouldn't need to call this function in normal usage. However, Nordic's BLE
+softdevice has some settings that cannot be reset. For example there are only a
+certain number of unique UUIDs. Once these are all used the only option is to
+restart the softdevice to clear them all out.
 */
 void jswrap_ble_restart(JsVar *callback) {
   if (jsble_has_connection()) {
@@ -610,8 +615,8 @@ void jswrap_ble_restart(JsVar *callback) {
 }
 Get this device's default Bluetooth MAC address.
 
-For Puck.js, the last 5 characters of this (eg. `ee:ff`)
-are used in the device's advertised Bluetooth name.
+For Puck.js, the last 5 characters of this (eg. `ee:ff`) are used in the
+device's advertised Bluetooth name.
 */
 JsVar *jswrap_ble_getAddress() {
 #ifdef NRF5X
@@ -649,13 +654,14 @@ NRF.setAddress("ff:ee:dd:cc:bb:aa random");
 Addresses take the form:
 
 * `"ff:ee:dd:cc:bb:aa"` or `"ff:ee:dd:cc:bb:aa public"` for a public address
-* `"ff:ee:dd:cc:bb:aa random"` for a random static address (the default for Espruino)
+* `"ff:ee:dd:cc:bb:aa random"` for a random static address (the default for
+  Espruino)
 
-This may throw a `INVALID_BLE_ADDR` error if the upper two bits
-of the address don't match the address type.
+This may throw a `INVALID_BLE_ADDR` error if the upper two bits of the address
+don't match the address type.
 
-To change the address, Espruino must restart the softdevice. It will only do
-so when it is disconnected from other devices.
+To change the address, Espruino must restart the softdevice. It will only do so
+when it is disconnected from other devices.
 */
 void jswrap_ble_setAddress(JsVar *address) {
 #ifdef NRF52_SERIES
@@ -678,7 +684,8 @@ void jswrap_ble_setAddress(JsVar *address) {
     "generate" : "jswrap_ble_getBattery",
     "return" : ["float", "Battery level in volts" ]
 }
-Get the battery level in volts (the voltage that the NRF chip is running off of).
+Get the battery level in volts (the voltage that the NRF chip is running off
+of).
 
 This is the battery level of the device itself - it has nothing to with any
 device that might be connected.
@@ -699,8 +706,9 @@ JsVarFloat jswrap_ble_getBattery() {
 }
 Change the data that Espruino advertises.
 
-Data can be of the form `{ UUID : data_as_byte_array }`. The UUID should be
-a [Bluetooth Service ID](https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx).
+Data can be of the form `{ UUID : data_as_byte_array }`. The UUID should be a
+[Bluetooth Service
+ID](https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx).
 
 For example to return battery level at 95%, do:
 
@@ -729,11 +737,11 @@ NRF.setAdvertising({
 });
 ```
 
-Service UUIDs can also be supplied in the second argument of
-`NRF.setServices`, but those go in the scan response packet.
+Service UUIDs can also be supplied in the second argument of `NRF.setServices`,
+but those go in the scan response packet.
 
-You can also supply the raw advertising data in an array. For example
-to advertise as an Eddystone beacon:
+You can also supply the raw advertising data in an array. For example to
+advertise as an Eddystone beacon:
 
 ```
 NRF.setAdvertising([0x03,  // Length of Service List
@@ -749,18 +757,19 @@ NRF.setAdvertising([0x03,  // Length of Service List
     {interval:100});
 ```
 
-(However for Eddystone we'd advise that you use the [Espruino Eddystone library](/Puck.js+Eddystone))
+(However for Eddystone we'd advise that you use the [Espruino Eddystone
+library](/Puck.js+Eddystone))
 
 **Note:** When specifying data as an array, certain advertising options such as
 `discoverable` and `showName` won't have any effect.
 
-**Note:** The size of Bluetooth LE advertising packets is limited to 31 bytes. If
-you want to advertise more data, consider using an array for `data` (See below), or
-`NRF.setScanResponse`.
+**Note:** The size of Bluetooth LE advertising packets is limited to 31 bytes.
+If you want to advertise more data, consider using an array for `data` (See
+below), or `NRF.setScanResponse`.
 
-You can even specify an array of arrays or objects, in which case each advertising packet
-will be used in turn - for instance to make your device advertise battery level and its name
-as well as both Eddystone and iBeacon :
+You can even specify an array of arrays or objects, in which case each
+advertising packet will be used in turn - for instance to make your device
+advertise battery level and its name as well as both Eddystone and iBeacon :
 
 ```
 NRF.setAdvertising([
@@ -786,26 +795,26 @@ NRF.setAdvertising([
 }
 ```
 
-Setting `connectable` and `scannable` to false gives the lowest power consumption
-as the BLE radio doesn't have to listen after sending advertising.
+Setting `connectable` and `scannable` to false gives the lowest power
+consumption as the BLE radio doesn't have to listen after sending advertising.
 
-**NOTE:** Non-`connectable` advertising can't have an advertising interval less than 100ms
-according to the BLE spec.
+**NOTE:** Non-`connectable` advertising can't have an advertising interval less
+than 100ms according to the BLE spec.
 
-So for instance to set the name of Puck.js without advertising any
-other data you can just use the command:
+So for instance to set the name of Puck.js without advertising any other data
+you can just use the command:
 
 ```
 NRF.setAdvertising({},{name:"Hello"});
 ```
 
-You can also specify 'manufacturer data', which is another form of advertising data.
-We've registered the Manufacturer ID 0x0590 (as Pur3 Ltd) for use with *Official
-Espruino devices* - use it to advertise whatever data you'd like, but we'd recommend
-using JSON. 
+You can also specify 'manufacturer data', which is another form of advertising
+data. We've registered the Manufacturer ID 0x0590 (as Pur3 Ltd) for use with
+*Official Espruino devices* - use it to advertise whatever data you'd like, but
+we'd recommend using JSON.
 
-For example by not advertising a device name you can send up to 24 bytes of JSON on
-Espruino's manufacturer ID:
+For example by not advertising a device name you can send up to 24 bytes of JSON
+on Espruino's manufacturer ID:
 
 ```
 var data = {a:1,b:2};
@@ -816,16 +825,16 @@ NRF.setAdvertising({},{
 });
 ```
 
-If you're using [EspruinoHub](https://github.com/espruino/EspruinoHub) then it will
-automatically decode this into the folling MQTT topics:
+If you're using [EspruinoHub](https://github.com/espruino/EspruinoHub) then it
+will automatically decode this into the folling MQTT topics:
 
 * `/ble/advertise/ma:c_:_a:dd:re:ss/espruino` -> `{"a":10,"b":15}`
 * `/ble/advertise/ma:c_:_a:dd:re:ss/a` -> `1`
 * `/ble/advertise/ma:c_:_a:dd:re:ss/b` -> `2`
 
-Note that **you only have 24 characters available for JSON**, so try to use
-the shortest field names possible and avoid floating point values that can
-be very long when converted to a String.
+Note that **you only have 24 characters available for JSON**, so try to use the
+shortest field names possible and avoid floating point values that can be very
+long when converted to a String.
 */
 void jswrap_ble_setAdvertising(JsVar *data, JsVar *options) {
   uint32_t err_code = 0;
@@ -978,8 +987,8 @@ JsVar *jswrap_ble_getCurrentAdvertisingData() {
     ],
     "return" : ["JsVar", "An array containing the advertising data" ]
 }
-This is just like `NRF.setAdvertising`, except instead of advertising
-the data, it returns the packet that would be advertised as an array.
+This is just like `NRF.setAdvertising`, except instead of advertising the data,
+it returns the packet that would be advertised as an array.
 */
 JsVar *jswrap_ble_getAdvertisingData(JsVar *data, JsVar *options) {
   uint32_t err_code;
@@ -1118,7 +1127,8 @@ JsVar *jswrap_ble_getAdvertisingData(JsVar *data, JsVar *options) {
     ]
 }
 
-The raw scan response data should be supplied as an array. For example to return "Sample" for the device name:
+The raw scan response data should be supplied as an array. For example to return
+"Sample" for the device name:
 
 ```
 NRF.setScanResponse([0x07,  // Length of Data
@@ -1126,9 +1136,9 @@ NRF.setScanResponse([0x07,  // Length of Data
   'S', 'a', 'm', 'p', 'l', 'e']);
 ```
 
-**Note:** `NRF.setServices(..., {advertise:[ ... ]})` writes advertised
-services into the scan response - so you can't use both `advertise`
-and `NRF.setServices` or one will overwrite the other.
+**Note:** `NRF.setServices(..., {advertise:[ ... ]})` writes advertised services
+into the scan response - so you can't use both `advertise` and `NRF.setServices`
+or one will overwrite the other.
 */
 void jswrap_ble_setScanResponse(JsVar *data) {
   uint32_t err_code = 0;
@@ -1188,10 +1198,11 @@ void jswrap_ble_setScanResponse(JsVar *data) {
 
 Change the services and characteristics Espruino advertises.
 
-If you want to **change** the value of a characteristic, you need
-to use `NRF.updateServices()` instead
+If you want to **change** the value of a characteristic, you need to use
+`NRF.updateServices()` instead
 
-To expose some information on Characteristic `ABCD` on service `BCDE` you could do:
+To expose some information on Characteristic `ABCD` on service `BCDE` you could
+do:
 
 ```
 NRF.setServices({
@@ -1262,8 +1273,8 @@ NRF.setServices({
 });
 ```
 
-**Note:** UUIDs can be integers between `0` and `0xFFFF`, strings of
-the form `"ABCD"`, or strings of the form `"ABCDABCD-ABCD-ABCD-ABCD-ABCDABCDABCD"`
+**Note:** UUIDs can be integers between `0` and `0xFFFF`, strings of the form
+`"ABCD"`, or strings of the form `"ABCDABCD-ABCD-ABCD-ABCD-ABCDABCDABCD"`
 
 `options` can be of the form:
 
@@ -1278,14 +1289,14 @@ NRF.setServices(undefined, {
 ```
 
 To enable BLE HID, you must set `hid` to an array which is the BLE report
-descriptor. The easiest way to do this is to use the `ble_hid_controls`
-or `ble_hid_keyboard` modules.
+descriptor. The easiest way to do this is to use the `ble_hid_controls` or
+`ble_hid_keyboard` modules.
 
-**Note:** Just creating a service doesn't mean that the service will
-be advertised. It will only be available after a device connects. To
-advertise, specify the UUIDs you wish to advertise in the `advertise`
-field of the second `options` argument. For example this will create
-and advertise a heart rate service:
+**Note:** Just creating a service doesn't mean that the service will be
+advertised. It will only be available after a device connects. To advertise,
+specify the UUIDs you wish to advertise in the `advertise` field of the second
+`options` argument. For example this will create and advertise a heart rate
+service:
 
 ```
 NRF.setServices({
@@ -1300,22 +1311,23 @@ NRF.setServices({
 
 You may specify 128 bit UUIDs to advertise, however you may get a `DATA_SIZE`
 exception because there is insufficient space in the Bluetooth LE advertising
-packet for the 128 bit UART UUID as well as the UUID you specified. In this
-case you can add `uart:false` after the `advertise` element to disable the
-UART, however you then be unable to connect to Puck.js's console via Bluetooth.
+packet for the 128 bit UART UUID as well as the UUID you specified. In this case
+you can add `uart:false` after the `advertise` element to disable the UART,
+however you then be unable to connect to Puck.js's console via Bluetooth.
 
 If you absolutely require two or more 128 bit UUIDs then you will have to
 specify your own raw advertising data packets with `NRF.setAdvertising`
 
-**Note:** The services on Espruino can only be modified when there is
-no device connected to it as it requires a restart of the Bluetooth stack.
-**iOS devices will 'cache' the list of services** so apps like
-NRF Connect may incorrectly display the old services even after you 
-have modified them. To fix this, disable and re-enable Bluetooth on your
-iOS device, or use an Android device to run NRF Connect.
+**Note:** The services on Espruino can only be modified when there is no device
+connected to it as it requires a restart of the Bluetooth stack. **iOS devices
+will 'cache' the list of services** so apps like NRF Connect may incorrectly
+display the old services even after you have modified them. To fix this, disable
+and re-enable Bluetooth on your iOS device, or use an Android device to run NRF
+Connect.
 
-**Note:** Not all combinations of security configuration values are valid, the valid combinations are: encrypted,
-encrypted + mitm, lesc, signed, signed + mitm. See `NRF.setSecurity` for more information.
+**Note:** Not all combinations of security configuration values are valid, the
+valid combinations are: encrypted, encrypted + mitm, lesc, signed, signed +
+mitm. See `NRF.setSecurity` for more information.
 */
 void jswrap_ble_setServices(JsVar *data, JsVar *options) {
   if (!(jsvIsObject(data) || jsvIsUndefined(data))) {
@@ -1420,8 +1432,9 @@ void jswrap_ble_setServices(JsVar *data, JsVar *options) {
     ]
 }
 
-Update values for the services and characteristics Espruino advertises.
-Only services and characteristics previously declared using `NRF.setServices` are affected.
+Update values for the services and characteristics Espruino advertises. Only
+services and characteristics previously declared using `NRF.setServices` are
+affected.
 
 To update the '0xABCD' characteristic in the '0xBCDE' service:
 
@@ -1435,7 +1448,8 @@ NRF.updateServices({
 });
 ```
 
-You can also use 128 bit UUIDs, for example `"b7920001-3c1b-4b40-869f-3c0db9be80c6"`.
+You can also use 128 bit UUIDs, for example
+`"b7920001-3c1b-4b40-869f-3c0db9be80c6"`.
 
 To define a service and characteristic and then notify connected clients of a
 change to it when a button is pressed:
@@ -1462,13 +1476,15 @@ setWatch(function() {
 }, BTN, { repeat:true, edge:"rising", debounce: 50 });
 ```
 
-This only works if the characteristic was created with `notify: true` using `NRF.setServices`,
-otherwise the characteristic will be updated but no notification will be sent.
+This only works if the characteristic was created with `notify: true` using
+`NRF.setServices`, otherwise the characteristic will be updated but no
+notification will be sent.
 
 Also note that `maxLen` was specified. If it wasn't then the maximum length of
 the characteristic would have been 5 - the length of `"Hello"`.
 
-To indicate (i.e. notify with ACK) connected clients of a change to the '0xABCD' characteristic in the '0xBCDE' service:
+To indicate (i.e. notify with ACK) connected clients of a change to the '0xABCD'
+characteristic in the '0xBCDE' service:
 
 ```
 NRF.updateServices({
@@ -1481,8 +1497,9 @@ NRF.updateServices({
 });
 ```
 
-This only works if the characteristic was created with `indicate: true` using `NRF.setServices`,
-otherwise the characteristic will be updated but no notification will be sent.
+This only works if the characteristic was created with `indicate: true` using
+`NRF.setServices`, otherwise the characteristic will be updated but no
+notification will be sent.
 
 **Note:** See `NRF.setServices` for more information
 */
@@ -1721,8 +1738,8 @@ bool jswrap_ble_filter_device(JsVar *filters, JsVar *device) {
 }
 
 Start/stop listening for BLE advertising packets within range. Returns a
-`BluetoothDevice` for each advertsing packet. **By default this is not an active scan, so
-Scan Response advertising data is not included (see below)**
+`BluetoothDevice` for each advertsing packet. **By default this is not an active
+scan, so Scan Response advertising data is not included (see below)**
 
 ```
 // Start scanning
@@ -1751,10 +1768,10 @@ BluetoothDevice {
  }
 ```
 
-You can also supply a set of filters (as described in `NRF.requestDevice`) as a second argument, which will
-allow you to filter the devices you get a callback for. This helps
-to cut down on the time spent processing JavaScript code in areas with
-a lot of Bluetooth advertisements. For example to find only devices
+You can also supply a set of filters (as described in `NRF.requestDevice`) as a
+second argument, which will allow you to filter the devices you get a callback
+for. This helps to cut down on the time spent processing JavaScript code in
+areas with a lot of Bluetooth advertisements. For example to find only devices
 with the manufacturer data `0x0590` (Espruino's ID) you could do:
 
 ```
@@ -1763,23 +1780,23 @@ NRF.setScan(function(d) {
 }, { filters: [{ manufacturerData:{0x0590:{}} }] });
 ```
 
-You can also specify `active:true` in the second argument to perform
-active scanning (this requests scan response packets) from any
-devices it finds.
+You can also specify `active:true` in the second argument to perform active
+scanning (this requests scan response packets) from any devices it finds.
 
-**Note:** Using a filter in `setScan` filters each advertising packet individually. As
-a result, if you filter based on a service UUID and a device advertises with multiple packets
-(or a scan response when `active:true`) only the packets matching the filter are returned. To
-aggregate multiple packets you can use `NRF.findDevices`.
+**Note:** Using a filter in `setScan` filters each advertising packet
+individually. As a result, if you filter based on a service UUID and a device
+advertises with multiple packets (or a scan response when `active:true`) only
+the packets matching the filter are returned. To aggregate multiple packets you
+can use `NRF.findDevices`.
 
-**Note:** BLE advertising packets can arrive quickly - faster than you'll
-be able to print them to the console. It's best only to print a few, or
-to use a function like `NRF.findDevices(..)` which will collate a list
-of available devices.
+**Note:** BLE advertising packets can arrive quickly - faster than you'll be
+able to print them to the console. It's best only to print a few, or to use a
+function like `NRF.findDevices(..)` which will collate a list of available
+devices.
 
-**Note:** Using setScan turns the radio's receive mode on constantly. This
-can draw a *lot* of power (12mA or so), so you should use it sparingly or
-you can run your battery down quickly.
+**Note:** Using setScan turns the radio's receive mode on constantly. This can
+draw a *lot* of power (12mA or so), so you should use it sparingly or you can
+run your battery down quickly.
 */
 void jswrap_ble_setScan_cb(JsVar *callback, JsVar *filters, JsVar *adv) {
   /* This is called when we get data - do some processing here in the main loop
@@ -1928,9 +1945,10 @@ void jswrap_ble_setScan(JsVar *callback, JsVar *options) {
 }
 This function can be used to quickly filter through Bluetooth devices.
 
-For instance if you wish to scan for multiple different types of device at the same time
-then you could use `NRF.findDevices` with all the filters you're interested in. When scanning
-is finished you can then use `NRF.filterDevices` to pick out just the devices of interest.
+For instance if you wish to scan for multiple different types of device at the
+same time then you could use `NRF.findDevices` with all the filters you're
+interested in. When scanning is finished you can then use `NRF.filterDevices` to
+pick out just the devices of interest.
 
 ```
 // the two types of device we're interested in
@@ -1978,8 +1996,8 @@ JsVar *jswrap_ble_filterDevices(JsVar *devices, JsVar *filters) {
     ],
     "typescript" : "findDevices(callback: (devices: BluetoothDevice[]) => void, options?: number | { filters?: NRFFilters, timeout?: number, active?: boolean }): void;"
 }
-Utility function to return a list of BLE devices detected in range. Behind the scenes,
-this uses `NRF.setScan(...)` and collates the results.
+Utility function to return a list of BLE devices detected in range. Behind the
+scenes, this uses `NRF.setScan(...)` and collates the results.
 
 ```
 NRF.findDevices(function(devices) {
@@ -2012,9 +2030,10 @@ prints something like:
 
 For more information on the structure returned, see `NRF.setScan`.
 
-If you want to scan only for specific devices you can replace the timeout with an object
-of the form `{filters: ..., timeout : ..., active: bool}` using the filters
-described in `NRF.requestDevice`. For example to search for devices with Espruino's `manufacturerData`:
+If you want to scan only for specific devices you can replace the timeout with
+an object of the form `{filters: ..., timeout : ..., active: bool}` using the
+filters described in `NRF.requestDevice`. For example to search for devices with
+Espruino's `manufacturerData`:
 
 ```
 NRF.findDevices(function(devices) {
@@ -2022,17 +2041,21 @@ NRF.findDevices(function(devices) {
 }, {timeout : 2000, filters : [{ manufacturerData:{0x0590:{}} }] });
 ```
 
-You could then use [`BluetoothDevice.gatt.connect(...)`](/Reference#l_BluetoothRemoteGATTServer_connect) on
-the device returned to make a connection.
+You could then use
+[`BluetoothDevice.gatt.connect(...)`](/Reference#l_BluetoothRemoteGATTServer_connect)
+on the device returned to make a connection.
 
-You can also use [`NRF.connect(...)`](/Reference#l_NRF_connect) on just the `id` string returned, which
-may be useful if you always want to connect to a specific device.
+You can also use [`NRF.connect(...)`](/Reference#l_NRF_connect) on just the `id`
+string returned, which may be useful if you always want to connect to a specific
+device.
 
-**Note:** Using findDevices turns the radio's receive mode on for 2000ms (or however long you specify). This
-can draw a *lot* of power (12mA or so), so you should use it sparingly or you can run your battery down quickly.
+**Note:** Using findDevices turns the radio's receive mode on for 2000ms (or
+however long you specify). This can draw a *lot* of power (12mA or so), so you
+should use it sparingly or you can run your battery down quickly.
 
-**Note:** The 'data' field contains the data of *the last packet received*. There may have been more
-packets. To get data for each packet individually use `NRF.setScan` instead.
+**Note:** The 'data' field contains the data of *the last packet received*.
+There may have been more packets. To get data for each packet individually use
+`NRF.setScan` instead.
 */
 void jswrap_ble_findDevices_found_cb(JsVar *device) {
   JsVar *arr = jsvObjectGetChild(execInfo.hiddenRoot, "BLEADV", JSV_ARRAY);
@@ -2135,8 +2158,8 @@ void jswrap_ble_findDevices(JsVar *callback, JsVar *options) {
     ]
 }
 
-Start/stop listening for RSSI values on the currently active connection
-(where This device is a peripheral and is being connected to by a 'central' device)
+Start/stop listening for RSSI values on the currently active connection (where
+This device is a peripheral and is being connected to by a 'central' device)
 
 ```
 // Start scanning
@@ -2187,19 +2210,18 @@ void jswrap_ble_setTxPower(JsVarInt pwr) {
     ]
 }
 
-**THIS IS DEPRECATED** - please use `NRF.setConnectionInterval` for
-peripheral and `NRF.connect(addr, options)`/`BluetoothRemoteGATTServer.connect(options)`
+**THIS IS DEPRECATED** - please use `NRF.setConnectionInterval` for peripheral
+and `NRF.connect(addr, options)`/`BluetoothRemoteGATTServer.connect(options)`
 for central connections.
 
-This sets the connection parameters - these affect the transfer speed and
-power usage when the device is connected.
+This sets the connection parameters - these affect the transfer speed and power
+usage when the device is connected.
 
 * When not low power, the connection interval is between 7.5 and 20ms
 * When low power, the connection interval is between 500 and 1000ms
 
-When low power connection is enabled, transfers of data over Bluetooth
-will be very slow, however power usage while connected will be drastically
-decreased.
+When low power connection is enabled, transfers of data over Bluetooth will be
+very slow, however power usage while connected will be drastically decreased.
 
 This will only take effect after the connection is disconnected and
 re-established.
@@ -2308,8 +2330,8 @@ void jswrap_nfc_URL(JsVar *url) {
 }
 Enables NFC and with an out of band 16 byte pairing key.
 
-For example the following will enable out of band pairing on BLE
-such that the device will pair when you tap the phone against it:
+For example the following will enable out of band pairing on BLE such that the
+device will pair when you tap the phone against it:
 
 ```
 var bleKey = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00];
@@ -2489,10 +2511,11 @@ void jswrap_nfc_raw(JsVar *payload) {
     ],
     "return" : ["JsVar", "Internal tag memory (first 10 bytes of tag data)" ]
 }
-**Advanced NFC Functionality.** If you just want to advertise a URL, use `NRF.nfcURL` instead.
+**Advanced NFC Functionality.** If you just want to advertise a URL, use
+`NRF.nfcURL` instead.
 
-Enables NFC and starts advertising. `NFCrx` events will be
-fired when data is received.
+Enables NFC and starts advertising. `NFCrx` events will be fired when data is
+received.
 
 ```
 NRF.nfcStart();
@@ -2555,7 +2578,8 @@ JsVar *jswrap_nfc_start(JsVar *payload) {
     "generate" : "jswrap_nfc_stop",
     "params" : [ ]
 }
-**Advanced NFC Functionality.** If you just want to advertise a URL, use `NRF.nfcURL` instead.
+**Advanced NFC Functionality.** If you just want to advertise a URL, use
+`NRF.nfcURL` instead.
 
 Disables NFC.
 
@@ -2581,12 +2605,13 @@ void jswrap_nfc_stop() {
       ["payload","JsVar","Optional tx data"]
     ]
 }
-**Advanced NFC Functionality.** If you just want to advertise a URL, use `NRF.nfcURL` instead.
+**Advanced NFC Functionality.** If you just want to advertise a URL, use
+`NRF.nfcURL` instead.
 
-Acknowledges the last frame and optionally transmits a response.
-If payload is an array, then a array.length byte nfc frame is sent.
-If payload is a int, then a 4bit ACK/NACK is sent.
-**Note:** ```nfcSend``` should always be called after an ```NFCrx``` event.
+Acknowledges the last frame and optionally transmits a response. If payload is
+an array, then a array.length byte nfc frame is sent. If payload is a int, then
+a 4bit ACK/NACK is sent. **Note:** ```nfcSend``` should always be called after
+an ```NFCrx``` event.
 
 ```
 NRF.nfcSend(new Uint8Array([0x01, 0x02, ...]));
@@ -2626,7 +2651,8 @@ void jswrap_nfc_send(JsVar *payload) {
       ["callback","JsVar","A callback function to be called when the data is sent"]
     ]
 }
-Send a USB HID report. HID must first be enabled with `NRF.setServices({}, {hid: hid_report})`
+Send a USB HID report. HID must first be enabled with `NRF.setServices({}, {hid:
+hid_report})`
 */
 void jswrap_ble_sendHIDReport(JsVar *data, JsVar *callback) {
 #if BLE_HIDS_ENABLED
@@ -2649,7 +2675,8 @@ void jswrap_ble_sendHIDReport(JsVar *data, JsVar *callback) {
   "params" : [["info","JsVar","An object (see below)"]],
   "ifdef" : "BANGLEJS"
 }
-Called when a notification arrives on an Apple iOS device Bangle.js is connected to
+Called when a notification arrives on an Apple iOS device Bangle.js is connected
+to
 
 
 ```
@@ -2680,7 +2707,8 @@ NRF.ancsGetNotificationInfo( event.uid ).then(a=>print("Notify",E.toJS(a)));
   "params" : [["info","JsVar","An object (see below)"]],
   "ifdef" : "BANGLEJS"
 }
-Called when a media event arrives on an Apple iOS device Bangle.js is connected to
+Called when a media event arrives on an Apple iOS device Bangle.js is connected
+to
 
 
 ```
@@ -2702,7 +2730,8 @@ truncated : bool // the 'value' was too big to be sent completely
     "params" : [ ],
     "return" : ["bool", "True if Apple Notification Center Service (ANCS) has been initialised and is active" ]
 }
-Check if Apple Notification Center Service (ANCS) is currently active on the BLE connection
+Check if Apple Notification Center Service (ANCS) is currently active on the BLE
+connection
 */
 bool jswrap_ble_ancsIsActive() {
 #if ESPR_BLUETOOTH_ANCS
@@ -2721,7 +2750,8 @@ bool jswrap_ble_ancsIsActive() {
       ["positive","bool","`true` for positive action, `false` for negative"]
     ]
 }
-Send an ANCS action for a specific Notification UID. Corresponds to posaction/negaction in the 'ANCS' event that was received
+Send an ANCS action for a specific Notification UID. Corresponds to
+posaction/negaction in the 'ANCS' event that was received
 */
 void jswrap_ble_ancsAction(int uid, bool isPositive) {
 #if ESPR_BLUETOOTH_ANCS
@@ -2844,16 +2874,19 @@ bool jswrap_ble_amsIsActive() {
     "return" : ["JsVar", "A `Promise` that is resolved (or rejected) when the connection is complete" ],
     "return_object" : "Promise"
 }
-Get Apple Media Service (AMS) info for the current media player.
-"playbackinfo" returns a concatenation of three comma-separated values:
+Get Apple Media Service (AMS) info for the current media player. "playbackinfo"
+returns a concatenation of three comma-separated values:
 
-- PlaybackState: a string that represents the integer value of the playback state:
+- PlaybackState: a string that represents the integer value of the playback
+  state:
     - PlaybackStatePaused = 0
     - PlaybackStatePlaying = 1
     - PlaybackStateRewinding = 2
     - PlaybackStateFastForwarding = 3
-- PlaybackRate: a string that represents the floating point value of the playback rate.
-- ElapsedTime: a string that represents the floating point value of the elapsed time of the current track, in seconds
+- PlaybackRate: a string that represents the floating point value of the
+  playback rate.
+- ElapsedTime: a string that represents the floating point value of the elapsed
+  time of the current track, in seconds
 
 */
 JsVar *jswrap_ble_amsGetPlayerInfo(JsVar *id) {
@@ -2931,7 +2964,8 @@ JsVar *jswrap_ble_amsGetTrackInfo(JsVar *id) {
 }
 Send an AMS command to an Apple Media Service device to control music playback
 
-Command is one of play, pause, playpause, next, prev, volup, voldown, repeat, shuffle, skipforward, skipback, like, dislike, bookmark
+Command is one of play, pause, playpause, next, prev, volup, voldown, repeat,
+shuffle, skipforward, skipback, like, dislike, bookmark
 */
 void jswrap_ble_amsCommand(JsVar *id) {
 #if ESPR_BLUETOOTH_ANCS
@@ -2986,29 +3020,39 @@ type NRFFilters = {
     "return" : ["JsVar", "A `Promise` that is resolved (or rejected) when the connection is complete" ],
     "return_object" : "Promise"
 }
-Search for available devices matching the given filters. Since we have no UI here,
-Espruino will pick the FIRST device it finds, or it'll call `catch`.
+Search for available devices matching the given filters. Since we have no UI
+here, Espruino will pick the FIRST device it finds, or it'll call `catch`.
 
 `options` can have the following fields:
 
-* `filters` - a list of filters that a device must match before it is returned (see below)
-* `timeout` - the maximum time to scan for in milliseconds (scanning stops when a match
-is found. eg. `NRF.requestDevice({ timeout:2000, filters: [ ... ] })`
-* `active` - whether to perform active scanning (requesting 'scan response' packets from any
-devices that are found). eg. `NRF.requestDevice({ active:true, filters: [ ... ] })`
-* `phy` - (NRF52840 only) use the long-range coded phy (`"1mbps"` default, can be `"1mbps/2mbps/both/coded"`)
-* `extended` - (NRF52840 only) support receiving extended-length advertising packets (default=true if phy isn't `"1mbps"`)
+* `filters` - a list of filters that a device must match before it is returned
+  (see below)
+* `timeout` - the maximum time to scan for in milliseconds (scanning stops when
+a match is found. eg. `NRF.requestDevice({ timeout:2000, filters: [ ... ] })`
+* `active` - whether to perform active scanning (requesting 'scan response'
+packets from any devices that are found). eg. `NRF.requestDevice({ active:true,
+filters: [ ... ] })`
+* `phy` - (NRF52840 only) use the long-range coded phy (`"1mbps"` default, can
+  be `"1mbps/2mbps/both/coded"`)
+* `extended` - (NRF52840 only) support receiving extended-length advertising
+  packets (default=true if phy isn't `"1mbps"`)
 
 **NOTE:** `timeout` and `active` are not part of the Web Bluetooth standard.
 
 The following filter types are implemented:
 
-* `services` - list of services as strings (all of which must match). 128 bit services must be in the form '01230123-0123-0123-0123-012301230123'
+* `services` - list of services as strings (all of which must match). 128 bit
+  services must be in the form '01230123-0123-0123-0123-012301230123'
 * `name` - exact device name
 * `namePrefix` - starting characters of device name
-* `id` - exact device address (`id:"e9:53:86:09:89:99 random"`) (this is Espruino-specific, and is not part of the Web Bluetooth spec)
-* `serviceData` - an object containing service characteristics which must all match (`serviceData:{"1809":{}}`). Matching of actual service data is not supported yet.
-* `manufacturerData` - an object containing manufacturer UUIDs which must all match (`manufacturerData:{0x0590:{}}`). Matching of actual manufacturer data is not supported yet.
+* `id` - exact device address (`id:"e9:53:86:09:89:99 random"`) (this is
+  Espruino-specific, and is not part of the Web Bluetooth spec)
+* `serviceData` - an object containing service characteristics which must all
+  match (`serviceData:{"1809":{}}`). Matching of actual service data is not
+  supported yet.
+* `manufacturerData` - an object containing manufacturer UUIDs which must all
+  match (`manufacturerData:{0x0590:{}}`). Matching of actual manufacturer data
+  is not supported yet.
 
 ```
 NRF.requestDevice({ filters: [{ namePrefix: 'Puck.js' }] }).then(function(device) { ... });
@@ -3052,11 +3096,13 @@ NRF.requestDevice({ filters: [{ namePrefix: 'Puck.js' }]}).then(
 Note that you have to keep track of the `gatt` variable so that you can
 disconnect the Bluetooth connection when you're done.
 
-**Note:** Using a filter in `NRF.requestDevice` filters each advertising packet individually. As
-soon as a matching advertisement is received,  `NRF.requestDevice` resolves the promise and stops
-scanning. This means that if you filter based on a service UUID and a device advertises with multiple packets
-(or a scan response when `active:true`) only the packet matching the filter is returned - you may not
-get the device's name is that was in a separate packet. To aggregate multiple packets you can use `NRF.findDevices`.
+**Note:** Using a filter in `NRF.requestDevice` filters each advertising packet
+individually. As soon as a matching advertisement is received,
+`NRF.requestDevice` resolves the promise and stops scanning. This means that if
+you filter based on a service UUID and a device advertises with multiple packets
+(or a scan response when `active:true`) only the packet matching the filter is
+returned - you may not get the device's name is that was in a separate packet.
+To aggregate multiple packets you can use `NRF.findDevices`.
 */
 #if CENTRAL_LINK_COUNT>0
 /// Called when we timeout waiting for a device
@@ -3133,8 +3179,8 @@ JsVar *jswrap_ble_requestDevice(JsVar *options) {
     "return" : ["JsVar", "A `Promise` that is resolved (or rejected) when the connection is complete" ],
     "return_object" : "Promise"
 }
-Connect to a BLE device by MAC address. Returns a promise,
-the argument of which is the `BluetoothRemoteGATTServer` connection.
+Connect to a BLE device by MAC address. Returns a promise, the argument of which
+is the `BluetoothRemoteGATTServer` connection.
 
 ```
 NRF.connect("aa:bb:cc:dd:ee").then(function(server) {
@@ -3142,10 +3188,12 @@ NRF.connect("aa:bb:cc:dd:ee").then(function(server) {
 });
 ```
 
-This has the same effect as calling `BluetoothDevice.gatt.connect` on a `BluetoothDevice` requested
-using `NRF.requestDevice`. It just allows you to specify the address directly (without having to scan).
+This has the same effect as calling `BluetoothDevice.gatt.connect` on a
+`BluetoothDevice` requested using `NRF.requestDevice`. It just allows you to
+specify the address directly (without having to scan).
 
-You can use it as follows - this would connect to another Puck device and turn its LED on:
+You can use it as follows - this would connect to another Puck device and turn
+its LED on:
 
 ```
 var gatt;
@@ -3162,11 +3210,12 @@ NRF.connect("aa:bb:cc:dd:ee random").then(function(g) {
 });
 ```
 
-**Note:** Espruino Bluetooth devices use a type of BLE address known as 'random static',
-which is different to a 'public' address. To connect to an Espruino device you'll need 
-to use an address string of the form `"aa:bb:cc:dd:ee random"` rather than just 
-`"aa:bb:cc:dd:ee"`. If you scan for devices with `NRF.findDevices`/`NRF.setScan` then
-addresses are already reported in the correct format.
+**Note:** Espruino Bluetooth devices use a type of BLE address known as 'random
+static', which is different to a 'public' address. To connect to an Espruino
+device you'll need to use an address string of the form `"aa:bb:cc:dd:ee
+random"` rather than just `"aa:bb:cc:dd:ee"`. If you scan for devices with
+`NRF.findDevices`/`NRF.setScan` then addresses are already reported in the
+correct format.
 */
 JsVar *jswrap_ble_connect(JsVar *mac, JsVar *options) {
 #if CENTRAL_LINK_COUNT>0
@@ -3195,14 +3244,13 @@ JsVar *jswrap_ble_connect(JsVar *mac, JsVar *options) {
       ["whitelisting","bool","Are we using a whitelist? (default false)"]
     ]
 }
-If set to true, whenever a device bonds it will be added to the
-whitelist.
+If set to true, whenever a device bonds it will be added to the whitelist.
 
-When set to false, the whitelist is cleared and newly bonded
-devices will not be added to the whitelist.
+When set to false, the whitelist is cleared and newly bonded devices will not be
+added to the whitelist.
 
-**Note:** This is remembered between `reset()`s but isn't
-remembered after power-on (you'll have to add it to `onInit()`.
+**Note:** This is remembered between `reset()`s but isn't remembered after
+power-on (you'll have to add it to `onInit()`.
 */
 void jswrap_ble_setWhitelist(bool whitelist) {
 #if PEER_MANAGER_ENABLED
@@ -3220,29 +3268,32 @@ void jswrap_ble_setWhitelist(bool whitelist) {
       ["interval","JsVar","The connection interval to use (see below)"]
     ]
 }
-When connected, Bluetooth LE devices communicate at a set interval.
-Lowering the interval (eg. more packets/second) means a lower delay when
-sending data, higher bandwidth, but also more power consumption.
+When connected, Bluetooth LE devices communicate at a set interval. Lowering the
+interval (eg. more packets/second) means a lower delay when sending data, higher
+bandwidth, but also more power consumption.
 
 By default, when connected as a peripheral Espruino automatically adjusts the
-connection interval. When connected it's as fast as possible (7.5ms) but when idle
-for over a minute it drops to 200ms. On continued activity (>1 BLE operation) the
-interval is raised to 7.5ms again.
+connection interval. When connected it's as fast as possible (7.5ms) but when
+idle for over a minute it drops to 200ms. On continued activity (>1 BLE
+operation) the interval is raised to 7.5ms again.
 
 The options for `interval` are:
 
 * `undefined` / `"auto"` : (default) automatically adjust connection interval
-* `100` : set min and max connection interval to the same number (between 7.5ms and 4000ms)
-* `{minInterval:20, maxInterval:100}` : set min and max connection interval as a range
+* `100` : set min and max connection interval to the same number (between 7.5ms
+  and 4000ms)
+* `{minInterval:20, maxInterval:100}` : set min and max connection interval as a
+  range
 
-This configuration is not remembered during a `save()` - you will have to
-re-set it via `onInit`.
+This configuration is not remembered during a `save()` - you will have to re-set
+it via `onInit`.
 
-**Note:** If connecting to another device (as Central), you can use
-an extra argument to `NRF.connect` or `BluetoothRemoteGATTServer.connect`
-to specify a connection interval.
+**Note:** If connecting to another device (as Central), you can use an extra
+argument to `NRF.connect` or `BluetoothRemoteGATTServer.connect` to specify a
+connection interval.
 
-**Note:** This overwrites any changes imposed by the deprecated `NRF.setLowPowerConnection`
+**Note:** This overwrites any changes imposed by the deprecated
+`NRF.setLowPowerConnection`
 */
 void jswrap_ble_setConnectionInterval(JsVar *interval) {
 #if NRF52_SERIES
@@ -3274,8 +3325,8 @@ void jswrap_ble_setConnectionInterval(JsVar *interval) {
       ["options","JsVar","An object containing security-related options (see below)"]
     ]
 }
-Sets the security options used when connecting/pairing. This applies to both central
-*and* peripheral mode.
+Sets the security options used when connecting/pairing. This applies to both
+central *and* peripheral mode.
 
 ```
 NRF.setSecurity({
@@ -3297,8 +3348,8 @@ NRF.setSecurity({
 
 **NOTE:** Some combinations of arguments will cause an error. For example
 supplying a passkey without `display:1` is not allowed. If `display:1` is set
-you do not require a physical display, the user just needs to know
-the passkey you supplied.
+you do not require a physical display, the user just needs to know the passkey
+you supplied.
 
 For instance, to require pairing and to specify a passkey, use:
 
@@ -3306,16 +3357,15 @@ For instance, to require pairing and to specify a passkey, use:
 NRF.setSecurity({passkey:"123456", mitm:1, display:1});
 ```
 
-However, while most devices will request a passkey for pairing at
-this point it is still possible for a device to connect without
-requiring one (eg. using the 'NRF Connect' app).
+However, while most devices will request a passkey for pairing at this point it
+is still possible for a device to connect without requiring one (eg. using the
+'NRF Connect' app).
 
 
-To force a passkey you need to protect each characteristic
-you define with `NRF.setSecurity`. For instance the following
-code will *require* that the passkey `123456` is entered
-before the characteristic `9d020002-bf5f-1d1a-b52a-fe52091d5b12`
-can be read.
+To force a passkey you need to protect each characteristic you define with
+`NRF.setSecurity`. For instance the following code will *require* that the
+passkey `123456` is entered before the characteristic
+`9d020002-bf5f-1d1a-b52a-fe52091d5b12` can be read.
 
 ```
 NRF.setSecurity({passkey:"123456", mitm:1, display:1});
@@ -3356,8 +3406,9 @@ NRF.setServices({
 });
 ```
 
-**Note:** If `passkey` or `oob` is specified, the Nordic UART service (if enabled)
-will automatically be set to require encryption, but otherwise it is open.
+**Note:** If `passkey` or `oob` is specified, the Nordic UART service (if
+enabled) will automatically be set to require encryption, but otherwise it is
+open.
 */
 void jswrap_ble_setSecurity(JsVar *options) {
   if (!jsvIsObject(options) && !jsvIsUndefined(options))
@@ -3379,8 +3430,8 @@ void jswrap_ble_setSecurity(JsVar *options) {
     "generate" : "jswrap_ble_getSecurityStatus",
     "return" : ["JsVar", "An object" ]
 }
-Return an object with information about the security
-state of the current peripheral connection:
+Return an object with information about the security state of the current
+peripheral connection:
 
 ```
 {
@@ -3426,7 +3477,8 @@ JsVar *jswrap_ble_startBonding(bool forceRePair) {
   "class" : "BluetoothDevice",
   "ifdef" : "NRF52_SERIES"
 }
-A Web Bluetooth-style device - you can request one using `NRF.requestDevice(address)`
+A Web Bluetooth-style device - you can request one using
+`NRF.requestDevice(address)`
 
 For example:
 
@@ -3491,7 +3543,8 @@ JsVar *jswrap_BluetoothDevice_gatt(JsVar *parent) {
 }
 Called when the device pairs and sends a passkey that Espruino should display.
 
-For this to be used, you'll have to specify that there's a display using `NRF.setSecurity`
+For this to be used, you'll have to specify that there's a display using
+`NRF.setSecurity`
 
 **This is not part of the Web Bluetooth Specification.** It has been added
 specifically for Espruino.
@@ -3502,11 +3555,14 @@ specifically for Espruino.
     "name" : "passkeyRequest",
     "ifdef" : "NRF52_SERIES"
 }
-Called when the device pairs, displays a passkey, and wants Espruino to tell it what the passkey was.
+Called when the device pairs, displays a passkey, and wants Espruino to tell it
+what the passkey was.
 
-Respond with `BluetoothDevice.sendPasskey()` with a 6 character string containing only `0..9`.
+Respond with `BluetoothDevice.sendPasskey()` with a 6 character string
+containing only `0..9`.
 
-For this to be used, you'll have to specify that there's a keyboard using `NRF.setSecurity`
+For this to be used, you'll have to specify that there's a keyboard using
+`NRF.setSecurity`
 
 **This is not part of the Web Bluetooth Specification.** It has been added
 specifically for Espruino.
@@ -3521,7 +3577,8 @@ specifically for Espruino.
       ["passkey","JsVar","A 6 character numeric String to be returned to the device"]
     ]
 }
-To be used as a response when the event `BluetoothDevice.sendPasskey` has been received.
+To be used as a response when the event `BluetoothDevice.sendPasskey` has been
+received.
 
 **This is not part of the Web Bluetooth Specification.** It has been added
 specifically for Espruino.
@@ -3550,8 +3607,8 @@ void jswrap_ble_BluetoothDevice_sendPasskey(JsVar *parent, JsVar *passkeyVar) {
     "return" : ["JsVar", "A `Promise` that is resolved (or rejected) when the connection is complete" ],
     "return_object" : "Promise"
 }
-Connect to a BLE device - returns a promise,
-the argument of which is the `BluetoothRemoteGATTServer` connection.
+Connect to a BLE device - returns a promise, the argument of which is the
+`BluetoothRemoteGATTServer` connection.
 
 See [`NRF.requestDevice`](/Reference#l_NRF_requestDevice) for usage examples.
 
@@ -3564,9 +3621,9 @@ See [`NRF.requestDevice`](/Reference#l_NRF_requestDevice) for usage examples.
 }
 ```
 
-By default the interval is 20-200ms (or 500-1000ms if `NRF.setLowPowerConnection(true)` was called.
-During connection Espruino negotiates with the other device to find a common interval that can be
-used.
+By default the interval is 20-200ms (or 500-1000ms if
+`NRF.setLowPowerConnection(true)` was called. During connection Espruino
+negotiates with the other device to find a common interval that can be used.
 
 For instance calling:
 
@@ -3576,12 +3633,13 @@ NRF.requestDevice({ filters: [{ namePrefix: 'Pixl.js' }] }).then(function(device
 }).then(function(g) {
 ```
 
-will force the connection to use the fastest connection interval possible (as long as the device
-at the other end supports it).
+will force the connection to use the fastest connection interval possible (as
+long as the device at the other end supports it).
 
-**Note:** The Web Bluetooth spec states that if a device hasn't advertised its name, when connected
-to a device the central (in this case Espruino) should automatically retrieve the name from the
-corresponding characteristic (`0x2a00` on service `0x1800`). Espruino does not automatically do this.
+**Note:** The Web Bluetooth spec states that if a device hasn't advertised its
+name, when connected to a device the central (in this case Espruino) should
+automatically retrieve the name from the corresponding characteristic (`0x2a00`
+on service `0x1800`). Espruino does not automatically do this.
 
 */
 #if CENTRAL_LINK_COUNT>0
@@ -3637,8 +3695,8 @@ JsVar *jswrap_ble_BluetoothRemoteGATTServer_connect(JsVar *parent, JsVar *option
   "class" : "BluetoothRemoteGATTServer",
     "#if" : "defined(NRF52_SERIES) || defined(ESP32)"
 }
-Web Bluetooth-style GATT server - get this using `NRF.connect(address)`
-or `NRF.requestDevice(options)` and `response.gatt.connect`
+Web Bluetooth-style GATT server - get this using `NRF.connect(address)` or
+`NRF.requestDevice(options)` and `response.gatt.connect`
 
 https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattserver
 */
@@ -3668,13 +3726,13 @@ https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattserver
     "#if" : "defined(NRF52_SERIES) || defined(ESP32)"
 }
 Disconnect from a previously connected BLE device connected with
-`BluetoothRemoteGATTServer.connect` - this does not disconnect from something that has
-connected to the Espruino.
+`BluetoothRemoteGATTServer.connect` - this does not disconnect from something
+that has connected to the Espruino.
 
-**Note:** While `.disconnect` is standard Web Bluetooth, in the spec it
-returns undefined not a `Promise` for implementation reasons. In Espruino
-we return a `Promise` to make it easier to detect when Espruino is free
-to connect to something else.
+**Note:** While `.disconnect` is standard Web Bluetooth, in the spec it returns
+undefined not a `Promise` for implementation reasons. In Espruino we return a
+`Promise` to make it easier to detect when Espruino is free to connect to
+something else.
 */
 JsVar *jswrap_BluetoothRemoteGATTServer_disconnect(JsVar *parent) {
 #if CENTRAL_LINK_COUNT>0
@@ -3723,8 +3781,8 @@ JsVar *jswrap_BluetoothRemoteGATTServer_disconnect(JsVar *parent) {
     "return" : ["JsVar", "A `Promise` that is resolved (or rejected) when the bonding is complete" ],
     "return_object" : "Promise"
 }
-Start negotiating bonding (secure communications) with the connected device,
-and return a Promise that is completed on success or failure.
+Start negotiating bonding (secure communications) with the connected device, and
+return a Promise that is completed on success or failure.
 
 ```
 var gatt;
@@ -3769,8 +3827,8 @@ JsVar *jswrap_ble_BluetoothRemoteGATTServer_startBonding(JsVar *parent, bool for
     "generate" : "jswrap_ble_BluetoothRemoteGATTServer_getSecurityStatus",
     "return" : ["JsVar", "An object" ]
 }
-Return an object with information about the security
-state of the current connection:
+Return an object with information about the security state of the current
+connection:
 
 
 ```
@@ -3782,8 +3840,8 @@ state of the current connection:
 }
 ```
 
-See `BluetoothRemoteGATTServer.startBonding` for information about
-negotiating a secure connection.
+See `BluetoothRemoteGATTServer.startBonding` for information about negotiating a
+secure connection.
 
 **This is not part of the Web Bluetooth Specification.** It has been added
 specifically for Puck.js.
@@ -3909,7 +3967,8 @@ void jswrap_BluetoothRemoteGATTServer_setRSSIHandler(JsVar *parent, JsVar *callb
   "class" : "BluetoothRemoteGATTService",
   "#if" : "defined(NRF52_SERIES) || defined(ESP32)"
 }
-Web Bluetooth-style GATT service - get this using `BluetoothRemoteGATTServer.getPrimaryService(s)`
+Web Bluetooth-style GATT service - get this using
+`BluetoothRemoteGATTServer.getPrimaryService(s)`
 
 https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattservice
 */
@@ -3988,7 +4047,8 @@ JsVar *jswrap_BluetoothRemoteGATTService_getCharacteristics(JsVar *parent) {
   "class" : "BluetoothRemoteGATTCharacteristic",
   "#if" : "defined(NRF52_SERIES) || defined(ESP32)"
 }
-Web Bluetooth-style GATT characteristic - get this using `BluetoothRemoteGATTService.getCharacteristic(s)`
+Web Bluetooth-style GATT characteristic - get this using
+`BluetoothRemoteGATTService.getCharacteristic(s)`
 
 https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattcharacteristic
 */
@@ -4102,8 +4162,9 @@ JsVar *jswrap_ble_BluetoothRemoteGATTCharacteristic_readValue(JsVar *characteris
     "return_object" : "Promise",
     "ifdef" : "NRF52_SERIES"
 }
-Starts notifications - whenever this characteristic's value changes, a `characteristicvaluechanged` event is fired
-and `characteristic.value` will then contain the new value as a `DataView`.
+Starts notifications - whenever this characteristic's value changes, a
+`characteristicvaluechanged` event is fired and `characteristic.value` will then
+contain the new value as a `DataView`.
 
 ```
 var device;
@@ -4125,8 +4186,8 @@ NRF.connect(device_address).then(function(d) {
 });
 ```
 
-For example, to listen to the output of another Puck.js's Nordic
-Serial port service, you can use:
+For example, to listen to the output of another Puck.js's Nordic Serial port
+service, you can use:
 
 ```
 var gatt;
@@ -4190,7 +4251,8 @@ JsVar *jswrap_ble_BluetoothRemoteGATTCharacteristic_startNotifications(JsVar *ch
     "return_object" : "Promise",
     "ifdef" : "NRF52_SERIES"
 }
-Stop notifications (that were requested with `BluetoothRemoteGATTCharacteristic.startNotifications`)
+Stop notifications (that were requested with
+`BluetoothRemoteGATTCharacteristic.startNotifications`)
 */
 JsVar *jswrap_ble_BluetoothRemoteGATTCharacteristic_stopNotifications(JsVar *characteristic) {
 #if CENTRAL_LINK_COUNT>0

--- a/libs/compression/jswrap_heatshrink.c
+++ b/libs/compression/jswrap_heatshrink.c
@@ -25,11 +25,17 @@
   "class" : "heatshrink",
   "ifndef" : "SAVE_ON_FLASH"
 }
-Simple library for compression/decompression using [heatshrink](https://github.com/atomicobject/heatshrink), an [LZSS](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Storer%E2%80%93Szymanski) compression tool.
+Simple library for compression/decompression using
+[heatshrink](https://github.com/atomicobject/heatshrink), an
+[LZSS](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Storer%E2%80%93Szymanski)
+compression tool.
 
-Espruino uses heatshrink internally to compress RAM down to fit in Flash memory when `save()` is used. This just exposes that functionality.
+Espruino uses heatshrink internally to compress RAM down to fit in Flash memory
+when `save()` is used. This just exposes that functionality.
 
-Functions here take and return buffers of data. There is no support for streaming, so both the compressed and decompressed data must be able to fit in memory at the same time.
+Functions here take and return buffers of data. There is no support for
+streaming, so both the compressed and decompressed data must be able to fit in
+memory at the same time.
 */
 
 

--- a/libs/crypto/jswrap_crypto.c
+++ b/libs/crypto/jswrap_crypto.c
@@ -45,7 +45,9 @@
 }
 Cryptographic functions
 
-**Note:** This library is currently only included in builds for boards where there is space. For other boards there is `crypto.js` which implements SHA1 in JS.
+**Note:** This library is currently only included in builds for boards where
+there is space. For other boards there is `crypto.js` which implements SHA1 in
+JS.
 */
 
 
@@ -57,7 +59,9 @@ Cryptographic functions
 }
 Class containing AES encryption/decryption
 
-**Note:** This library is currently only included in builds for boards where there is space. For other boards there is `crypto.js` which implements SHA1 in JS.
+**Note:** This library is currently only included in builds for boards where
+there is space. For other boards there is `crypto.js` which implements SHA1 in
+JS.
 */
 /*JSON{
   "type" : "staticproperty",
@@ -190,9 +194,9 @@ JsVar *jswrap_crypto_SHAx(JsVar *message, int shaNum) {
 
 Performs a SHA1 hash and returns the result as a 20 byte ArrayBuffer.
 
-**Note:** On some boards (currently only Espruino Original) there
-isn't space for a fully unrolled SHA1 implementation so a slower
-all-JS implementation is used instead.
+**Note:** On some boards (currently only Espruino Original) there isn't space
+for a fully unrolled SHA1 implementation so a slower all-JS implementation is
+used instead.
 */
 /*JSON{
   "type" : "staticmethod",

--- a/libs/filesystem/jswrap_file.c
+++ b/libs/filesystem/jswrap_file.c
@@ -119,7 +119,8 @@ bool jsfsInit() {
     ["csPin","pin","The pin to use for Chip Select"]
   ]
 }
-Setup the filesystem so that subsequent calls to `E.openFile` and `require('fs').*` will use an SD card on the supplied SPI device and pin.
+Setup the filesystem so that subsequent calls to `E.openFile` and
+`require('fs').*` will use an SD card on the supplied SPI device and pin.
 
 It can even work using software SPI - for instance:
 
@@ -136,11 +137,12 @@ console.log(require("fs").readdirSync());
 
 See [the page on File IO](http://www.espruino.com/File+IO) for more information.
 
-**Note:** We'd strongly suggest you add a pullup resistor from CD/CS pin to 3.3v. It is
-good practise to avoid accidental writes before Espruino is initialised, and some cards
-will not work reliably without one.
+**Note:** We'd strongly suggest you add a pullup resistor from CD/CS pin to
+3.3v. It is good practise to avoid accidental writes before Espruino is
+initialised, and some cards will not work reliably without one.
 
-**Note:** If you want to remove an SD card after you have started using it, you *must* call `E.unmountSD()` or you may cause damage to the card.
+**Note:** If you want to remove an SD card after you have started using it, you
+*must* call `E.unmountSD()` or you may cause damage to the card.
 */
 void jswrap_E_connectSDCard(JsVar *spi, Pin csPin) {
 #ifdef SD_CARD_ANYWHERE
@@ -165,11 +167,16 @@ void jswrap_E_connectSDCard(JsVar *spi, Pin csPin) {
   "type" : "class",
   "class" : "File"
 }
-This is the File object - it allows you to stream data to and from files (As opposed to the `require('fs').readFile(..)` style functions that read an entire file).
+This is the File object - it allows you to stream data to and from files (As
+opposed to the `require('fs').readFile(..)` style functions that read an entire
+file).
 
-To create a File object, you must type ```var fd = E.openFile('filepath','mode')``` - see [E.openFile](#l_E_openFile) for more information.
+To create a File object, you must type ```var fd =
+E.openFile('filepath','mode')``` - see [E.openFile](#l_E_openFile) for more
+information.
 
-**Note:** If you want to remove an SD card after you have started using it, you *must* call `E.unmountSD()` or you may cause damage to the card.
+**Note:** If you want to remove an SD card after you have started using it, you
+*must* call `E.unmountSD()` or you may cause damage to the card.
 */
 
 static JsVar* fsGetArray(bool create) {
@@ -227,7 +234,9 @@ void jswrap_file_kill() {
   "name" : "unmountSD",
   "generate" : "jswrap_E_unmountSD"
 }
-Unmount the SD card, so it can be removed. If you remove the SD card without calling this you may cause corruption, and you will be unable to access another SD card until you reset Espruino or call `E.unmountSD()`.
+Unmount the SD card, so it can be removed. If you remove the SD card without
+calling this you may cause corruption, and you will be unable to access another
+SD card until you reset Espruino or call `E.unmountSD()`.
 */
 void jswrap_E_unmountSD() {
   jswrap_file_kill();
@@ -394,12 +403,11 @@ void jswrap_file_close(JsVar* parent) {
 }
 Write data to a file.
 
-**Note:** By default this function flushes all changes to the
-SD card, which makes it slow (but also safe!). You can use
-`E.setFlags({unsyncFiles:1})` to disable this behaviour and
-really speed up writes - but then you must be sure to close
-all files you are writing before power is lost or you will
-cause damage to your SD card's filesystem.
+**Note:** By default this function flushes all changes to the SD card, which
+makes it slow (but also safe!). You can use `E.setFlags({unsyncFiles:1})` to
+disable this behaviour and really speed up writes - but then you must be sure to
+close all files you are writing before power is lost or you will cause damage to
+your SD card's filesystem.
 */
 size_t jswrap_file_write(JsVar* parent, JsVar* buffer) {
   if (!buffer) return 0;
@@ -598,8 +606,8 @@ Pipe this file to a stream (an object with a 'write' method)
   ],
   "return" : ["bool","True on success, or false on failure"]  
 }
-Change the parameters used for the flash filesystem.
-The default address is the last 1Mb of 4Mb Flash, 0x300000, with total size of 1Mb.
+Change the parameters used for the flash filesystem. The default address is the
+last 1Mb of 4Mb Flash, 0x300000, with total size of 1Mb.
 
 Before first use the media needs to be formatted.
 
@@ -615,8 +623,9 @@ fs.writeFileSync("bang.txt", "This is the way the world ends\nnot with a bang bu
 fs.readdirSync();
 ```
 
-This will create a drive of 100 * 4096 bytes at 0x300000. Be careful with the selection of flash addresses as you can overwrite firmware!
-You only need to format once, as each will erase the content.
+This will create a drive of 100 * 4096 bytes at 0x300000. Be careful with the
+selection of flash addresses as you can overwrite firmware! You only need to
+format once, as each will erase the content.
 
 `E.flashFatFS({ addr:0x300000,sectors:100,format:true });`
 */

--- a/libs/filesystem/jswrap_fs.c
+++ b/libs/filesystem/jswrap_fs.c
@@ -35,13 +35,20 @@
   "type" : "library",
   "class" : "fs"
 }
-This library handles interfacing with a FAT32 filesystem on an SD card. The API is designed to be similar to node.js's - However Espruino does not currently support asynchronous file IO, so the functions behave like node.js's xxxxSync functions. Versions of the functions with 'Sync' after them are also provided for compatibility.
+This library handles interfacing with a FAT32 filesystem on an SD card. The API
+is designed to be similar to node.js's - However Espruino does not currently
+support asynchronous file IO, so the functions behave like node.js's xxxxSync
+functions. Versions of the functions with 'Sync' after them are also provided
+for compatibility.
 
-To use this, you must type ```var fs = require('fs')``` to get access to the library
+To use this, you must type ```var fs = require('fs')``` to get access to the
+library
 
-See [the page on File IO](http://www.espruino.com/File+IO) for more information, and for examples on wiring up an SD card if your device doesn't come with one.
+See [the page on File IO](http://www.espruino.com/File+IO) for more information,
+and for examples on wiring up an SD card if your device doesn't come with one.
 
-**Note:** If you want to remove an SD card after you have started using it, you *must* call `E.unmountSD()` or you may cause damage to the card.
+**Note:** If you want to remove an SD card after you have started using it, you
+*must* call `E.unmountSD()` or you may cause damage to the card.
 */
 
 #ifndef LINUX
@@ -78,7 +85,8 @@ extern void jsfsReportError(const char *msg, FRESULT res);
 }
 List all files in the supplied directory, returning them as an array of strings.
 
-NOTE: Espruino does not yet support Async file IO, so this function behaves like the 'Sync' version.
+NOTE: Espruino does not yet support Async file IO, so this function behaves like
+the 'Sync' version.
 */
 /*JSON{
   "type" : "staticmethod",
@@ -160,7 +168,8 @@ JsVar *jswrap_fs_readdir(JsVar *path) {
 }
 Write the data to the given file
 
-NOTE: Espruino does not yet support Async file IO, so this function behaves like the 'Sync' version.
+NOTE: Espruino does not yet support Async file IO, so this function behaves like
+the 'Sync' version.
 */
 /*JSON{
   "type" : "staticmethod",
@@ -189,7 +198,8 @@ Write the data to the given file
 }
 Append the data to the given file, created a new file if it doesn't exist
 
-NOTE: Espruino does not yet support Async file IO, so this function behaves like the 'Sync' version.
+NOTE: Espruino does not yet support Async file IO, so this function behaves like
+the 'Sync' version.
 */
 /*JSON{
   "type" : "staticmethod",
@@ -229,7 +239,8 @@ bool jswrap_fs_writeOrAppendFile(JsVar *path, JsVar *data, bool append) {
 }
 Read all data from a file and return as a string
 
-NOTE: Espruino does not yet support Async file IO, so this function behaves like the 'Sync' version.
+NOTE: Espruino does not yet support Async file IO, so this function behaves like
+the 'Sync' version.
 */
 /*JSON{
   "type" : "staticmethod",
@@ -244,7 +255,8 @@ NOTE: Espruino does not yet support Async file IO, so this function behaves like
 }
 Read all data from a file and return as a string.
 
-**Note:** The size of files you can load using this method is limited by the amount of available RAM. To read files a bit at a time, see the `File` class.
+**Note:** The size of files you can load using this method is limited by the
+amount of available RAM. To read files a bit at a time, see the `File` class.
 */
 JsVar *jswrap_fs_readFile(JsVar *path) {
   JsVar *fMode = jsvNewFromString("r");
@@ -270,7 +282,8 @@ JsVar *jswrap_fs_readFile(JsVar *path) {
 }
 Delete the given file
 
-NOTE: Espruino does not yet support Async file IO, so this function behaves like the 'Sync' version.
+NOTE: Espruino does not yet support Async file IO, so this function behaves like
+the 'Sync' version.
 */
 /*JSON{
   "type" : "staticmethod",
@@ -320,8 +333,7 @@ bool jswrap_fs_unlink(JsVar *path) {
 Return information on the given file. This returns an object with the following
 fields:
 
-size: size in bytes
-dir: a boolean specifying if the file is a directory or not
+size: size in bytes dir: a boolean specifying if the file is a directory or not
 mtime: A Date structure specifying the time the file was last modified
 */
 JsVar *jswrap_fs_stat(JsVar *path) {
@@ -384,7 +396,8 @@ JsVar *jswrap_fs_stat(JsVar *path) {
 }
 Create the directory
 
-NOTE: Espruino does not yet support Async file IO, so this function behaves like the 'Sync' version.
+NOTE: Espruino does not yet support Async file IO, so this function behaves like
+the 'Sync' version.
 */
 /*JSON{
   "type" : "staticmethod",

--- a/libs/graphics/jswrap_graphics.c
+++ b/libs/graphics/jswrap_graphics.c
@@ -417,9 +417,13 @@ NO_INLINE void _jswrap_drawImageSimple(JsGraphics *gfx, int xPos, int yPos, GfxD
 }
 This class provides Graphics operations that can be applied to a surface.
 
-Use Graphics.createXXX to create a graphics object that renders in the way you want. See [the Graphics page](https://www.espruino.com/Graphics) for more information.
+Use Graphics.createXXX to create a graphics object that renders in the way you
+want. See [the Graphics page](https://www.espruino.com/Graphics) for more
+information.
 
-**Note:** On boards that contain an LCD, there is a built-in 'LCD' object of type Graphics. For instance to draw a line you'd type: ```LCD.drawLine(0,0,100,100)```
+**Note:** On boards that contain an LCD, there is a built-in 'LCD' object of
+type Graphics. For instance to draw a line you'd type:
+```LCD.drawLine(0,0,100,100)```
 */
 
 /*JSON{
@@ -428,28 +432,23 @@ Use Graphics.createXXX to create a graphics object that renders in the way you w
   "params" : [ ["all","bool","[optional] (only on some devices) If `true` then copy all pixels, not just those that have changed."] ],
   "name" : "flip"
 }
-On instances of graphics that drive a display with
-an offscreen buffer, calling this function will
-copy the contents of the offscreen buffer to the
+On instances of graphics that drive a display with an offscreen buffer, calling
+this function will copy the contents of the offscreen buffer to the screen.
+
+Call this when you have drawn something to Graphics and you want it shown on the
 screen.
 
-Call this when you have drawn something to Graphics
-and you want it shown on the screen.
+If a display does not have an offscreen buffer, it may not have a `g.flip()`
+method.
 
-If a display does not have an offscreen buffer,
-it may not have a `g.flip()` method.
+On Bangle.js 1, there are different graphics modes chosen with
+`Bangle.setLCDMode()`. The default mode is unbuffered and in this mode
+`g.flip()` does not affect the screen contents.
 
-On Bangle.js 1, there are different graphics modes
-chosen with `Bangle.setLCDMode()`. The default mode
-is unbuffered and in this mode `g.flip()` does not
-affect the screen contents.
-
-On some devices, this command will attempt to
-only update the areas of the screen that have
-changed in order to increase speed. If you have
-accessed the `Graphics.buffer` directly then you
-may need to use `Graphics.flip(true)` to force
-a full update of the screen.
+On some devices, this command will attempt to only update the areas of the
+screen that have changed in order to increase speed. If you have accessed the
+`Graphics.buffer` directly then you may need to use `Graphics.flip(true)` to
+force a full update of the screen.
 */
 /*JSON{
   "type" : "property",
@@ -458,9 +457,8 @@ a full update of the screen.
   "return" : ["JsVar","An ArrayBuffer (or not defined on Graphics instances not created with `Graphics.createArrayBuffer`)"],
   "typescript" : "buffer: IsBuffer extends true ? ArrayBuffer : undefined"
 }
-On Graphics instances with an offscreen buffer, this
-is an `ArrayBuffer` that provides access to the underlying
-pixel data.
+On Graphics instances with an offscreen buffer, this is an `ArrayBuffer` that
+provides access to the underlying pixel data.
 
 ```
 g=Graphics.createArrayBuffer(8,8,8)
@@ -532,9 +530,9 @@ void jswrap_graphics_init() {
   "return" : ["JsVar","An instance of `Graphics` or undefined"],
   "typescript" : "getInstance(): Graphics | undefined"
 }
-On devices like Pixl.js or HYSTM boards that contain a built-in display
-this will return an instance of the graphics class that can be used to
-access that display.
+On devices like Pixl.js or HYSTM boards that contain a built-in display this
+will return an instance of the graphics class that can be used to access that
+display.
 
 Internally, this is stored as a member called `gfx` inside the 'hiddenRoot'.
 */
@@ -568,7 +566,8 @@ static bool isValidBPP(int bpp) {
   "return_object" : "Graphics",
   "typescript" : "createArrayBuffer(width: number, height: number, bpp: number, options?: { zigzag?: boolean, vertical_byte?: boolean, msb?: boolean, color_order?: \"rgb\" | \"rbg\" | \"brg\" | \"bgr\" | \"grb\" | \"gbr\" }): Graphics<true>;"
 }
-Create a Graphics object that renders to an Array Buffer. This will have a field called 'buffer' that can get used to get at the buffer itself
+Create a Graphics object that renders to an Array Buffer. This will have a field
+called 'buffer' that can get used to get at the buffer itself
 */
 JsVar *jswrap_graphics_createArrayBuffer(int width, int height, int bpp, JsVar *options) {
   if (width<=0 || height<=0 || width>32767 || height>32767) {
@@ -648,7 +647,8 @@ JsVar *jswrap_graphics_createArrayBuffer(int width, int height, int bpp, JsVar *
   "return_object" : "Graphics",
   "typescript" : "createCallback(width: number, height: number, bpp: number, callback: ((x: number, y: number, col: number) => void) | { setPixel: (x: number, y: number, col: number) => void; fillRect: (x1: number, y1: number, x2: number, y2: number, col: number) => void }): Graphics<false>;"
 }
-Create a Graphics object that renders by calling a JavaScript callback function to draw pixels
+Create a Graphics object that renders by calling a JavaScript callback function
+to draw pixels
 */
 JsVar *jswrap_graphics_createCallback(int width, int height, int bpp, JsVar *callback) {
   if (width<=0 || height<=0 || width>32767 || height>32767) {
@@ -767,8 +767,8 @@ XXXXXXXXX
 g.drawImage(img, x,y);
 ```
 
-If the characters at the beginning and end of the string are newlines, they
-will be ignored. Spaces are treated as `0`, and any other character is a `1`
+If the characters at the beginning and end of the string are newlines, they will
+be ignored. Spaces are treated as `0`, and any other character is a `1`
 */
 JsVar *jswrap_graphics_createImage(JsVar *data) {
   if (!jsvIsString(data)) {
@@ -865,10 +865,10 @@ int jswrap_graphics_getWidthOrHeight(JsVar *parent, bool height) {
 }
 The number of bits per pixel of this Graphics instance
 
-**Note:** Bangle.js 2 behaves a little differently here. The display
-is 3 bit, so `getBPP` returns 3 and `asBMP`/`asImage`/etc return 3 bit images.
-However in order to allow dithering, the colors returned by `Graphics.getColor` and `Graphics.theme`
-are actually 16 bits.
+**Note:** Bangle.js 2 behaves a little differently here. The display is 3 bit,
+so `getBPP` returns 3 and `asBMP`/`asImage`/etc return 3 bit images. However in
+order to allow dithering, the colors returned by `Graphics.getColor` and
+`Graphics.theme` are actually 16 bits.
 */
 int jswrap_graphics_getBPP(JsVar *parent) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -887,8 +887,8 @@ int jswrap_graphics_getBPP(JsVar *parent) {
   "return" : ["JsVar","The instance of Graphics this was called on, to allow call chaining"],
   "return_object" : "Graphics"
 }
-Reset the state of Graphics to the defaults (e.g. Color, Font, etc)
-that would have been used when Graphics was initialised.
+Reset the state of Graphics to the defaults (e.g. Color, Font, etc) that would
+have been used when Graphics was initialised.
 */
 JsVar *jswrap_graphics_reset(JsVar *parent) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -1547,17 +1547,18 @@ JsVarInt jswrap_graphics_getColorX(JsVar *parent, bool isForeground) {
   "return" : ["JsVar","The instance of Graphics this was called on, to allow call chaining"],
   "return_object" : "Graphics"
 }
-This sets the 'clip rect' that subsequent drawing operations are clipped to
-sit between.
+This sets the 'clip rect' that subsequent drawing operations are clipped to sit
+between.
 
 These values are inclusive - e.g. `g.setClipRect(1,0,5,0)` will ensure that only
 pixel rows 1,2,3,4,5 are touched on column 0.
 
-**Note:** For maximum flexibility on Bangle.js 1, the values here are not range checked. For normal
-use, X and Y should be between 0 and `getWidth()-1`/`getHeight()-1`.
+**Note:** For maximum flexibility on Bangle.js 1, the values here are not range
+checked. For normal use, X and Y should be between 0 and
+`getWidth()-1`/`getHeight()-1`.
 
-**Note:** The x/y values here are rotated, so that if `Graphics.setRotation` is used
-they correspond to the coordinates given to the draw functions, *not to the
+**Note:** The x/y values here are rotated, so that if `Graphics.setRotation` is
+used they correspond to the coordinates given to the draw functions, *not to the
 physical device pixels*.
 */
 JsVar *jswrap_graphics_setClipRect(JsVar *parent, int x1, int y1, int x2, int y2) {
@@ -1617,7 +1618,8 @@ It is recommended that you use `Graphics.setFont("4x6")` for more flexibility.
 }
 Make subsequent calls to `drawString` use a Vector Font of the given height.
 
-It is recommended that you use `Graphics.setFont("Vector", size)` for more flexibility.
+It is recommended that you use `Graphics.setFont("Vector", size)` for more
+flexibility.
 */
 JsVar *jswrap_graphics_setFontSizeX(JsVar *parent, int size, bool isVectorFont) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -1659,13 +1661,16 @@ JsVar *jswrap_graphics_setFontSizeX(JsVar *parent, int size, bool isVectorFont) 
   "return_object" : "Graphics",
   "typescript" : "setFontCustom(bitmap: ArrayBuffer, firstChar: number, width: number | string, height: number): Graphics;"
 }
-Make subsequent calls to `drawString` use a Custom Font of the given height. See the [Fonts page](http://www.espruino.com/Fonts) for more
-information about custom fonts and how to create them.
+Make subsequent calls to `drawString` use a Custom Font of the given height. See
+the [Fonts page](http://www.espruino.com/Fonts) for more information about
+custom fonts and how to create them.
 
-For examples of use, see the [font modules](https://www.espruino.com/Fonts#font-modules).
+For examples of use, see the [font
+modules](https://www.espruino.com/Fonts#font-modules).
 
-**Note:** while you can specify the character code of the first character with `firstChar`,
-the newline character 13 will always be treated as a newline and not rendered.
+**Note:** while you can specify the character code of the first character with
+`firstChar`, the newline character 13 will always be treated as a newline and
+not rendered.
 */
 #ifndef SAVE_ON_FLASH
 JsVar *jswrap_graphics_setFontCustom(JsVar *parent, JsVar *bitmap, int firstChar, JsVar *width, int height) {
@@ -1802,7 +1807,7 @@ You can also use these forms, but they are not recommended:
 
 `g.getFont()` will return the current font as a String.
 
-For a list of available font names, you can use `g.getFonts()`. 
+For a list of available font names, you can use `g.getFonts()`.
 
 */
 JsVar *jswrap_graphics_setFont(JsVar *parent, JsVar *fontId, int size) {
@@ -1886,11 +1891,11 @@ JsVar *jswrap_graphics_setFont(JsVar *parent, JsVar *fontId, int size) {
 }
 Get the font by name - can be saved and used with `Graphics.setFont`.
 
-Normally this might return something like `"4x6"`, but if a scale
-factor is specified, a colon and then the size is reported, like "4x6:2"
+Normally this might return something like `"4x6"`, but if a scale factor is
+specified, a colon and then the size is reported, like "4x6:2"
 
-**Note:** For custom fonts, `Custom` is currently
-reported instead of the font name.
+**Note:** For custom fonts, `Custom` is currently reported instead of the font
+name.
 */
 JsVar *jswrap_graphics_getFont(JsVar *parent) {
 #ifndef SAVE_ON_FLASH
@@ -1939,8 +1944,8 @@ JsVar *jswrap_graphics_getFont(JsVar *parent) {
 }
 Return an array of all fonts currently in the Graphics library.
 
-**Note:** Vector fonts are specified as `Vector#` where `#` is the font height. As there
-are effectively infinite fonts, just `Vector` is included in the list.
+**Note:** Vector fonts are specified as `Vector#` where `#` is the font height.
+As there are effectively infinite fonts, just `Vector` is included in the list.
 */
 
 void jswrap_graphics_getFonts_callback(void *cbdata, JsVar *key) {
@@ -2284,9 +2289,9 @@ Draw a string of text in the current font.
 g.drawString("Hello World", 10, 10);
 ```
 
-Images may also be embedded inside strings (e.g. to render Emoji or characters not in the current font).
-To do this, just add `0` then the image string ([about Images](http://www.espruino.com/Graphics#images-bitmaps))
-For example:
+Images may also be embedded inside strings (e.g. to render Emoji or characters
+not in the current font). To do this, just add `0` then the image string ([about
+Images](http://www.espruino.com/Graphics#images-bitmaps)) For example:
 
 ```
 g.drawString("Hi \0\7\5\1\x82 D\x17\xC0");
@@ -2603,7 +2608,8 @@ JsVar *jswrap_graphics_moveTo(JsVar *parent, int x, int y) {
   "return_object" : "Graphics",
   "typescript" : "drawPoly(poly: number[], closed?: boolean): Graphics;"
 }
-Draw a polyline (lines between each of the points in `poly`) in the current foreground color
+Draw a polyline (lines between each of the points in `poly`) in the current
+foreground color
 
 **Note:** there is a limit of 64 points (128 XY elements) for polygons
 */
@@ -2621,7 +2627,8 @@ Draw a polyline (lines between each of the points in `poly`) in the current fore
   "return_object" : "Graphics",
   "typescript" : "drawPolyAA(poly: number[], closed?: boolean): Graphics;"
 }
-Draw an **antialiased** polyline (lines between each of the points in `poly`) in the current foreground color
+Draw an **antialiased** polyline (lines between each of the points in `poly`) in
+the current foreground color
 
 **Note:** there is a limit of 64 points (128 XY elements) for polygons
 */
@@ -2700,10 +2707,10 @@ g.fillPoly([
   0, 27 ]);
 ```
 
-This fills from the top left hand side of the polygon (low X, low Y)
-*down to but not including* the bottom right. When placed together polygons
-will align perfectly without overdraw - but this will not fill the
-same pixels as `drawPoly` (drawing a line around the edge of the polygon).
+This fills from the top left hand side of the polygon (low X, low Y) *down to
+but not including* the bottom right. When placed together polygons will align
+perfectly without overdraw - but this will not fill the same pixels as
+`drawPoly` (drawing a line around the edge of the polygon).
 
 **Note:** there is a limit of 64 points (128 XY elements) for polygons
 */
@@ -2732,10 +2739,10 @@ g.fillPolyAA([
   0, 27 ]);
 ```
 
-This fills from the top left hand side of the polygon (low X, low Y)
-*down to but not including* the bottom right. When placed together polygons
-will align perfectly without overdraw - but this will not fill the
-same pixels as `drawPoly` (drawing a line around the edge of the polygon).
+This fills from the top left hand side of the polygon (low X, low Y) *down to
+but not including* the bottom right. When placed together polygons will align
+perfectly without overdraw - but this will not fill the same pixels as
+`drawPoly` (drawing a line around the edge of the polygon).
 
 **Note:** there is a limit of 64 points (128 XY elements) for polygons
 */
@@ -2832,11 +2839,13 @@ JsVar *jswrap_graphics_setRotation(JsVar *parent, int rotation, bool reflect) {
   "return" : ["JsVar","An object containing `{width,height,bpp,transparent}` for the image"],
   "typescript" : "imageMetrics(img: Image): { width: number, height: number, bpp: number, transparent: number, frames?: ArrayBuffer[] } | undefined;"
 }
-Return the width and height in pixels of an image (either Graphics, Image Object, Image String or ArrayBuffer). Returns
-`undefined` if image couldn't be decoded.
+Return the width and height in pixels of an image (either Graphics, Image
+Object, Image String or ArrayBuffer). Returns `undefined` if image couldn't be
+decoded.
 
-`frames` is also included is the image contains more information than you'd expect for a single bitmap. In
-this case the bitmap might be an animation with multiple frames
+`frames` is also included is the image contains more information than you'd
+expect for a single bitmap. In this case the bitmap might be an animation with
+multiple frames
 */
 JsVar *jswrap_graphics_imageMetrics(JsVar *parent, JsVar *var) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -2874,21 +2883,32 @@ JsVar *jswrap_graphics_imageMetrics(JsVar *parent, JsVar *var) {
 }
 Image can be:
 
-* An object with the following fields `{ width : int, height : int, bpp : optional int, buffer : ArrayBuffer/String, transparent: optional int, palette : optional Uint16Array(2/4/16) }`. bpp = bits per pixel (default is 1), transparent (if defined) is the colour that will be treated as transparent, and palette is a color palette that each pixel will be looked up in first
-* A String where the the first few bytes are: `width,height,bpp,[transparent,]image_bytes...`. If a transparent colour is specified the top bit of `bpp` should be set.
-* An ArrayBuffer Graphics object (if `bpp<8`, `msb:true` must be set) - this is disabled on devices without much flash memory available
+* An object with the following fields `{ width : int, height : int, bpp :
+  optional int, buffer : ArrayBuffer/String, transparent: optional int,
+  palette : optional Uint16Array(2/4/16) }`. bpp = bits per pixel (default is
+  1), transparent (if defined) is the colour that will be treated as
+  transparent, and palette is a color palette that each pixel will be looked up
+  in first
+* A String where the the first few bytes are:
+  `width,height,bpp,[transparent,]image_bytes...`. If a transparent colour is
+  specified the top bit of `bpp` should be set.
+* An ArrayBuffer Graphics object (if `bpp<8`, `msb:true` must be set) - this is
+  disabled on devices without much flash memory available
 
 Draw an image at the specified position.
 
-* If the image is 1 bit, the graphics foreground/background colours will be used.
-* If `img.palette` is a Uint16Array or 2/4/16 elements, color data will be looked from the supplied palette
+* If the image is 1 bit, the graphics foreground/background colours will be
+  used.
+* If `img.palette` is a Uint16Array or 2/4/16 elements, color data will be
+  looked from the supplied palette
 * On Bangle.js, 2 bit images blend from background(0) to foreground(1) colours
 * On Bangle.js, 4 bit images use the Apple Mac 16 color palette
 * On Bangle.js, 8 bit images use the Web Safe 216 color palette
 * Otherwise color data will be copied as-is. Bitmaps are rendered MSB-first
 
-If `options` is supplied, `drawImage` will allow images to be rendered at any scale or angle. If `options.rotate` is set it will
-center images at `x,y`. `options` must be an object of the form:
+If `options` is supplied, `drawImage` will allow images to be rendered at any
+scale or angle. If `options.rotate` is set it will center images at `x,y`.
+`options` must be an object of the form:
 
 ```
 {
@@ -3223,9 +3243,10 @@ JsVar *jswrap_graphics_drawImages(JsVar *parent, JsVar *layersVar, JsVar *option
     "asImage(type: \"string\"): string;"
   ]
 }
-Return this Graphics object as an Image that can be used with `Graphics.drawImage`.
-Check out [the Graphics reference page](http://www.espruino.com/Graphics#images-bitmaps)
-for more information on images.
+Return this Graphics object as an Image that can be used with
+`Graphics.drawImage`. Check out [the Graphics reference
+page](http://www.espruino.com/Graphics#images-bitmaps) for more information on
+images.
 
 Will return undefined if data can't be allocated for the image.
 
@@ -3236,8 +3257,7 @@ The image data itself will be referenced rather than copied if:
 * Is 8 bpp *OR* the `{msb:true}` option was given
 * No other format options (zigzag/etc) were given
 
-Otherwise data will be copied, which takes up more space and
-may be quite slow.
+Otherwise data will be copied, which takes up more space and may be quite slow.
 */
 JsVar *jswrap_graphics_asImage(JsVar *parent, JsVar *imgType) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -3332,10 +3352,11 @@ JsVar *jswrap_graphics_asImage(JsVar *parent, JsVar *imgType) {
   "return" : ["JsVar","An object {x1,y1,x2,y2} containing the modified area, or undefined if not modified"],
   "typescript" : "getModified(reset?: boolean): { x1: number, y1: number, x2: number, y2: number };"
 }
-Return the area of the Graphics canvas that has been modified, and optionally clear
-the modified area to 0.
+Return the area of the Graphics canvas that has been modified, and optionally
+clear the modified area to 0.
 
-For instance if `g.setPixel(10,20)` was called, this would return `{x1:10, y1:20, x2:10, y2:20}`
+For instance if `g.setPixel(10,20)` was called, this would return `{x1:10,
+y1:20, x2:10, y2:20}`
 */
 JsVar *jswrap_graphics_getModified(JsVar *parent, bool reset) {
 #ifndef NO_MODIFIED_AREA
@@ -3379,8 +3400,8 @@ JsVar *jswrap_graphics_getModified(JsVar *parent, bool reset) {
 Scroll the contents of this graphics in a certain direction. The remaining area
 is filled with the background color.
 
-Note: This uses repeated pixel reads and writes, so will not work on platforms that
-don't support pixel reads.
+Note: This uses repeated pixel reads and writes, so will not work on platforms
+that don't support pixel reads.
 */
 JsVar *jswrap_graphics_scroll(JsVar *parent, int xdir, int ydir) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -3414,8 +3435,8 @@ g.blit({
 });
 ```
 
-Note: This uses repeated pixel reads and writes, so will not work on platforms that
-don't support pixel reads.
+Note: This uses repeated pixel reads and writes, so will not work on platforms
+that don't support pixel reads.
 */
 JsVar *jswrap_graphics_blit(JsVar *parent, JsVar *options) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -3486,7 +3507,8 @@ JsVar *jswrap_graphics_blit(JsVar *parent, JsVar *options) {
   "return" : ["JsVar","A String representing the Graphics as a Windows BMP file (or 'undefined' if not possible)"],
   "typescript" : "asBMP(): string;"
 }
-Create a Windows BMP file from this Graphics instance, and return it as a String.
+Create a Windows BMP file from this Graphics instance, and return it as a
+String.
 */
 JsVar *jswrap_graphics_asBMP(JsVar *parent) {
   JsGraphics gfx; if (!graphicsGetFromVar(&gfx, parent)) return 0;
@@ -3604,9 +3626,11 @@ JsVar *jswrap_graphics_asBMP(JsVar *parent) {
   "return" : ["JsVar","A String representing the Graphics as a URL (or 'undefined' if not possible)"],
   "typescript" : "asURL(): string;"
 }
-Create a URL of the form `data:image/bmp;base64,...` that can be pasted into the browser.
+Create a URL of the form `data:image/bmp;base64,...` that can be pasted into the
+browser.
 
-The Espruino Web IDE can detect this data on the console and render the image inline automatically.
+The Espruino Web IDE can detect this data on the console and render the image
+inline automatically.
 */
 JsVar *jswrap_graphics_asURL(JsVar *parent) {
   JsVar *imgData = jswrap_graphics_asBMP(parent);
@@ -3626,12 +3650,17 @@ JsVar *jswrap_graphics_asURL(JsVar *parent) {
   "#if" : "!defined(SAVE_ON_FLASH) && !defined(ESPRUINOBOARD)",
   "generate" : "jswrap_graphics_dump"
 }
-Output this image as a bitmap URL of the form `data:image/bmp;base64,...`. The Espruino Web IDE will detect this on the console and will render the image inline automatically.
+Output this image as a bitmap URL of the form `data:image/bmp;base64,...`. The
+Espruino Web IDE will detect this on the console and will render the image
+inline automatically.
 
-This is identical to `console.log(g.asURL())` - it is just a convenient function for easy debugging and producing screenshots of what is currently in the Graphics instance.
+This is identical to `console.log(g.asURL())` - it is just a convenient function
+for easy debugging and producing screenshots of what is currently in the
+Graphics instance.
 
-**Note:** This may not work on some bit depths of Graphics instances. It will also not work for the main Graphics instance
-of Bangle.js 1 as the graphics on Bangle.js 1 are stored in write-only memory.
+**Note:** This may not work on some bit depths of Graphics instances. It will
+also not work for the main Graphics instance of Bangle.js 1 as the graphics on
+Bangle.js 1 are stored in write-only memory.
 */
 void jswrap_graphics_dump(JsVar *parent) {
   JsVar *url = jswrap_graphics_asURL(parent);
@@ -3655,9 +3684,7 @@ void jswrap_graphics_dump(JsVar *parent) {
 }
  Calculate the square area under a Bezier curve.
 
- x0,y0: start point
- x1,y1: control point
- y2,y2: end point
+ x0,y0: start point x1,y1: control point y2,y2: end point
 
  Max 10 points without start point.
 */
@@ -3835,11 +3862,14 @@ Returns an object of the form:
 }
 ```
 
-These values can then be passed to `g.setColor`/`g.setBgColor` for example `g.setColor(g.theme.fg2)`. When the Graphics
-instance is reset, the background color is automatically set to `g.theme.bg` and foreground is set to `g.theme.fg`.
+These values can then be passed to `g.setColor`/`g.setBgColor` for example
+`g.setColor(g.theme.fg2)`. When the Graphics instance is reset, the background
+color is automatically set to `g.theme.bg` and foreground is set to
+`g.theme.fg`.
 
-On Bangle.js these values can be changed by writing updated values to `theme` in `settings.js` and reloading the app - or they can
-be changed temporarily by calling `Graphics.setTheme`
+On Bangle.js these values can be changed by writing updated values to `theme` in
+`settings.js` and reloading the app - or they can be changed temporarily by
+calling `Graphics.setTheme`
 */
 JsVar *jswrap_graphics_theme(JsVar *parent) {
   NOT_USED(parent);
@@ -3871,10 +3901,11 @@ JsVar *jswrap_graphics_theme(JsVar *parent) {
   "return_object" : "Graphics",
   "typescript" : "setTheme(theme: { [key in keyof Theme]?: Theme[key] extends number ? ColorResolvable | Theme[key] }): Graphics;"
 }
-Set the global colour scheme. On Bangle.js, this is reloaded from `settings.json` for each new app loaded.
+Set the global colour scheme. On Bangle.js, this is reloaded from
+`settings.json` for each new app loaded.
 
-See `Graphics.theme` for the fields that can be provided. For instance you can change
-the background to red using:
+See `Graphics.theme` for the fields that can be provided. For instance you can
+change the background to red using:
 
 ```
 g.setTheme({bg:"#f00"});

--- a/libs/graphics/jswrap_terminal.c
+++ b/libs/graphics/jswrap_terminal.c
@@ -28,9 +28,8 @@
 }
 A simple VT100 terminal emulator.
 
-When data is sent to the `Terminal` object, `Graphics.getInstance()`
-is called and if an instance of `Graphics` is found then characters
-are written to it.
+When data is sent to the `Terminal` object, `Graphics.getInstance()` is called
+and if an instance of `Graphics` is found then characters are written to it.
 */
 
 #ifdef USE_FONT_6X8

--- a/libs/hexbadge/jswrap_hexbadge.c
+++ b/libs/hexbadge/jswrap_hexbadge.c
@@ -178,7 +178,8 @@ Class containing utility functions for accessing IO on the hexagonal badge
 }
 Capacitive sense - the higher the capacitance, the higher the number returned.
 
-Supply a corner number between 1 and 6, and an integer value will be returned that is proportional to the capacitance
+Supply a corner number between 1 and 6, and an integer value will be returned
+that is proportional to the capacitance
 */
 int jswrap_badge_capSense(int corner) {
   if (corner>=1 && corner<=6) {
@@ -194,8 +195,8 @@ int jswrap_badge_capSense(int corner) {
     "generate" : "jswrap_badge_getBatteryPercentage",
     "return" : ["int", "A percentage between 0 and 100" ]
 }
-Return an approximate battery percentage remaining based on
-a normal CR2032 battery (2.8 - 2.2v)
+Return an approximate battery percentage remaining based on a normal CR2032
+battery (2.8 - 2.2v)
 */
 int jswrap_badge_getBatteryPercentage() {
   JsVarFloat v = jswrap_ble_getBattery();
@@ -246,7 +247,7 @@ void badge_lcd_flip(JsVar *g) {
       ["c","float","Contrast between 0 and 1"]
     ]
 }
-Set the LCD's contrast */
+Set the LCD's contrast*/
 void jswrap_badge_setContrast(JsVarFloat c) {
   if (c<0) c=0;
   if (c>1) c=1;

--- a/libs/math/jswrap_math.c
+++ b/libs/math/jswrap_math.c
@@ -458,7 +458,8 @@ double jswrap_math_sqrt(double x) {
   ],
   "return" : ["float","The value of x, clipped so as not to be below min or above max."]
 }
-DEPRECATED - Please use `E.clip()` instead. Clip a number to be between min and max (inclusive)
+DEPRECATED - Please use `E.clip()` instead. Clip a number to be between min and
+max (inclusive)
 */
 JsVarFloat jswrap_math_clip(JsVarFloat x, JsVarFloat min, JsVarFloat max) {
   if (x<min) x=min;
@@ -480,7 +481,8 @@ JsVarFloat jswrap_math_clip(JsVarFloat x, JsVarFloat min, JsVarFloat max) {
 }
 DEPRECATED - This is not part of standard JavaScript libraries
 
-Wrap a number around if it is less than 0 or greater than or equal to max. For instance you might do: ```Math.wrap(angleInDegrees, 360)```
+Wrap a number around if it is less than 0 or greater than or equal to max. For
+instance you might do: ```Math.wrap(angleInDegrees, 360)```
 */
 
 /*JSON{

--- a/libs/microbit/jswrap_microbit.c
+++ b/libs/microbit/jswrap_microbit.c
@@ -223,13 +223,15 @@ void jswrap_microbit_kill() {
   ],
   "ifdef" : "MICROBIT"
 }
-**Note:** This function is only available on the [BBC micro:bit](/MicroBit) board
+**Note:** This function is only available on the [BBC micro:bit](/MicroBit)
+board
 
 Show an image on the in-built 5x5 LED screen.
 
 Image can be:
 
-* A number where each bit represents a pixel (so 25 bits). eg. `5` or `0x1FFFFFF`
+* A number where each bit represents a pixel (so 25 bits). eg. `5` or
+  `0x1FFFFFF`
 * A string, eg: `show("10001")`. Newlines are ignored, and anything that is not
 a space or `0` is treated as a 1.
 * An array of 4 bytes (more will be ignored), eg `show([1,2,3,0])`
@@ -330,7 +332,8 @@ JsVar *getXYZ(int x, int y, int z, JsVarFloat range) {
   "return" : ["JsVar", "An object with x, y, and z fields in it"],
   "ifdef" : "MICROBIT"
 }
-**Note:** This function is only available on the [BBC micro:bit](/MicroBit) board
+**Note:** This function is only available on the [BBC micro:bit](/MicroBit)
+board
 
 Get the current acceleration of the micro:bit from the on-board accelerometer
 
@@ -369,9 +372,11 @@ JsVar *jswrap_microbit_acceleration() {
   "return" : ["JsVar", "An object with x, y, and z fields in it"],
   "ifdef" : "MICROBIT"
 }
-**Note:** This function is only available on the [BBC micro:bit](/MicroBit) board
+**Note:** This function is only available on the [BBC micro:bit](/MicroBit)
+board
 
-Get the current compass position for the micro:bit from the on-board magnetometer
+Get the current compass position for the micro:bit from the on-board
+magnetometer
 
 **This is deprecated.** Please use `Microbit.mag` instead.
 */
@@ -562,7 +567,8 @@ The micro:bit's microphone enable pin
     "class" : "Microbit",
     "ifdef" : "MICROBIT"
 }
-Class containing [micro:bit's](https://www.espruino.com/MicroBit) utility functions.
+Class containing [micro:bit's](https://www.espruino.com/MicroBit) utility
+functions.
 */
 /*JSON{
   "type" : "event",
@@ -573,7 +579,8 @@ Class containing [micro:bit's](https://www.espruino.com/MicroBit) utility functi
   ],
   "ifdef" : "MICROBIT2"
 }
-Called when the Micro:bit is moved in a deliberate fashion, and includes data on the detected gesture.
+Called when the Micro:bit is moved in a deliberate fashion, and includes data on
+the detected gesture.
  */
 /*JSON{
   "type" : "staticmethod",
@@ -602,7 +609,8 @@ Called when the Micro:bit is moved in a deliberate fashion, and includes data on
   ],
   "ifdef" : "MICROBIT2"
 }
-**Note:** This function is only available on the [BBC micro:bit](/MicroBit) board
+**Note:** This function is only available on the [BBC micro:bit](/MicroBit)
+board
 
 Write the given value to the accelerometer
 */
@@ -627,10 +635,11 @@ void jswrap_microbit_accelWr(int a, int data) {
   "generate" : "jswrap_microbit_accelOn",
   "ifdef" : "MICROBIT2"
 }
-Turn on the accelerometer, and create `Microbit.accel` and `Microbit.gesture` events.
+Turn on the accelerometer, and create `Microbit.accel` and `Microbit.gesture`
+events.
 
-**Note:** The accelerometer is currently always enabled - this code
-just responds to interrupts and reads
+**Note:** The accelerometer is currently always enabled - this code just
+responds to interrupts and reads
 */
 void jswrap_microbit_accelOn() {
   if (accel_watch) return;

--- a/libs/misc/jswrap_unistroke.c
+++ b/libs/misc/jswrap_unistroke.c
@@ -19,8 +19,8 @@
     "class" : "Unistroke",
     "ifdef" : "BANGLEJS2"
 }
-This class provides functionality to recognise gestures drawn
-on a touchscreen. It is only built into Bangle.js 2.
+This class provides functionality to recognise gestures drawn on a touchscreen.
+It is only built into Bangle.js 2.
 
 Usage:
 

--- a/libs/neopixel/jswrap_neopixel.c
+++ b/libs/neopixel/jswrap_neopixel.c
@@ -58,8 +58,8 @@ implementation on some devices - hence this library to simplify things.
     ["data","JsVar","The data to write to the LED strip (must be a multiple of 3 bytes long)"]
   ]
 }
-Write to a strip of NeoPixel/WS281x/APA104/APA106/SK6812-style LEDs
-attached to the given pin.
+Write to a strip of NeoPixel/WS281x/APA104/APA106/SK6812-style LEDs attached to
+the given pin.
 
 ```
 // set just one pixel, red, green, blue
@@ -86,25 +86,23 @@ setInterval(function() {
 
 **Note:**
 
-* Different types of LED have the data in different orders - so don't
-be surprised by RGB or BGR orderings!
+* Different types of LED have the data in different orders - so don't be
+surprised by RGB or BGR orderings!
 
-* Some LED strips (SK6812) actually take 4 bytes per LED (red, green, blue and white).
-These are still supported but the array of data supplied must still be a multiple of 3
-bytes long. Just round the size up - it won't cause any problems.
+* Some LED strips (SK6812) actually take 4 bytes per LED (red, green, blue and
+white). These are still supported but the array of data supplied must still be a
+multiple of 3 bytes long. Just round the size up - it won't cause any problems.
 
-* On some platforms like STM32, pins capable of hardware SPI MOSI
-are required.
+* On some platforms like STM32, pins capable of hardware SPI MOSI are required.
 
-* Espruino devices tend to have 3.3v IO, while WS2812/etc run
-off of 5v. Many WS2812 will only register a logic '1' at 70%
-of their input voltage - so if powering them off 5v you will not
-be able to send them data reliably. You can work around this by
-powering the LEDs off a lower voltage (for example 3.7v from a LiPo
-battery), can put the output into the `af_opendrain` state and use
-a pullup resistor to 5v on STM32 based boards (nRF52 are not 5v tolerant
-so you can't do this), or can use a level shifter to shift the voltage up
-into the 5v range.
+* Espruino devices tend to have 3.3v IO, while WS2812/etc run off of 5v. Many
+WS2812 will only register a logic '1' at 70% of their input voltage - so if
+powering them off 5v you will not be able to send them data reliably. You can
+work around this by powering the LEDs off a lower voltage (for example 3.7v from
+a LiPo battery), can put the output into the `af_opendrain` state and use a
+pullup resistor to 5v on STM32 based boards (nRF52 are not 5v tolerant so you
+can't do this), or can use a level shifter to shift the voltage up into the 5v
+range.
 */
 void jswrap_neopixel_write(Pin pin, JsVar *data) {
   JSV_GET_AS_CHAR_ARRAY(rgbData, rgbSize, data);

--- a/libs/network/cc3000/jswrap_cc3000.c
+++ b/libs/network/cc3000/jswrap_cc3000.c
@@ -166,7 +166,8 @@ bool jswrap_wlan_connect(JsVar *wlanObj, JsVar *vAP, JsVar *vKey, JsVar *callbac
   "name" : "disconnect",
   "generate" : "jswrap_wlan_disconnect"
 }
-Completely uninitialise and power down the CC3000. After this you'll have to use ```require("CC3000").connect()``` again.
+Completely uninitialise and power down the CC3000. After this you'll have to use
+```require("CC3000").connect()``` again.
 */
 void jswrap_wlan_disconnect(JsVar *wlanObj) {
   JsNetwork net;
@@ -186,7 +187,8 @@ void jswrap_wlan_disconnect(JsVar *wlanObj) {
   "name" : "reconnect",
   "generate" : "jswrap_wlan_reconnect"
 }
-Completely uninitialise and power down the CC3000, then reconnect to the old access point.
+Completely uninitialise and power down the CC3000, then reconnect to the old
+access point.
 */
 void jswrap_wlan_reconnect(JsVar *wlanObj) {
   JsNetwork net;
@@ -262,9 +264,11 @@ static void _wlan_getIP_set_address(JsVar *options, char *name, unsigned char *p
   ],
   "return" : ["bool","True on success"]
 }
-Set the current IP address for get an IP from DHCP (if no options object is specified).
+Set the current IP address for get an IP from DHCP (if no options object is
+specified).
 
-**Note:** Changes are written to non-volatile memory, but will only take effect after calling `wlan.reconnect()`
+**Note:** Changes are written to non-volatile memory, but will only take effect
+after calling `wlan.reconnect()`
 */
 bool jswrap_wlan_setIP(JsVar *wlanObj, JsVar *options) {
   NOT_USED(wlanObj);

--- a/libs/network/esp8266/jswrap_esp8266_network.c
+++ b/libs/network/esp8266/jswrap_esp8266_network.c
@@ -218,8 +218,11 @@ static char macFmt[] = "%02x:%02x:%02x:%02x:%02x:%02x";
    "type": "library",
    "class": "ESP8266"
 }
-The ESP8266 library is specific to the ESP8266 version of Espruino, i.e., running Espruino on an ESP8266 module (not to be confused with using the ESP8266 as Wifi add-on to an Espruino board).  This library contains functions to handle ESP8266-specific actions.
-For example: `var esp8266 = require('ESP8266'); esp8266.reboot();` performs a hardware reset of the module.
+The ESP8266 library is specific to the ESP8266 version of Espruino, i.e.,
+running Espruino on an ESP8266 module (not to be confused with using the ESP8266
+as Wifi add-on to an Espruino board). This library contains functions to handle
+ESP8266-specific actions. For example: `var esp8266 = require('ESP8266');
+esp8266.reboot();` performs a hardware reset of the module.
 */
 
 /** Get the global object for the Wifi library/module, this is used in order to send the
@@ -1255,8 +1258,9 @@ void   jswrap_ESP8266_wifi_init1() {
   "generate":"jswrap_ESP8266_wifi_soft_init"
 }
 
-// This function is called in soft_init to hook-up the network. This happens from user_main's
-// init_done() and also from `reset()` in order to re-hook-up the network.
+// This function is called in soft_init to hook-up the network. This happens
+from user_main's // init_done() and also from `reset()` in order to re-hook-up
+the network.
 */
 void jswrap_ESP8266_wifi_soft_init() {
   DBGV("> Wifi.soft_init\n");
@@ -1283,7 +1287,8 @@ void jswrap_ESP8266_wifi_soft_init() {
 }
 **DEPRECATED** - please use `Wifi.ping` instead.
 
-Perform a network ping request. The parameter can be either a String or a numeric IP address.
+Perform a network ping request. The parameter can be either a String or a
+numeric IP address.
 */
 void jswrap_wifi_ping(
     JsVar *ipAddr,      //!< A string or integer representation of an IP address.

--- a/libs/network/http/jswrap_http.c
+++ b/libs/network/http/jswrap_http.c
@@ -26,9 +26,12 @@
 }
 This library allows you to create http servers and make http requests
 
-In order to use this, you will need an extra module to get network connectivity such as the [TI CC3000](/CC3000) or [WIZnet W5500](/WIZnet).
+In order to use this, you will need an extra module to get network connectivity
+such as the [TI CC3000](/CC3000) or [WIZnet W5500](/WIZnet).
 
-This is designed to be a cut-down version of the [node.js library](http://nodejs.org/api/http.html). Please see the [Internet](/Internet) page for more information on how to use it.
+This is designed to be a cut-down version of the [node.js
+library](http://nodejs.org/api/http.html). Please see the [Internet](/Internet)
+page for more information on how to use it.
 */
 
 /*JSON{
@@ -55,7 +58,9 @@ The HTTP server request
     ["data","JsVar","A string containing one or more characters of received data"]
   ]
 }
-The 'data' event is called when data is received. If a handler is defined with `X.on('data', function(data) { ... })` then it will be called, otherwise data will be stored in an internal buffer, where it can be retrieved with `X.read()`
+The 'data' event is called when data is received. If a handler is defined with
+`X.on('data', function(data) { ... })` then it will be called, otherwise data
+will be stored in an internal buffer, where it can be retrieved with `X.read()`
 */
 /*JSON{
   "type" : "event",
@@ -104,7 +109,8 @@ The URL requested in this HTTP request, for instance:
   "generate" : "jswrap_stream_available",
   "return" : ["int","How many bytes are available"]
 }
-Return how many bytes are available to read. If there is already a listener for data, this will always return 0.
+Return how many bytes are available to read. If there is already a listener for
+data, this will always return 0.
 */
 /*JSON{
   "type" : "method",
@@ -144,7 +150,8 @@ The HTTP server response
   "class" : "httpSRs",
   "name" : "drain"
 }
-An event that is fired when the buffer is empty and it can accept more data to send.
+An event that is fired when the buffer is empty and it can accept more data to
+send.
 */
 /*JSON{
   "type" : "event",
@@ -166,14 +173,18 @@ The HTTP client request, returned by `http.request()` and `http.get()`.
   "class" : "httpCRq",
   "name" : "drain"
 }
-An event that is fired when the buffer is empty and it can accept more data to send.
+An event that is fired when the buffer is empty and it can accept more data to
+send.
 */
 /*JSON{
   "type" : "event",
   "class" : "httpCRq",
   "name" : "error"
 }
-An event that is fired if there is an error making the request and the response callback has not been invoked. In this case the error event concludes the request attempt. The error event function receives an error object as parameter with a `code` field and a `message` field.
+An event that is fired if there is an error making the request and the response
+callback has not been invoked. In this case the error event concludes the
+request attempt. The error event function receives an error object as parameter
+with a `code` field and a `message` field.
 */
 
 /*JSON{
@@ -181,7 +192,8 @@ An event that is fired if there is an error making the request and the response 
   "library" : "http",
   "class" : "httpCRs"
 }
-The HTTP client response, passed to the callback of `http.request()` an `http.get()`.
+The HTTP client response, passed to the callback of `http.request()` an
+`http.get()`.
 */
 /*JSON{
   "type" : "event",
@@ -191,21 +203,27 @@ The HTTP client response, passed to the callback of `http.request()` an `http.ge
     ["data","JsVar","A string containing one or more characters of received data"]
   ]
 }
-The 'data' event is called when data is received. If a handler is defined with `X.on('data', function(data) { ... })` then it will be called, otherwise data will be stored in an internal buffer, where it can be retrieved with `X.read()`
+The 'data' event is called when data is received. If a handler is defined with
+`X.on('data', function(data) { ... })` then it will be called, otherwise data
+will be stored in an internal buffer, where it can be retrieved with `X.read()`
 */
 /*JSON{
   "type" : "event",
   "class" : "httpCRs",
   "name" : "close"
 }
-Called when the connection closes with one `hadError` boolean parameter, which indicates whether an error occurred.
+Called when the connection closes with one `hadError` boolean parameter, which
+indicates whether an error occurred.
 */
 /*JSON{
   "type" : "event",
   "class" : "httpCRs",
   "name" : "error"
 }
-An event that is fired if there is an error receiving the response. The error event function receives an error object as parameter with a `code` field and a `message` field. After the error event the close even will also be triggered to conclude the HTTP request/response.
+An event that is fired if there is an error receiving the response. The error
+event function receives an error object as parameter with a `code` field and a
+`message` field. After the error event the close even will also be triggered to
+conclude the HTTP request/response.
 */
 /*JSON{
     "type" : "property",
@@ -250,7 +268,8 @@ The HTTP version reported back by the server - usually `"1.1"`
   "generate" : "jswrap_stream_available",
   "return" : ["int","How many bytes are available"]
 }
-Return how many bytes are available to read. If there is a 'data' event handler, this will always return 0.
+Return how many bytes are available to read. If there is a 'data' event handler,
+this will always return 0.
 */
 /*JSON{
   "type" : "method",
@@ -300,7 +319,9 @@ Pipe this to a stream (an object with a 'write' method)
 }
 Create an HTTP Server
 
-When a request to the server is made, the callback is called. In the callback you can use the methods on the response (`httpSRs`) to send data. You can also add `request.on('data',function() { ... })` to listen for POSTed data
+When a request to the server is made, the callback is called. In the callback
+you can use the methods on the response (`httpSRs`) to send data. You can also
+add `request.on('data',function() { ... })` to listen for POSTed data
 */
 
 JsVar *jswrap_http_createServer(JsVar *callback) {
@@ -326,7 +347,8 @@ JsVar *jswrap_http_createServer(JsVar *callback) {
   "return" : ["JsVar","Returns a new httpCRq object"],
   "return_object" : "httpCRq"
 }
-Create an HTTP Request - `end()` must be called on it to complete the operation. `options` is of the form:
+Create an HTTP Request - `end()` must be called on it to complete the operation.
+`options` is of the form:
 
 ```
 var options = {
@@ -349,12 +371,14 @@ var req = require("http").request(options, function(res) {
 req.end(); // called to finish the HTTP request and get the response
 ```
 
-You can easily pre-populate `options` from a URL using `var options = url.parse("http://www.example.com/foo.html")`
+You can easily pre-populate `options` from a URL using `var options =
+url.parse("http://www.example.com/foo.html")`
 
-There's an example of using [`http.request` for HTTP POST here](/Internet#http-post)
+There's an example of using [`http.request` for HTTP POST
+here](/Internet#http-post)
 
-**Note:** if TLS/HTTPS is enabled, options can have `ca`, `key` and `cert` fields. See `tls.connect` for
-more information about these and how to use them.
+**Note:** if TLS/HTTPS is enabled, options can have `ca`, `key` and `cert`
+fields. See `tls.connect` for more information about these and how to use them.
 
 */
 
@@ -370,7 +394,8 @@ more information about these and how to use them.
   "return" : ["JsVar","Returns a new httpCRq object"],
   "return_object" : "httpCRq"
 }
-Request a webpage over HTTP - a convenience function for `http.request()` that makes sure the HTTP command is 'GET', and that calls `end` automatically.
+Request a webpage over HTTP - a convenience function for `http.request()` that
+makes sure the HTTP command is 'GET', and that calls `end` automatically.
 
 ```
 require("http").get("http://pur3.co.uk/hello.txt", function(res) {
@@ -383,7 +408,8 @@ require("http").get("http://pur3.co.uk/hello.txt", function(res) {
 });
 ```
 
-See `http.request()` and [the Internet page](/Internet) and ` for more usage examples.
+See `http.request()` and [the Internet page](/Internet) and ` for more usage
+examples.
 */
 JsVar *jswrap_http_get(JsVar *options, JsVar *callback) {
   JsNetwork net;
@@ -469,8 +495,9 @@ The default contents are:
   "return" : ["bool","For node.js compatibility, returns the boolean false. When the send buffer is empty, a `drain` event will be sent"]
 }
 This function writes the `data` argument as a string. Data that is passed in
-(including arrays) will be converted to a string with the normal JavaScript 
-`toString` method. For more information about sending binary data see `Socket.write`
+(including arrays) will be converted to a string with the normal JavaScript
+`toString` method. For more information about sending binary data see
+`Socket.write`
 */
 bool jswrap_httpSRs_write(JsVar *parent, JsVar *data) {
   serverResponseWrite(parent, data);
@@ -504,12 +531,11 @@ void jswrap_httpSRs_end(JsVar *parent, JsVar *data) {
     ["headers","JsVar","An object containing the headers"]
   ]
 }
-Send the given status code and headers. If not explicitly called
-this will be done automatically the first time data is written
-to the response.
+Send the given status code and headers. If not explicitly called this will be
+done automatically the first time data is written to the response.
 
-This cannot be called twice, or after data has already been sent
-in the response.
+This cannot be called twice, or after data has already been sent in the
+response.
 */
 void jswrap_httpSRs_writeHead(JsVar *parent, int statusCode, JsVar *headers) {
   serverResponseWriteHead(parent, statusCode, headers);
@@ -525,9 +551,11 @@ void jswrap_httpSRs_writeHead(JsVar *parent, int statusCode, JsVar *headers) {
     ["value","JsVar","The value of the header as a String"]
   ]
 }
-Set a value to send in the header of this HTTP response. This updates the `httpSRs.headers` property.
+Set a value to send in the header of this HTTP response. This updates the
+`httpSRs.headers` property.
 
-Any headers supplied to `writeHead` will overwrite any headers with the same name.
+Any headers supplied to `writeHead` will overwrite any headers with the same
+name.
 */
 void jswrap_httpSRs_setHeader(JsVar *parent, JsVar *name, JsVar *value) {
   serverResponseSetHeader(parent, name, value);
@@ -548,8 +576,9 @@ void jswrap_httpSRs_setHeader(JsVar *parent, JsVar *name, JsVar *value) {
   "return" : ["bool","For node.js compatibility, returns the boolean false. When the send buffer is empty, a `drain` event will be sent"]
 }
 This function writes the `data` argument as a string. Data that is passed in
-(including arrays) will be converted to a string with the normal JavaScript 
-`toString` method. For more information about sending binary data see `Socket.write`
+(including arrays) will be converted to a string with the normal JavaScript
+`toString` method. For more information about sending binary data see
+`Socket.write`
 */
 // Re-use existing
 

--- a/libs/network/js/jswrap_jsnetwork.c
+++ b/libs/network/js/jswrap_jsnetwork.c
@@ -38,7 +38,8 @@ Library that initialises a network device that calls into JavaScript
   ],
   "return" : ["JsVar","The object passed in"]
 }
-Initialise the network using the callbacks given and return the first argument. For instance:
+Initialise the network using the callbacks given and return the first argument.
+For instance:
 
 ```
 require("NetworkJS").create({
@@ -68,8 +69,9 @@ require("NetworkJS").create({
 });
 ```
 
-`socketType` is an integer - 2 for UDP, or see SocketType in https://github.com/espruino/Espruino/blob/master/libs/network/network.h
-for more information.
+`socketType` is an integer - 2 for UDP, or see SocketType in
+https://github.com/espruino/Espruino/blob/master/libs/network/network.h for more
+information.
 */
 JsVar *jswrap_networkjs_create(JsVar *obj) {
   JsNetwork net;

--- a/libs/network/jswrap_net.c
+++ b/libs/network/jswrap_net.c
@@ -64,7 +64,8 @@ void jswrap_net_kill() {
   "type" : "class",
   "class" : "url"
 }
-This class helps to convert URLs into Objects of information ready for http.request/get
+This class helps to convert URLs into Objects of information ready for
+http.request/get
 */
 
 
@@ -83,7 +84,8 @@ A utility function to split a URL into parts
 
 This is useful in web servers for instance when handling a request.
 
-For instance `url.parse("/a?b=c&d=e",true)` returns `{"method":"GET","host":"","path":"/a?b=c&d=e","pathname":"/a","search":"?b=c&d=e","port":80,"query":{"b":"c","d":"e"}}`
+For instance `url.parse("/a?b=c&d=e",true)` returns
+`{"method":"GET","host":"","path":"/a?b=c&d=e","pathname":"/a","search":"?b=c&d=e","port":80,"query":{"b":"c","d":"e"}}`
 */
 JsVar *jswrap_url_parse(JsVar *url, bool parseQuery) {
   if (!jsvIsString(url)) return 0;
@@ -219,7 +221,9 @@ This library allows you to create TCPIP servers and clients
 
 In order to use this, you will need an extra module to get network connectivity.
 
-This is designed to be a cut-down version of the [node.js library](http://nodejs.org/api/net.html). Please see the [Internet](/Internet) page for more information on how to use it.
+This is designed to be a cut-down version of the [node.js
+library](http://nodejs.org/api/net.html). Please see the [Internet](/Internet)
+page for more information on how to use it.
 */
 
 /*JSON{
@@ -244,7 +248,9 @@ An actual socket connection - allowing transmit/receive of TCP data
     ["data","JsVar","A string containing one or more characters of received data"]
   ]
 }
-The 'data' event is called when data is received. If a handler is defined with `X.on('data', function(data) { ... })` then it will be called, otherwise data will be stored in an internal buffer, where it can be retrieved with `X.read()`
+The 'data' event is called when data is received. If a handler is defined with
+`X.on('data', function(data) { ... })` then it will be called, otherwise data
+will be stored in an internal buffer, where it can be retrieved with `X.read()`
 */
 /*JSON{
   "type" : "event",
@@ -264,10 +270,12 @@ Called when the connection closes.
     ["details","JsVar","An error object with an error code (a negative integer) and a message."]
   ]
 }
-There was an error on this socket and it is closing (or wasn't opened in the first place). If a "connected" event was issued on this socket then the error event is always followed by a close event.
-The error codes are:
+There was an error on this socket and it is closing (or wasn't opened in the
+first place). If a "connected" event was issued on this socket then the error
+event is always followed by a close event. The error codes are:
 
-* -1: socket closed (this is not really an error and will not cause an error callback)
+* -1: socket closed (this is not really an error and will not cause an error
+  callback)
 * -2: out of memory (typically while allocating a buffer to hold data)
 * -3: timeout
 * -4: no route
@@ -290,7 +298,8 @@ The error codes are:
   "generate" : "jswrap_stream_available",
   "return" : ["int","How many bytes are available"]
 }
-Return how many bytes are available to read. If there is already a listener for data, this will always return 0.
+Return how many bytes are available to read. If there is already a listener for
+data, this will always return 0.
 */
 /*JSON{
   "type" : "method",
@@ -322,7 +331,8 @@ Pipe this to a stream (an object with a 'write' method)
   "class" : "Socket",
   "name" : "drain"
 }
-An event that is fired when the buffer is empty and it can accept more data to send.
+An event that is fired when the buffer is empty and it can accept more data to
+send.
 */
 
 
@@ -344,7 +354,9 @@ An event that is fired when the buffer is empty and it can accept more data to s
 }
 Create a Server
 
-When a request to the server is made, the callback is called. In the callback you can use the methods on the connection to send data. You can also add `connection.on('data',function() { ... })` to listen for received data
+When a request to the server is made, the callback is called. In the callback
+you can use the methods on the connection to send data. You can also add
+`connection.on('data',function() { ... })` to listen for received data
 */
 
 JsVar *jswrap_net_createServer(JsVar *callback) {
@@ -434,7 +446,9 @@ This library allows you to create UDP/DATAGRAM servers and clients
 
 In order to use this, you will need an extra module to get network connectivity.
 
-This is designed to be a cut-down version of the [node.js library](http://nodejs.org/api/dgram.html). Please see the [Internet](/Internet) page for more information on how to use it.
+This is designed to be a cut-down version of the [node.js
+library](http://nodejs.org/api/dgram.html). Please see the [Internet](/Internet)
+page for more information on how to use it.
 */
 
 /*JSON{
@@ -524,7 +538,8 @@ void jswrap_dgram_socket_send(JsVar *parent, JsVar *buffer, JsVar *offset, JsVar
     ["rinfo","JsVar","Sender address,port containing information"]
   ]
 }
-The 'message' event is called when a datagram message is received. If a handler is defined with `X.on('message', function(msg) { ... })` then it will be called`
+The 'message' event is called when a datagram message is received. If a handler
+is defined with `X.on('message', function(msg) { ... })` then it will be called`
 */
 
 /*JSON{
@@ -609,7 +624,9 @@ This library allows you to create TCPIP servers and clients using TLS encryption
 
 In order to use this, you will need an extra module to get network connectivity.
 
-This is designed to be a cut-down version of the [node.js library](http://nodejs.org/api/tls.html). Please see the [Internet](/Internet) page for more information on how to use it.
+This is designed to be a cut-down version of the [node.js
+library](http://nodejs.org/api/tls.html). Please see the [Internet](/Internet)
+page for more information on how to use it.
 */
 
 /*JSON{
@@ -627,7 +644,8 @@ This is designed to be a cut-down version of the [node.js library](http://nodejs
 }
 Create a socket connection using TLS
 
-Options can have `ca`, `key` and `cert` fields, which should be the decoded content of the certificate.
+Options can have `ca`, `key` and `cert` fields, which should be the decoded
+content of the certificate.
 
 ```
 var options = url.parse("localhost:1234");
@@ -637,11 +655,15 @@ options.ca = atob("MIIFgDCC ... GosQML4sc=");
 require("tls").connect(options, ... );
 ```
 
-If you have the certificates as `.pem` files, you need to load these files, take the information between the lines beginning with `----`, remove the newlines from it so you have raw base64, and then feed it into `atob` as above.
+If you have the certificates as `.pem` files, you need to load these files, take
+the information between the lines beginning with `----`, remove the newlines
+from it so you have raw base64, and then feed it into `atob` as above.
 
 You can also:
-* Just specify the filename (<=100 characters) and it will be loaded and parsed if you have an SD card connected. For instance `options.key = "key.pem";`
-* Specify a function, which will be called to retrieve the data.  For instance `options.key = function() { eeprom.load_my_info(); };
+* Just specify the filename (<=100 characters) and it will be loaded and parsed
+  if you have an SD card connected. For instance `options.key = "key.pem";`
+* Specify a function, which will be called to retrieve the data. For instance
+  `options.key = function() { eeprom.load_my_info(); };
 
 For more information about generating and using certificates, see:
 
@@ -710,13 +732,13 @@ void jswrap_net_server_close(JsVar *parent) {
   "return" : ["bool","For node.js compatibility, returns the boolean false. When the send buffer is empty, a `drain` event will be sent"]
 }
 This function writes the `data` argument as a string. Data that is passed in
-(including arrays) will be converted to a string with the normal JavaScript 
+(including arrays) will be converted to a string with the normal JavaScript
 `toString` method.
 
-If you wish to send binary data then you need to convert that data directly to a 
+If you wish to send binary data then you need to convert that data directly to a
 String. This can be done with `String.fromCharCode`, however it's often easier
-and faster to use the Espruino-specific `E.toString`, which will read its arguments
-as an array of bytes and convert that to a String:
+and faster to use the Espruino-specific `E.toString`, which will read its
+arguments as an array of bytes and convert that to a String:
 
 ```
 socket.write(E.toString([0,1,2,3,4,5]));

--- a/libs/network/jswrap_wifi.c
+++ b/libs/network/jswrap_wifi.c
@@ -18,9 +18,9 @@
    "type": "library",
    "class": "Wifi"
 }
-The Wifi library is designed to control the Wifi interface. It supports functionality
-such as connecting to wifi networks, getting network information, starting an access
-point, etc.
+The Wifi library is designed to control the Wifi interface. It supports
+functionality such as connecting to wifi networks, getting network information,
+starting an access point, etc.
 
 It is available on these devices:
 
@@ -28,17 +28,19 @@ It is available on these devices:
 * [ESP8266](http://www.espruino.com/EspruinoESP8266)
 * [ESP32](http://www.espruino.com/ESP32)
 
-**Certain features may or may not be implemented on your device** however
-we have documented what is available and what isn't.
+**Certain features may or may not be implemented on your device** however we
+have documented what is available and what isn't.
 
 If you're not using one of the devices above, a separate WiFi library is
 provided. For instance:
 
-* An [ESP8266 connected to an Espruino board](http://www.espruino.com/ESP8266#software)
+* An [ESP8266 connected to an Espruino
+  board](http://www.espruino.com/ESP8266#software)
 * An [CC3000 WiFi Module](http://www.espruino.com/CC3000)
 
-[Other ways of connecting to the net](http://www.espruino.com/Internet#related-pages) such
-as GSM, Ethernet and LTE have their own libraries.
+[Other ways of connecting to the
+net](http://www.espruino.com/Internet#related-pages) such as GSM, Ethernet and
+LTE have their own libraries.
 
 You can use the WiFi library as follows:
 
@@ -47,8 +49,9 @@ var wifi = require("Wifi");
 wifi.connect("my-ssid", {password:"my-pwd"}, function(ap){ console.log("connected:", ap); });
 ```
 
-On ESP32/ESP8266 if you want the connection to happen automatically at boot, add `wifi.save();`.
-On other platforms, place `wifi.connect` in a function called `onInit`.
+On ESP32/ESP8266 if you want the connection to happen automatically at boot, add
+`wifi.save();`. On other platforms, place `wifi.connect` in a function called
+`onInit`.
 */
 
 /*JSON{
@@ -59,7 +62,8 @@ On other platforms, place `wifi.connect` in a function called `onInit`.
     ["details","JsVar","An object with event details"]
   ]
 }
-The 'associated' event is called when an association with an access point has succeeded, i.e., a connection to the AP's network has been established.
+The 'associated' event is called when an association with an access point has
+succeeded, i.e., a connection to the AP's network has been established.
 
 On ESP32/ESP8266 there is a `details` parameter which includes:
 
@@ -77,7 +81,8 @@ On ESP32/ESP8266 there is a `details` parameter which includes:
     ["details","JsVar","An object with event details"]
   ]
 }
-The 'disconnected' event is called when an association with an access point has been lost.
+The 'disconnected' event is called when an association with an access point has
+been lost.
 
 On ESP32/ESP8266 there is a `details` parameter which includes:
 
@@ -96,8 +101,8 @@ On ESP32/ESP8266 there is a `details` parameter which includes:
     ["details","JsVar","An object with event details"]
   ]
 }
-The 'auth_change' event is called when the authentication mode with the associated access point changes.
-The details include:
+The 'auth_change' event is called when the authentication mode with the
+associated access point changes. The details include:
 
 * oldMode - The old auth mode (string: open, wep, wpa, wpa2, wpa_wpa2)
 * newMode - The new auth mode (string: open, wep, wpa, wpa2, wpa_wpa2)
@@ -110,7 +115,8 @@ The details include:
   "name" : "dhcp_timeout",
   "#if" : "defined(ESP32) || defined(ESP8266)"
 }
-The 'dhcp_timeout' event is called when a DHCP request to the connected access point fails and thus no IP address could be acquired (or renewed).
+The 'dhcp_timeout' event is called when a DHCP request to the connected access
+point fails and thus no IP address could be acquired (or renewed).
 */
 
 /*JSON{
@@ -121,7 +127,11 @@ The 'dhcp_timeout' event is called when a DHCP request to the connected access p
     ["details","JsVar","An object with event details"]
   ]
 }
-The 'connected' event is called when the connection with an access point is ready for traffic. In the case of a dynamic IP address configuration this is when an IP address is obtained, in the case of static IP address allocation this happens when an association is formed (in that case the 'associated' and 'connected' events are fired in rapid succession).
+The 'connected' event is called when the connection with an access point is
+ready for traffic. In the case of a dynamic IP address configuration this is
+when an IP address is obtained, in the case of static IP address allocation this
+happens when an association is formed (in that case the 'associated' and
+'connected' events are fired in rapid succession).
 
 On ESP32/ESP8266 there is a `details` parameter which includes:
 
@@ -140,8 +150,8 @@ On ESP32/ESP8266 there is a `details` parameter which includes:
     ["details","JsVar","An object with event details"]
   ]
 }
-The 'sta_joined' event is called when a station establishes an association (i.e. connects) with the esp8266's access point.
-The details include:
+The 'sta_joined' event is called when a station establishes an association (i.e.
+connects) with the esp8266's access point. The details include:
 
 * mac - The MAC address of the station in string format (00:00:00:00:00:00)
 
@@ -156,8 +166,8 @@ The details include:
     ["details","JsVar","An object with event details"]
   ]
 }
-The 'sta_left' event is called when a station disconnects from the esp8266's access point (or its association times out?).
-The details include:
+The 'sta_left' event is called when a station disconnects from the esp8266's
+access point (or its association times out?). The details include:
 
 * mac - The MAC address of the station in string format (00:00:00:00:00:00)
 
@@ -172,8 +182,8 @@ The details include:
     ["details","JsVar","An object with event details"]
   ]
 }
-The 'probe_recv' event is called when a probe request is received from some station by the esp8266's access point.
-The details include:
+The 'probe_recv' event is called when a probe request is received from some
+station by the esp8266's access point. The details include:
 
 * mac - The MAC address of the station in string format (00:00:00:00:00:00)
 * rssi - The signal strength in dB of the probe request
@@ -189,7 +199,10 @@ The details include:
     ["callback", "JsVar", "An optional `callback()` function to be called back on disconnection. The callback function receives no argument."]
   ]
 }
-Disconnect the wifi station from an access point and disable the station mode. It is OK to call `disconnect` to turn off station mode even if no connection exists (for example, connection attempts may be failing). Station mode can be re-enabled by calling `connect` or `scan`.
+Disconnect the wifi station from an access point and disable the station mode.
+It is OK to call `disconnect` to turn off station mode even if no connection
+exists (for example, connection attempts may be failing). Station mode can be
+re-enabled by calling `connect` or `scan`.
 */
 
 /*JSON{
@@ -201,7 +214,8 @@ Disconnect the wifi station from an access point and disable the station mode. I
     ["callback", "JsVar", "An optional `callback()` function to be called back on successful stop. The callback function receives no argument."]
   ]
 }
-Stop being an access point and disable the AP operation mode. AP mode can be re-enabled by calling `startAP`.
+Stop being an access point and disable the AP operation mode. AP mode can be
+re-enabled by calling `startAP`.
 */
 
 /*JSON{
@@ -215,21 +229,37 @@ Stop being an access point and disable the AP operation mode. AP mode can be re-
     ["callback", "JsVar", "A `callback(err)`  function to be called back on completion. `err` is null on success, or contains an error string on failure."]
   ]
 }
-Connect to an access point as a station. If there is an existing connection to an AP it is first disconnected if the SSID or password are different from those passed as parameters. Put differently, if the passed SSID and password are identical to the currently connected AP then nothing is changed.
-When the connection attempt completes the callback function is invoked with one `err` parameter, which is NULL if there is no error and a string message if there is an error. If DHCP is enabled the callback occurs once an IP addres has been obtained, if a static IP is set the callback occurs once the AP's network has been joined.  The callback is also invoked if a connection already exists and does not need to be changed.
+Connect to an access point as a station. If there is an existing connection to
+an AP it is first disconnected if the SSID or password are different from those
+passed as parameters. Put differently, if the passed SSID and password are
+identical to the currently connected AP then nothing is changed. When the
+connection attempt completes the callback function is invoked with one `err`
+parameter, which is NULL if there is no error and a string message if there is
+an error. If DHCP is enabled the callback occurs once an IP addres has been
+obtained, if a static IP is set the callback occurs once the AP's network has
+been joined. The callback is also invoked if a connection already exists and
+does not need to be changed.
 
 The options properties may contain:
 
 * `password` - Password string to be used to access the network.
-* `dnsServers` (array of String) - An array of up to two DNS servers in dotted decimal format string.
-* `channel`  - Wifi channel of the access point  (integer, typ 0..14, 0 means any channel), only on ESP8266. 
-* `bssid`   -  Mac address of the access point (string, type "00:00:00:00:00:00"), only on ESP8266.
+* `dnsServers` (array of String) - An array of up to two DNS servers in dotted
+  decimal format string.
+* `channel` - Wifi channel of the access point (integer, typ 0..14, 0 means any
+  channel), only on ESP8266.
+* `bssid` - Mac address of the access point (string, type "00:00:00:00:00:00"),
+  only on ESP8266.
 
 Notes:
 
-* the options should include the ability to set a static IP and associated netmask and gateway, this is a future enhancement.
-* the only error reported in the callback is "Bad password", all other errors (such as access point not found or DHCP timeout) just cause connection retries. If the reporting of such temporary errors is desired, the caller must use its own timeout and the `getDetails().status` field.
-* the `connect` call automatically enabled station mode, it can be disabled again by calling `disconnect`.
+* the options should include the ability to set a static IP and associated
+  netmask and gateway, this is a future enhancement.
+* the only error reported in the callback is "Bad password", all other errors
+  (such as access point not found or DHCP timeout) just cause connection
+  retries. If the reporting of such temporary errors is desired, the caller must
+  use its own timeout and the `getDetails().status` field.
+* the `connect` call automatically enabled station mode, it can be disabled
+  again by calling `disconnect`.
 
 */
 
@@ -242,7 +272,9 @@ Notes:
     ["callback", "JsVar", "A `callback(err, ap_list)` function to be called back on completion. `err==null` and `ap_list` is an array on success, or `err` is an error string and `ap_list` is undefined on failure."]
   ]
 }
-Perform a scan for access points. This will enable the station mode if it is not currently enabled. Once the scan is complete the callback function is called with an array of APs found, each AP is an object with:
+Perform a scan for access points. This will enable the station mode if it is not
+currently enabled. Once the scan is complete the callback function is called
+with an array of APs found, each AP is an object with:
 
 * `ssid`: SSID string.
 * `mac`: access point MAC address in 00:00:00:00:00:00 format.
@@ -252,7 +284,8 @@ Perform a scan for access points. This will enable the station mode if it is not
 * `rssi`: signal strength in dB in the range -110..0.
 
 Notes:
-* in order to perform the scan the station mode is turned on and remains on, use Wifi.disconnect() to turn it off again, if desired.
+* in order to perform the scan the station mode is turned on and remains on, use
+  Wifi.disconnect() to turn it off again, if desired.
 * only one scan can be in progress at a time.
 
 */
@@ -268,20 +301,30 @@ Notes:
     ["callback", "JsVar", "Optional `callback(err)` function to be called when the AP is successfully started. `err==null` on success, or an error string on failure."]
   ]
 }
-Create a WiFi access point allowing stations to connect. If the password is NULL or an empty string the access point is open, otherwise it is encrypted.
-The callback function is invoked once the access point is set-up and receives one `err` argument, which is NULL on success and contains an error message string otherwise.
+Create a WiFi access point allowing stations to connect. If the password is NULL
+or an empty string the access point is open, otherwise it is encrypted. The
+callback function is invoked once the access point is set-up and receives one
+`err` argument, which is NULL on success and contains an error message string
+otherwise.
 
 The `options` object can contain the following properties.
 
-* `authMode` - The authentication mode to use.  Can be one of "open", "wpa2", "wpa", "wpa_wpa2". The default is open (but open access points are not recommended).
+* `authMode` - The authentication mode to use. Can be one of "open", "wpa2",
+  "wpa", "wpa_wpa2". The default is open (but open access points are not
+  recommended).
 * `password` - The password for connecting stations if authMode is not open.
-* `channel` - The channel to be used for the access point in the range 1..13. If the device is also connected to an access point as a station then that access point determines the channel.
-* `hidden` - The flag if visible or not (0:visible, 1:hidden), default is visible.
+* `channel` - The channel to be used for the access point in the range 1..13. If
+  the device is also connected to an access point as a station then that access
+  point determines the channel.
+* `hidden` - The flag if visible or not (0:visible, 1:hidden), default is
+  visible.
 
 Notes:
 
-* the options should include the ability to set the AP IP and associated netmask, this is a future enhancement.
-* the `startAP` call automatically enables AP mode. It can be disabled again by calling `stopAP`.
+* the options should include the ability to set the AP IP and associated
+  netmask, this is a future enhancement.
+* the `startAP` call automatically enables AP mode. It can be disabled again by
+  calling `stopAP`.
 
 */
 
@@ -297,14 +340,25 @@ Notes:
     ["callback", "JsVar", "Optional `callback(status)` function to be called back with the current Wifi status, i.e. the same object as returned directly."]
   ]
 }
-Retrieve the current overall WiFi configuration. This call provides general information that pertains to both station and access point modes. The getDetails and getAPDetails calls provide more in-depth information about the station and access point configurations, respectively. The status object has the following properties:
+Retrieve the current overall WiFi configuration. This call provides general
+information that pertains to both station and access point modes. The getDetails
+and getAPDetails calls provide more in-depth information about the station and
+access point configurations, respectively. The status object has the following
+properties:
 
 * `station` - Status of the wifi station: `off`, `connecting`, ...
 * `ap` - Status of the wifi access point: `disabled`, `enabled`.
 * `mode` - The current operation mode: `off`, `sta`, `ap`, `sta+ap`.
-* `phy` - Modulation standard configured: `11b`, `11g`, `11n` (the esp8266 docs are not very clear, but it is assumed that 11n means b/g/n). This setting limits the modulations that the radio will use, it does not indicate the current modulation used with a specific access point.
-* `powersave` - Power saving mode: `none` (radio is on all the time), `ps-poll` (radio is off between beacons as determined by the access point's DTIM setting). Note that in 'ap' and 'sta+ap' modes the radio is always on, i.e., no power saving is possible.
-* `savedMode` - The saved operation mode which will be applied at boot time: `off`, `sta`, `ap`, `sta+ap`.
+* `phy` - Modulation standard configured: `11b`, `11g`, `11n` (the esp8266 docs
+  are not very clear, but it is assumed that 11n means b/g/n). This setting
+  limits the modulations that the radio will use, it does not indicate the
+  current modulation used with a specific access point.
+* `powersave` - Power saving mode: `none` (radio is on all the time), `ps-poll`
+  (radio is off between beacons as determined by the access point's DTIM
+  setting). Note that in 'ap' and 'sta+ap' modes the radio is always on, i.e.,
+  no power saving is possible.
+* `savedMode` - The saved operation mode which will be applied at boot time:
+  `off`, `sta`, `ap`, `sta+ap`.
 
 */
 
@@ -319,13 +373,20 @@ Retrieve the current overall WiFi configuration. This call provides general info
     ["settings", "JsVar", "An object with the configuration settings to change."]
   ]
 }
-Sets a number of global wifi configuration settings. All parameters are optional and which are passed determines which settings are updated.
-The settings available are:
+Sets a number of global wifi configuration settings. All parameters are optional
+and which are passed determines which settings are updated. The settings
+available are:
 
-* `phy` - Modulation standard to allow: `11b`, `11g`, `11n` (the esp8266 docs are not very clear, but it is assumed that 11n means b/g/n).
-* `powersave` - Power saving mode: `none` (radio is on all the time), `ps-poll` (radio is off between beacons as determined by the access point's DTIM setting). Note that in 'ap' and 'sta+ap' modes the radio is always on, i.e., no power saving is possible.
+* `phy` - Modulation standard to allow: `11b`, `11g`, `11n` (the esp8266 docs
+  are not very clear, but it is assumed that 11n means b/g/n).
+* `powersave` - Power saving mode: `none` (radio is on all the time), `ps-poll`
+  (radio is off between beacons as determined by the access point's DTIM
+  setting). Note that in 'ap' and 'sta+ap' modes the radio is always on, i.e.,
+  no power saving is possible.
 
-Note: esp8266 SDK programmers may be missing an "opmode" option to set the sta/ap/sta+ap operation mode. Please use connect/scan/disconnect/startAP/stopAP, which all set the esp8266 opmode indirectly.
+Note: esp8266 SDK programmers may be missing an "opmode" option to set the
+sta/ap/sta+ap operation mode. Please use connect/scan/disconnect/startAP/stopAP,
+which all set the esp8266 opmode indirectly.
 */
 
 /*JSON{
@@ -339,13 +400,22 @@ Note: esp8266 SDK programmers may be missing an "opmode" option to set the sta/a
     ["callback", "JsVar", "An optional `callback(details)` function to be called back with the wifi details, i.e. the same object as returned directly."]
   ]
 }
-Retrieve the wifi station configuration and status details. The details object has the following properties:
+Retrieve the wifi station configuration and status details. The details object
+has the following properties:
 
-* `status` - Details about the wifi station connection, one of `off`, `connecting`, `wrong_password`, `no_ap_found`, `connect_fail`, or `connected`. The off, bad_password and connected states are stable, the other states are transient. The connecting state will either result in connected or one of the error states (bad_password, no_ap_found, connect_fail) and the no_ap_found and connect_fail states will result in a reconnection attempt after some interval.
-* `rssi` - signal strength of the connected access point in dB, typically in the range -110 to 0, with anything greater than -30 being an excessively strong signal.
+* `status` - Details about the wifi station connection, one of `off`,
+  `connecting`, `wrong_password`, `no_ap_found`, `connect_fail`, or `connected`.
+  The off, bad_password and connected states are stable, the other states are
+  transient. The connecting state will either result in connected or one of the
+  error states (bad_password, no_ap_found, connect_fail) and the no_ap_found and
+  connect_fail states will result in a reconnection attempt after some interval.
+* `rssi` - signal strength of the connected access point in dB, typically in the
+  range -110 to 0, with anything greater than -30 being an excessively strong
+  signal.
 * `ssid` - SSID of the access point.
 * `password` - the password used to connect to the access point.
-* `authMode` - the authentication used: `open`, `wpa`, `wpa2`, `wpa_wpa2` (not currently supported).
+* `authMode` - the authentication used: `open`, `wpa`, `wpa2`, `wpa_wpa2` (not
+  currently supported).
 * `savedSsid` - the SSID to connect to automatically at boot time, null if none.
 
 */
@@ -361,16 +431,21 @@ Retrieve the wifi station configuration and status details. The details object h
     ["callback", "JsVar", "An optional `callback(details)` function to be called back with the current access point details, i.e. the same object as returned directly."]
   ]
 }
-Retrieve the current access point configuration and status.  The details object has the following properties:
+Retrieve the current access point configuration and status. The details object
+has the following properties:
 
 * `status` - Current access point status: `enabled` or `disabled`
-* `stations` - an array of the stations connected to the access point.  This array may be empty.  Each entry in the array is an object describing the station which, at a minimum contains `ip` being the IP address of the station.
+* `stations` - an array of the stations connected to the access point. This
+  array may be empty. Each entry in the array is an object describing the
+  station which, at a minimum contains `ip` being the IP address of the station.
 * `ssid` - SSID to broadcast.
 * `password` - Password for authentication.
-* `authMode` - the authentication required of stations: `open`, `wpa`, `wpa2`, `wpa_wpa2`.
+* `authMode` - the authentication required of stations: `open`, `wpa`, `wpa2`,
+  `wpa_wpa2`.
 * `hidden` - True if the SSID is hidden, false otherwise.
 * `maxConn` - Max number of station connections supported.
-* `savedSsid` - the SSID to broadcast automatically at boot time, null if the access point is to be disabled at boot.
+* `savedSsid` - the SSID to broadcast automatically at boot time, null if the
+  access point is to be disabled at boot.
 
 */
 
@@ -384,9 +459,13 @@ Retrieve the current access point configuration and status.  The details object 
     ["what", "JsVar", "An optional parameter to specify what to save, on the esp8266 the two supported values are `clear` and `sta+ap`. The default is `sta+ap`"]
   ]
 }
-On boards where this is not available, just issue the `connect` commands you need to run at startup from an `onInit` function.
+On boards where this is not available, just issue the `connect` commands you
+need to run at startup from an `onInit` function.
 
-Save the current wifi configuration (station and access point) to flash and automatically apply this configuration at boot time, unless `what=="clear"`, in which case the saved configuration is cleared such that wifi remains disabled at boot. The saved configuration includes:
+Save the current wifi configuration (station and access point) to flash and
+automatically apply this configuration at boot time, unless `what=="clear"`, in
+which case the saved configuration is cleared such that wifi remains disabled at
+boot. The saved configuration includes:
 
 * mode (off/sta/ap/sta+ap)
 * SSIDs & passwords
@@ -456,8 +535,10 @@ Return the access point IP information in an object which contains:
     ["callback", "JsVar", "The `callback(ip)` to invoke when the IP is returned. `ip==null` on failure."]
   ]
 }
-Lookup the hostname and invoke a callback with the IP address as integer argument. If the lookup fails, the callback is invoked with a null argument.
-**Note:** only a single hostname lookup can be made at a time, concurrent lookups are not supported.
+Lookup the hostname and invoke a callback with the IP address as integer
+argument. If the lookup fails, the callback is invoked with a null argument.
+**Note:** only a single hostname lookup can be made at a time, concurrent
+lookups are not supported.
 
 */
 
@@ -472,7 +553,8 @@ Lookup the hostname and invoke a callback with the IP address as integer argumen
     ["callback", "JsVar", "An optional `callback(hostname)` function to be called back with the hostname."]
   ]
 }
-Returns the hostname announced to the DHCP server and broadcast via mDNS when connecting to an access point.
+Returns the hostname announced to the DHCP server and broadcast via mDNS when
+connecting to an access point.
 */
 
 /*JSON{
@@ -486,9 +568,12 @@ Returns the hostname announced to the DHCP server and broadcast via mDNS when co
     ["callback", "JsVar", "An optional `callback()` function to be called back when the hostname is set"]
   ]
 }
-Set the hostname. Depending on implemenation, the hostname is sent with every DHCP request and is broadcast via mDNS. The DHCP hostname may be visible in the access point and may be forwarded into DNS as hostname.local.
-If a DHCP lease currently exists changing the hostname will cause a disconnect and reconnect in order to transmit the change to the DHCP server.
-The mDNS announcement also includes an announcement for the "espruino" service.
+Set the hostname. Depending on implemenation, the hostname is sent with every
+DHCP request and is broadcast via mDNS. The DHCP hostname may be visible in the
+access point and may be forwarded into DNS as hostname.local. If a DHCP lease
+currently exists changing the hostname will cause a disconnect and reconnect in
+order to transmit the change to the DHCP server. The mDNS announcement also
+includes an announcement for the "espruino" service.
 */
 
 /*JSON{
@@ -502,8 +587,12 @@ The mDNS announcement also includes an announcement for the "espruino" service.
     ["tz_offset", "JsVar", "Local time zone offset in the range -11..13."]
   ]
 }
-Starts the SNTP (Simple Network Time Protocol) service to keep the clock synchronized with the specified server. Note that the time zone is really just an offset to UTC and doesn't handle daylight savings time.
-The interval determines how often the time server is queried and Espruino's time is synchronized. The initial synchronization occurs asynchronously after setSNTP returns.
+Starts the SNTP (Simple Network Time Protocol) service to keep the clock
+synchronized with the specified server. Note that the time zone is really just
+an offset to UTC and doesn't handle daylight savings time. The interval
+determines how often the time server is queried and Espruino's time is
+synchronized. The initial synchronization occurs asynchronously after setSNTP
+returns.
 */
 
 
@@ -522,7 +611,7 @@ The interval determines how often the time server is queried and Espruino's time
 The `settings` object must contain the following properties.
 
 * `ip` IP address as string (e.g. "192.168.5.100")
-* `gw`  The network gateway as string (e.g. "192.168.5.1")
+* `gw` The network gateway as string (e.g. "192.168.5.1")
 * `netmask` The interface netmask as string (e.g. "255.255.255.0")
 
 */
@@ -541,7 +630,7 @@ The `settings` object must contain the following properties.
 The `settings` object must contain the following properties.
 
 * `ip` IP address as string (e.g. "192.168.5.100")
-* `gw`  The network gateway as string (e.g. "192.168.5.1")
+* `gw` The network gateway as string (e.g. "192.168.5.1")
 * `netmask` The interface netmask as string (e.g. "255.255.255.0")
 */
 
@@ -559,7 +648,8 @@ The `settings` object must contain the following properties.
     ["callback", "JsVar", "A `callback(time)` function to invoke when a ping is received"]
   ]
 }
-Issues a ping to the given host, and calls a callback with the time when the ping is received.
+Issues a ping to the given host, and calls a callback with the time when the
+ping is received.
 */
 
 /*JSON{
@@ -577,7 +667,6 @@ Switch to using a higher communication speed with the WiFi module.
 
 * `true` = 921600 baud
 * `false` = 115200
-* `1843200` (or any number) = use a specific baud rate.
-*
-eg. `wifi.turbo(true,callback)` or `wifi.turbo(1843200,callback)`
+* `1843200` (or any number) = use a specific baud rate. * eg.
+`wifi.turbo(true,callback)` or `wifi.turbo(1843200,callback)`
 */

--- a/libs/network/telnet/jswrap_telnet.c
+++ b/libs/network/telnet/jswrap_telnet.c
@@ -69,9 +69,9 @@ static uint8_t      tnSrvMode;    ///< current mode for the telnet server
   "type"  : "library",
   "class" : "TelnetServer"
 }
-This library implements a telnet console for the Espruino interpreter. It requires a network
-connection, e.g. Wifi, and **currently only functions on the ESP8266 and on Linux **. It uses
-port 23 on the ESP8266 and port 2323 on Linux.
+This library implements a telnet console for the Espruino interpreter. It
+requires a network connection, e.g. Wifi, and **currently only functions on the
+ESP8266 and on Linux **. It uses port 23 on the ESP8266 and port 2323 on Linux.
 
 **Note:** To enable on Linux, run `./espruino --telnet`
 */

--- a/libs/network/wiznet/jswrap_wiznet.c
+++ b/libs/network/wiznet/jswrap_wiznet.c
@@ -245,10 +245,11 @@ static void _eth_getIP_set_address(JsVar *options, char *name, unsigned char *pt
   ],
   "return" : ["bool","True on success"]
 }
-Set the current IP address or get an IP from DHCP (if no options object is specified)
+Set the current IP address or get an IP from DHCP (if no options object is
+specified)
 
-If 'mac' is specified as an option, it must be a string of the form `"00:01:02:03:04:05"`
-The default mac is 00:08:DC:01:02:03.
+If 'mac' is specified as an option, it must be a string of the form
+`"00:01:02:03:04:05"` The default mac is 00:08:DC:01:02:03.
 */
 bool jswrap_ethernet_setIP(JsVar *wlanObj, JsVar *options, JsVar *callback) {
   NOT_USED(wlanObj);
@@ -333,10 +334,10 @@ bool jswrap_ethernet_setIP(JsVar *wlanObj, JsVar *options, JsVar *callback) {
   ],
   "return" : ["bool","True on success"]
 }
-Set hostname allow to set the hosname used during the dhcp request.
-min 8 and max 12 char, best set before calling `eth.setIP()`
-Default is WIZnet010203, 010203 is the default nic as part of the mac.
-Best to set the hosname before calling setIP().
+Set hostname allow to set the hosname used during the dhcp request. min 8 and
+max 12 char, best set before calling `eth.setIP()` Default is WIZnet010203,
+010203 is the default nic as part of the mac. Best to set the hosname before
+calling setIP().
 */
 bool jswrap_ethernet_setHostname(JsVar *wlanObj, JsVar *jsHostname, JsVar *callback){
   NOT_USED(wlanObj);
@@ -402,7 +403,7 @@ JsVar * jswrap_ethernet_getHostname(JsVar *wlanObj, JsVar *callback) {
   ],
   "return" : ["JsVar" ]
 }
-Get the current status of the ethernet device 
+Get the current status of the ethernet device
 
 */
 JsVar * jswrap_ethernet_getStatus( JsVar *wlanObj, JsVar *callback) {

--- a/libs/pixljs/jswrap_pixljs.c
+++ b/libs/pixljs/jswrap_pixljs.c
@@ -38,7 +38,8 @@ const Pin PIXL_IO_PINS[] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19};
     "type": "class",
     "class" : "Pixl"
 }
-Class containing utility functions for [Pixl.js](http://www.espruino.com/Pixl.js)
+Class containing utility functions for
+[Pixl.js](http://www.espruino.com/Pixl.js)
 */
 
 /*JSON{
@@ -50,8 +51,8 @@ Class containing utility functions for [Pixl.js](http://www.espruino.com/Pixl.js
 }
 DEPRECATED - Please use `E.getBattery()` instead.
 
-Return an approximate battery percentage remaining based on
-a normal CR2032 battery (2.8 - 2.2v)
+Return an approximate battery percentage remaining based on a normal CR2032
+battery (2.8 - 2.2v)
 */
 JsVarInt jswrap_pixljs_getBattery() {
   JsVarFloat v = jshReadVRef();
@@ -71,7 +72,8 @@ JsVarInt jswrap_pixljs_getBattery() {
   "ifdef" : "PIXLJS",
   "return" : ["pin",""]
 }
-The pin marked SDA on the Arduino pin footprint. This is connected directly to pin A4.
+The pin marked SDA on the Arduino pin footprint. This is connected directly to
+pin A4.
 */
 /*JSON{
   "type" : "variable",
@@ -80,7 +82,8 @@ The pin marked SDA on the Arduino pin footprint. This is connected directly to p
   "ifdef" : "PIXLJS",
   "return" : ["pin",""]
 }
-The pin marked SDA on the Arduino pin footprint. This is connected directly to pin A5.
+The pin marked SDA on the Arduino pin footprint. This is connected directly to
+pin A5.
 */
 
 
@@ -491,7 +494,8 @@ bool jswrap_pixljs_idle() {
     "return" : ["JsVar", "A menu object with `draw`, `move` and `select` functions" ],
     "typescript" : "menu(menu: Menu): MenuInstance;"
 }
-Display a menu on Pixl.js's screen, and set up the buttons to navigate through it.
+Display a menu on Pixl.js's screen, and set up the buttons to navigate through
+it.
 
 DEPRECATED: Use `E.showMenu`
 */
@@ -579,8 +583,8 @@ type MenuInstance = {
 }
 Display a menu on the screen, and set up the buttons to navigate through it.
 
-Supply an object containing menu items. When an item is selected, the
-function it references will be executed. For example:
+Supply an object containing menu items. When an item is selected, the function
+it references will be executed. For example:
 
 ```
 var boolean = false;
@@ -614,8 +618,8 @@ var submenu = {
 E.showMenu(mainmenu);
 ```
 
-The menu will stay onscreen and active until explicitly removed,
-which you can do by calling `E.showMenu()` without arguments.
+The menu will stay onscreen and active until explicitly removed, which you can
+do by calling `E.showMenu()` without arguments.
 
 See http://www.espruino.com/graphical_menu for more detailed information.
 */
@@ -659,12 +663,11 @@ E.showMessage("These are\nLots of\nLines","My Title")
     ]
 }
 
-Displays a full screen prompt on the screen, with the buttons
-requested (or `Yes` and `No` for defaults).
+Displays a full screen prompt on the screen, with the buttons requested (or
+`Yes` and `No` for defaults).
 
-When the button is pressed the promise is resolved with the
-requested values (for the `Yes` and `No` defaults, `true` and `false`
-are returned).
+When the button is pressed the promise is resolved with the requested values
+(for the `Yes` and `No` defaults, `true` and `false` are returned).
 
 ```
 E.showPrompt("Do you like fish?").then(function(v) {

--- a/libs/puckjs/jswrap_puck.c
+++ b/libs/puckjs/jswrap_puck.c
@@ -593,7 +593,8 @@ Class containing [Puck.js's](http://www.puck-js.com) utility functions.
   "ifdef" : "PUCKJS",
   "return" : ["pin",""]
 }
-On Puck.js V2 (not v1.0) this is the pin that controls the FET, for high-powered outputs.
+On Puck.js V2 (not v1.0) this is the pin that controls the FET, for high-powered
+outputs.
 */
 
 /*JSON{
@@ -607,20 +608,20 @@ On Puck.js V2 (not v1.0) this is the pin that controls the FET, for high-powered
 Turn on the magnetometer, take a single reading, and then turn it off again.
 
 An object of the form `{x,y,z}` is returned containing magnetometer readings.
-Due to residual magnetism in the Puck and magnetometer itself, with
-no magnetic field the Puck will not return `{x:0,y:0,z:0}`.
+Due to residual magnetism in the Puck and magnetometer itself, with no magnetic
+field the Puck will not return `{x:0,y:0,z:0}`.
 
-Instead, it's up to you to figure out what the 'zero value' is for your
-Puck in your location and to then subtract that from the value returned. If
-you're not trying to measure the Earth's magnetic field then it's a good idea
-to just take a reading at startup and use that.
+Instead, it's up to you to figure out what the 'zero value' is for your Puck in
+your location and to then subtract that from the value returned. If you're not
+trying to measure the Earth's magnetic field then it's a good idea to just take
+a reading at startup and use that.
 
 With the aerial at the top of the board, the `y` reading is vertical, `x` is
 horizontal, and `z` is through the board.
 
 Readings are in increments of 0.1 micro Tesla (uT). The Earth's magnetic field
-varies from around 25-60 uT, so the reading will vary by 250 to 600 depending
-on location.
+varies from around 25-60 uT, so the reading will vary by 250 to 600 depending on
+location.
 */
 JsVar *jswrap_puck_mag() {
   if (!PUCKJS_HAS_MAG) {
@@ -652,14 +653,17 @@ JsVar *jswrap_puck_mag() {
   "generate" : "jswrap_puck_magTemp",
   "return" : ["float", "Temperature in degrees C" ]
 }
-Turn on the magnetometer, take a single temperature reading from the MAG3110 chip, and then turn it off again.
+Turn on the magnetometer, take a single temperature reading from the MAG3110
+chip, and then turn it off again.
 
 (If the magnetometer is already on, this just returns the last reading obtained)
 
-`E.getTemperature()` uses the microcontroller's temperature sensor, but this uses the magnetometer's.
+`E.getTemperature()` uses the microcontroller's temperature sensor, but this
+uses the magnetometer's.
 
-The reading obtained is an integer (so no decimal places), but the sensitivity is factory trimmed. to 1&deg;C, however the temperature
-offset isn't - so absolute readings may still need calibrating.
+The reading obtained is an integer (so no decimal places), but the sensitivity
+is factory trimmed. to 1&deg;C, however the temperature offset isn't - so
+absolute readings may still need calibrating.
 */
 JsVarFloat jswrap_puck_magTemp() {
   if (!PUCKJS_HAS_MAG) {
@@ -682,13 +686,13 @@ JsVarFloat jswrap_puck_magTemp() {
   "name" : "mag",
   "ifdef" : "PUCKJS"
 }
-Called after `Puck.magOn()` every time magnetometer data
-is sampled. There is one argument which is an object
-of the form `{x,y,z}` containing magnetometer readings
-as integers (for more information see `Puck.mag()`).
+Called after `Puck.magOn()` every time magnetometer data is sampled. There is
+one argument which is an object of the form `{x,y,z}` containing magnetometer
+readings as integers (for more information see `Puck.mag()`).
 
-Check out [the Puck.js page on the magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information.
+Check out [the Puck.js page on the
+magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information.
  */
 
 /*JSON{
@@ -699,13 +703,13 @@ for more information.
 }
 Only on Puck.js v2.0
 
-Called after `Puck.accelOn()` every time accelerometer data
-is sampled. There is one argument which is an object
-of the form `{acc:{x,y,z}, gyro:{x,y,z}}` containing the data.
+Called after `Puck.accelOn()` every time accelerometer data is sampled. There is
+one argument which is an object of the form `{acc:{x,y,z}, gyro:{x,y,z}}`
+containing the data.
 
-The data is as it comes off the accelerometer and is not
-scaled to 1g. For more information see `Puck.accel()` or
-[the Puck.js page on the magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals).
+The data is as it comes off the accelerometer and is not scaled to 1g. For more
+information see `Puck.accel()` or [the Puck.js page on the
+magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals).
  */
 
 /*JSON{
@@ -718,8 +722,8 @@ scaled to 1g. For more information see `Puck.accel()` or
       ["samplerate","float","The sample rate in Hz, or undefined"]
   ]
 }
-Turn the magnetometer on and start periodic sampling. Samples will then cause
-a 'mag' event on 'Puck':
+Turn the magnetometer on and start periodic sampling. Samples will then cause a
+'mag' event on 'Puck':
 
 ```
 Puck.magOn();
@@ -732,8 +736,9 @@ Puck.on('mag', function(xyz) {
 
 This call will be ignored if the sampling is already on.
 
-If given an argument, the sample rate is set (if not, it's at 0.63 Hz). 
-The sample rate must be one of the following (resulting in the given power consumption):
+If given an argument, the sample rate is set (if not, it's at 0.63 Hz). The
+sample rate must be one of the following (resulting in the given power
+consumption):
 
 * 80 Hz - 900uA
 * 40 Hz - 550uA
@@ -747,12 +752,13 @@ The sample rate must be one of the following (resulting in the given power consu
 * 0.16 Hz - 8uA
 * 0.08 Hz - 8uA
 
-When the battery level drops too low while sampling is turned on,
-the magnetometer may stop sampling without warning, even while other
-Puck functions continue uninterrupted.
+When the battery level drops too low while sampling is turned on, the
+magnetometer may stop sampling without warning, even while other Puck functions
+continue uninterrupted.
 
-Check out [the Puck.js page on the magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information.
+Check out [the Puck.js page on the
+magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information.
 
 */
 void jswrap_puck_magOn(JsVarFloat hz) {
@@ -819,10 +825,12 @@ void jswrap_puck_magOff() {
     ],
     "ifdef" : "PUCKJS"
 }
-Writes a register on the LIS3MDL / MAX3110 Magnetometer. Can be used for configuring advanced functions.
+Writes a register on the LIS3MDL / MAX3110 Magnetometer. Can be used for
+configuring advanced functions.
 
-Check out [the Puck.js page on the magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information and links to modules that use this function.
+Check out [the Puck.js page on the
+magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information and links to modules that use this function.
 */
 void jswrap_puck_magWr(JsVarInt reg, JsVarInt data) {
   if (!PUCKJS_HAS_MAG) {
@@ -843,10 +851,12 @@ void jswrap_puck_magWr(JsVarInt reg, JsVarInt data) {
     "return" : ["int",""],
     "ifdef" : "PUCKJS"
 }
-Reads a register from the LIS3MDL / MAX3110 Magnetometer. Can be used for configuring advanced functions.
+Reads a register from the LIS3MDL / MAX3110 Magnetometer. Can be used for
+configuring advanced functions.
 
-Check out [the Puck.js page on the magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information and links to modules that use this function.
+Check out [the Puck.js page on the
+magnetometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information and links to modules that use this function.
 */
 int jswrap_puck_magRd(JsVarInt reg) {
   if (!PUCKJS_HAS_MAG) {
@@ -890,7 +900,8 @@ void temp_off() {
   "generate" : "jswrap_puck_getTemperature",
   "return" : ["float", "Temperature in degrees C" ]
 }
-On Puck.js v2.0 this will use the on-board PCT2075TP temperature sensor, but on Puck.js the less accurate on-chip Temperature sensor is used.
+On Puck.js v2.0 this will use the on-board PCT2075TP temperature sensor, but on
+Puck.js the less accurate on-chip Temperature sensor is used.
 */
 JsVarFloat jswrap_puck_getTemperature() {
   if (PUCKJS_HAS_TEMP_SENSOR) {
@@ -936,7 +947,8 @@ Accepted values are:
 * 833 Hz (with Gyro) (not recommended)
 * 1660 Hz (with Gyro) (not recommended)
 
-Once `Puck.accelOn()` is called, the `Puck.accel` event will be called each time data is received. `Puck.accelOff()` can be called to turn the accelerometer off.
+Once `Puck.accelOn()` is called, the `Puck.accel` event will be called each time
+data is received. `Puck.accelOff()` can be called to turn the accelerometer off.
 
 For instance to light the red LED whenever Puck.js is face up:
 
@@ -947,8 +959,9 @@ Puck.on('accel', function(a) {
 Puck.accelOn();
 ```
 
-Check out [the Puck.js page on the accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information.
+Check out [the Puck.js page on the
+accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information.
 
 */
 void jswrap_puck_accelOn(JsVarFloat hz) {
@@ -977,10 +990,11 @@ void jswrap_puck_accelOn(JsVarFloat hz) {
   "ifdef" : "PUCKJS",
   "generate" : "jswrap_puck_accelOff"
 }
-Turn the accelerometer off after it has been turned on by `Puck.accelOn()`. 
+Turn the accelerometer off after it has been turned on by `Puck.accelOn()`.
 
-Check out [the Puck.js page on the accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information.
+Check out [the Puck.js page on the
+accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information.
 */
 void jswrap_puck_accelOff() {
   if (!PUCKJS_HAS_ACCEL) {
@@ -1006,10 +1020,13 @@ Turn on the accelerometer, take a single reading, and then turn it off again.
 
 The values reported are the raw values from the chip. In normal configuration:
 
-* accelerometer: full-scale (32768) is 4g, so you need to divide by 8192 to get correctly scaled values
-* gyro: full-scale (32768) is 245 dps, so you need to divide by 134 to get correctly scaled values
+* accelerometer: full-scale (32768) is 4g, so you need to divide by 8192 to get
+  correctly scaled values
+* gyro: full-scale (32768) is 245 dps, so you need to divide by 134 to get
+  correctly scaled values
 
-If taking more than one reading, we'd suggest you use `Puck.accelOn()` and the `Puck.accel` event.
+If taking more than one reading, we'd suggest you use `Puck.accelOn()` and the
+`Puck.accel` event.
 */
 JsVar *jswrap_puck_accel() {
   if (!PUCKJS_HAS_ACCEL) {
@@ -1041,10 +1058,12 @@ JsVar *jswrap_puck_accel() {
     ],
     "ifdef" : "PUCKJS"
 }
-Writes a register on the LSM6DS3TR-C Accelerometer. Can be used for configuring advanced functions.
+Writes a register on the LSM6DS3TR-C Accelerometer. Can be used for configuring
+advanced functions.
 
-Check out [the Puck.js page on the accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information and links to modules that use this function.
+Check out [the Puck.js page on the
+accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information and links to modules that use this function.
 */
 void jswrap_puck_accelWr(JsVarInt reg, JsVarInt data) {
   if (!PUCKJS_HAS_ACCEL) {
@@ -1068,10 +1087,12 @@ void jswrap_puck_accelWr(JsVarInt reg, JsVarInt data) {
     "return" : ["int",""],
     "ifdef" : "PUCKJS"
 }
-Reads a register from the LSM6DS3TR-C Accelerometer. Can be used for configuring advanced functions.
+Reads a register from the LSM6DS3TR-C Accelerometer. Can be used for configuring
+advanced functions.
 
-Check out [the Puck.js page on the accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals)
-for more information and links to modules that use this function.
+Check out [the Puck.js page on the
+accelerometer](http://www.espruino.com/Puck.js#on-board-peripherals) for more
+information and links to modules that use this function.
 */
 int jswrap_puck_accelRd(JsVarInt reg) {
   if (!PUCKJS_HAS_ACCEL) {
@@ -1097,17 +1118,17 @@ int jswrap_puck_accelRd(JsVarInt reg) {
       ["anode","pin","(optional) pin to use for IR LED anode - if not defined, the built-in IR LED is used"]
   ]
 }
-Transmit the given set of IR pulses - data should be an array of pulse times
-in milliseconds (as `[on, off, on, off, on, etc]`).
+Transmit the given set of IR pulses - data should be an array of pulse times in
+milliseconds (as `[on, off, on, off, on, etc]`).
 
 For example `Puck.IR(pulseTimes)` - see http://www.espruino.com/Puck.js+Infrared
 for a full example.
 
-You can also attach an external LED to Puck.js, in which case
-you can just execute `Puck.IR(pulseTimes, led_cathode, led_anode)`
+You can also attach an external LED to Puck.js, in which case you can just
+execute `Puck.IR(pulseTimes, led_cathode, led_anode)`
 
-It is also possible to just supply a single pin for IR transmission
-with `Puck.IR(pulseTimes, led_anode)` (on 2v05 and above).
+It is also possible to just supply a single pin for IR transmission with
+`Puck.IR(pulseTimes, led_anode)` (on 2v05 and above).
 */
 Pin _jswrap_puck_IR_pin;
 void _jswrap_puck_IR_on() {
@@ -1210,17 +1231,16 @@ void jswrap_puck_IR(JsVar *data, Pin cathode, Pin anode) {
 }
 Capacitive sense - the higher the capacitance, the higher the number returned.
 
-If called without arguments, a value depending on the capacitance of what is 
+If called without arguments, a value depending on the capacitance of what is
 attached to pin D11 will be returned. If you attach a length of wire to D11,
 you'll be able to see a higher value returned when your hand is near the wire
 than when it is away.
 
-You can also supply pins to use yourself, however if you do this then
-the TX pin must be connected to RX pin and sense plate via a roughly 1MOhm 
-resistor.
+You can also supply pins to use yourself, however if you do this then the TX pin
+must be connected to RX pin and sense plate via a roughly 1MOhm resistor.
 
-When not supplying pins, Puck.js uses an internal resistor between D12(tx)
-and D11(rx).
+When not supplying pins, Puck.js uses an internal resistor between D12(tx) and
+D11(rx).
 */
 int jswrap_puck_capSense(Pin tx, Pin rx) {
   if (!PUCKJS_HAS_CAPSENSE) {
@@ -1243,8 +1263,8 @@ int jswrap_puck_capSense(Pin tx, Pin rx) {
 }
 Return a light value based on the light the red LED is seeing.
 
-**Note:** If called more than 5 times per second, the received light value
-may not be accurate.
+**Note:** If called more than 5 times per second, the received light value may
+not be accurate.
 */
 JsVarFloat jswrap_puck_light() {
   // If pin state wasn't an analog input before, make it one now,
@@ -1281,8 +1301,8 @@ JsVarFloat jswrap_puck_light() {
 }
 DEPRECATED - Please use `E.getBattery()` instead.
 
-Return an approximate battery percentage remaining based on
-a normal CR2032 battery (2.8 - 2.2v).
+Return an approximate battery percentage remaining based on a normal CR2032
+battery (2.8 - 2.2v).
 */
 JsVarInt jswrap_puck_getBattery() {
   JsVarFloat v = jshReadVRef();
@@ -1349,16 +1369,16 @@ static bool selftest_check_pin(Pin pin, char *err) {
     "generate" : "jswrap_puck_selfTest",
     "return" : ["bool", "True if the self-test passed" ]
 }
-Run a self-test, and return true for a pass. This checks for shorts
-between pins, so your Puck shouldn't have anything connected to it.
+Run a self-test, and return true for a pass. This checks for shorts between
+pins, so your Puck shouldn't have anything connected to it.
 
-**Note:** This self-test auto starts if you hold the button on your Puck
-down while inserting the battery, leave it pressed for 3 seconds (while
-the green LED is lit) and release it soon after all LEDs turn on. 5
-red blinks is a fail, 5 green is a pass.
+**Note:** This self-test auto starts if you hold the button on your Puck down
+while inserting the battery, leave it pressed for 3 seconds (while the green LED
+is lit) and release it soon after all LEDs turn on. 5 red blinks is a fail, 5
+green is a pass.
 
-If the self test fails, it'll set the Puck.js Bluetooth advertising name
-to `Puck.js !ERR` where ERR is a 3 letter error code.
+If the self test fails, it'll set the Puck.js Bluetooth advertising name to
+`Puck.js !ERR` where ERR is a 3 letter error code.
 
 */
 

--- a/libs/trigger/jswrap_trigger.c
+++ b/libs/trigger/jswrap_trigger.c
@@ -22,7 +22,11 @@
   "type" : "class",
   "class" : "Trig"
 }
-This class exists in order to interface Espruino with fast-moving trigger wheels. Trigger wheels are physical discs with evenly spaced teeth cut into them, and often with one or two teeth next to each other missing. A sensor sends a signal whenever a tooth passed by, and this allows a device to measure not only RPM, but absolute position.
+This class exists in order to interface Espruino with fast-moving trigger
+wheels. Trigger wheels are physical discs with evenly spaced teeth cut into
+them, and often with one or two teeth next to each other missing. A sensor sends
+a signal whenever a tooth passed by, and this allows a device to measure not
+only RPM, but absolute position.
 
 This class is currently in testing - it is NOT AVAILABLE on normal boards.
 */

--- a/libs/wio_lte/jswrap_wio_lte.c
+++ b/libs/wio_lte/jswrap_wio_lte.c
@@ -61,7 +61,8 @@ void jswrap_wio_lte_led(int r, int g, int b) {
       ["onoff","bool","Whether to turn the Grove connectors power on or off (D38/D39 are always powered)"]
     ]
 }
-Set the power of Grove connectors, except for `D38` and `D39` which are always on.
+Set the power of Grove connectors, except for `D38` and `D39` which are always
+on.
 */
 void jswrap_wio_lte_setGrovePower(bool pwr) {
   jshPinOutput(JSH_PORTB_OFFSET+10, pwr);
@@ -78,7 +79,8 @@ void jswrap_wio_lte_setGrovePower(bool pwr) {
 }
 Turn power to the WIO's LED on or off.
 
-Turning the LED on won't immediately display a color - that must be done with `WioLTE.LED(r,g,b)`
+Turning the LED on won't immediately display a color - that must be done with
+`WioLTE.LED(r,g,b)`
 */
 void jswrap_wio_lte_setLEDPower(bool pwr) {
   jshPinOutput(JSH_PORTA_OFFSET+8, pwr);

--- a/src/jswrap_array.c
+++ b/src/jswrap_array.c
@@ -29,7 +29,8 @@
 }
 This is the built-in JavaScript class for arrays.
 
-Arrays can be defined with ```[]```, ```new Array()```, or ```new Array(length)```
+Arrays can be defined with ```[]```, ```new Array()```, or ```new
+Array(length)```
  */
 
 /*JSON{
@@ -50,7 +51,8 @@ Arrays can be defined with ```[]```, ```new Array()```, or ```new Array(length)`
     "<T>(...items: T[]): T[];"
   ]
 }
-Create an Array. Either give it one integer argument (>=0) which is the length of the array, or any number of arguments
+Create an Array. Either give it one integer argument (>=0) which is the length
+of the array, or any number of arguments
  */
 JsVar *jswrap_array_constructor(JsVar *args) {
   assert(args);
@@ -176,7 +178,8 @@ bool jswrap_array_includes(JsVar *arr, JsVar *value, JsVarInt startIdx) {
   "return" : ["JsVar","A String representing the Joined array"],
   "typescript" : "join(separator?: string): string;"
 }
-Join all elements of this array together into one string, using 'separator' between them. e.g. ```[1,2,3].join(' ')=='1 2 3'```
+Join all elements of this array together into one string, using 'separator'
+between them. e.g. ```[1,2,3].join(' ')=='1 2 3'```
  */
 JsVar *jswrap_array_join(JsVar *parent, JsVar *filler) {
   if (!jsvIsIterable(parent)) return 0;
@@ -203,7 +206,8 @@ JsVar *jswrap_array_join(JsVar *parent, JsVar *filler) {
 }
 Push a new value onto the end of this array'
 
-This is the opposite of `[1,2,3].unshift(0)`, which adds one or more elements to the beginning of the array.
+This is the opposite of `[1,2,3].unshift(0)`, which adds one or more elements to
+the beginning of the array.
  */
 JsVarInt jswrap_array_push(JsVar *parent, JsVar *args) {
   if (!jsvIsArray(parent)) return -1;
@@ -233,7 +237,8 @@ JsVarInt jswrap_array_push(JsVar *parent, JsVar *args) {
 }
 Remove and return the value on the end of this array.
 
-This is the opposite of `[1,2,3].shift()`, which removes an element from the beginning of the array.
+This is the opposite of `[1,2,3].shift()`, which removes an element from the
+beginning of the array.
  */
 
 /// return types for _jswrap_array_iterate_with_callback
@@ -345,7 +350,8 @@ static JsVar *_jswrap_array_iterate_with_callback(
   "return" : ["JsVar","An array containing the results"],
   "typescript" : "map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];"
 }
-Return an array which is made from the following: ```A.map(function) = [function(A[0]), function(A[1]), ...]```
+Return an array which is made from the following: ```A.map(function) =
+[function(A[0]), function(A[1]), ...]```
  */
 JsVar *jswrap_array_map(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   return _jswrap_array_iterate_with_callback("map", parent, funcVar, thisVar, RETURN_ARRAY, false, false);
@@ -383,7 +389,8 @@ void jswrap_array_forEach(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
     "filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];"
   ]
 }
-Return an array which contains only those elements for which the callback function returns 'true'
+Return an array which contains only those elements for which the callback
+function returns 'true'
  */
 JsVar *jswrap_array_filter(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   return _jswrap_array_iterate_with_callback("filter", parent, funcVar, thisVar, RETURN_ARRAY, true, true);
@@ -404,7 +411,8 @@ JsVar *jswrap_array_filter(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
     "find(predicate: (value: T, index: number, obj: T[]) => unknown): T | undefined;"
   ]
 }
-Return the array element where `function` returns `true`, or `undefined` if it doesn't returns `true` for any element.
+Return the array element where `function` returns `true`, or `undefined` if it
+doesn't returns `true` for any element.
 
 ```
 ["Hello","There","World"].find(a=>a[0]=="T")
@@ -427,7 +435,8 @@ JsVar *jswrap_array_find(JsVar *parent, JsVar *funcVar) {
   "return" : ["JsVar","The array element's index where `function` returns `true`, or `-1`"],
   "typescript" : "findIndex(predicate: (value: T, index: number, obj: T[]) => unknown): number;"
 }
-Return the array element's index where `function` returns `true`, or `-1` if it doesn't returns `true` for any element.
+Return the array element's index where `function` returns `true`, or `-1` if it
+doesn't returns `true` for any element.
 
 ```
 ["Hello","There","World"].findIndex(a=>a[0]=="T")
@@ -452,7 +461,8 @@ JsVar *jswrap_array_findIndex(JsVar *parent, JsVar *funcVar) {
   "return" : ["JsVar","A boolean containing the result"],
   "typescript" : "some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;"
 }
-Return 'true' if the callback returns 'true' for any of the elements in the array
+Return 'true' if the callback returns 'true' for any of the elements in the
+array
  */
 JsVar *jswrap_array_some(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   return _jswrap_array_iterate_with_callback("some", parent, funcVar, thisVar, RETURN_BOOL, true, false);
@@ -489,7 +499,9 @@ JsVar *jswrap_array_every(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   "return" : ["JsVar","The value returned by the last function called"],
   "typescript" : "reduce(callback: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;"
 }
-Execute `previousValue=initialValue` and then `previousValue = callback(previousValue, currentValue, index, array)` for each element in the array, and finally return previousValue.
+Execute `previousValue=initialValue` and then `previousValue =
+callback(previousValue, currentValue, index, array)` for each element in the
+array, and finally return previousValue.
  */
 JsVar *jswrap_array_reduce(JsVar *parent, JsVar *funcVar, JsVar *initialValue) {
   const char *name = "reduce";
@@ -673,7 +685,8 @@ JsVar *jswrap_array_shift(JsVar *parent) {
 }
 Add one or more items to the start of the array, and return its new length.
 
-This is the opposite of `[1,2,3].push(4)`, which puts one or more elements on the end.
+This is the opposite of `[1,2,3].push(4)`, which puts one or more elements on
+the end.
  */
 JsVarInt jswrap_array_unshift(JsVar *parent, JsVar *elements) {
   // just use splice, as this does all the hard work for us
@@ -907,7 +920,8 @@ JsVar *jswrap_array_sort (JsVar *array, JsVar *compareFn) {
   "return" : ["JsVar","An Array"],
   "typescript" : "concat(...args: (T | T[])[]): T[];"
 }
-Create a new array, containing the elements from this one and any arguments, if any argument is an array then those elements will be added.
+Create a new array, containing the elements from this one and any arguments, if
+any argument is an array then those elements will be added.
  */
 JsVar *jswrap_array_concat(JsVar *parent, JsVar *args) {
   JsVar *result = jsvNewEmptyArray();

--- a/src/jswrap_arraybuffer.c
+++ b/src/jswrap_arraybuffer.c
@@ -34,8 +34,8 @@ interface ArrayLike<T> {
 }
 This is the built-in JavaScript class for array buffers.
 
-If you want to access arrays of differing types of data
-you may also find `DataView` useful.
+If you want to access arrays of differing types of data you may also find
+`DataView` useful.
  */
 
 /*JSON{
@@ -56,8 +56,8 @@ This is the built-in JavaScript class that is the prototype for:
 * [Float32Array](/Reference#Float32Array)
 * [Float64Array](/Reference#Float64Array)
 
-If you want to access arrays of differing types of data
-you may also find `DataView` useful.
+If you want to access arrays of differing types of data you may also find
+`DataView` useful.
 */
 
 /*JSON{
@@ -67,11 +67,14 @@ you may also find `DataView` useful.
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_UINT8",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 8 bit unsigned integers.
+This is the built-in JavaScript class for a typed array of 8 bit unsigned
+integers.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -80,11 +83,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==(ARRAYBUFFERVIEW_UINT8|ARRAYBUFFERVIEW_CLAMPED)",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 8 bit unsigned integers that are automatically clamped to the range 0 to 255.
+This is the built-in JavaScript class for a typed array of 8 bit unsigned
+integers that are automatically clamped to the range 0 to 255.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -93,11 +99,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_INT8",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 8 bit signed integers.
+This is the built-in JavaScript class for a typed array of 8 bit signed
+integers.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -106,11 +115,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_UINT16",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 16 bit unsigned integers.
+This is the built-in JavaScript class for a typed array of 16 bit unsigned
+integers.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -119,11 +131,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_INT16",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 16 bit signed integers.
+This is the built-in JavaScript class for a typed array of 16 bit signed
+integers.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -133,11 +148,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_UINT24",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 24 bit unsigned integers.
+This is the built-in JavaScript class for a typed array of 24 bit unsigned
+integers.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -146,11 +164,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_UINT32",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 32 bit unsigned integers.
+This is the built-in JavaScript class for a typed array of 32 bit unsigned
+integers.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -159,11 +180,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_INT32",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 32 bit signed integers.
+This is the built-in JavaScript class for a typed array of 32 bit signed
+integers.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -172,11 +196,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_FLOAT32",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 32 bit floating point values.
+This is the built-in JavaScript class for a typed array of 32 bit floating point
+values.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 /*JSON{
   "type" : "class",
@@ -185,11 +212,14 @@ Arrays of this type include all the methods from [ArrayBufferView](/Reference#Ar
   "check" : "jsvIsArrayBuffer(var) && var->varData.arraybuffer.type==ARRAYBUFFERVIEW_FLOAT64",
   "not_real_object" : "Don't treat this as a real object - it's handled differently internally"
 }
-This is the built-in JavaScript class for a typed array of 64 bit floating point values.
+This is the built-in JavaScript class for a typed array of 64 bit floating point
+values.
 
-Instantiate this in order to efficiently store arrays of data (Espruino's normal arrays store data in a map, which is inefficient for non-sparse arrays).
+Instantiate this in order to efficiently store arrays of data (Espruino's normal
+arrays store data in a map, which is inefficient for non-sparse arrays).
 
-Arrays of this type include all the methods from [ArrayBufferView](/Reference#ArrayBufferView)
+Arrays of this type include all the methods from
+[ArrayBufferView](/Reference#ArrayBufferView)
  */
 
 
@@ -267,7 +297,10 @@ The length, in bytes, of the `ArrayBuffer`
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint8Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -287,9 +320,13 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint8ClampedArray;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
 
-Clamped arrays clamp their values to the allowed range, rather than 'wrapping'. e.g. after `a[0]=12345;`, `a[0]==255`.
+Clamped arrays clamp their values to the allowed range, rather than 'wrapping'.
+e.g. after `a[0]=12345;`, `a[0]==255`.
  */
 /*JSON{
   "type" : "constructor",
@@ -309,7 +346,10 @@ Clamped arrays clamp their values to the allowed range, rather than 'wrapping'. 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Int8Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -329,7 +369,10 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint16Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -349,7 +392,10 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Int16Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -370,7 +416,10 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint24Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -390,7 +439,10 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint32Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -410,7 +462,10 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Int32Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -430,7 +485,10 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Float32Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 /*JSON{
   "type" : "constructor",
@@ -450,7 +508,10 @@ Create a typed array based on the given input. Either an existing Array Buffer, 
     "new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Float64Array;"
   ]
 }
-Create a typed array based on the given input. Either an existing Array Buffer, an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g. `Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied rather than referenced.
+Create a typed array based on the given input. Either an existing Array Buffer,
+an Integer as a Length, or a simple array. If an `ArrayBufferView` (e.g.
+`Uint8Array` rather than `ArrayBuffer`) is given, it will be completely copied
+rather than referenced.
  */
 
 JsVar *jswrap_typedarray_constructor(JsVarDataArrayBufferViewType type, JsVar *arr, JsVarInt byteOffset, JsVarInt length) {
@@ -536,7 +597,8 @@ The length, in bytes, of the `ArrayBufferView`
   "return" : ["int","The byte Offset"],
   "typescript" : "readonly byteOffset: number;"
 }
-The offset, in bytes, to the first byte of the view within the backing `ArrayBuffer`
+The offset, in bytes, to the first byte of the view within the backing
+`ArrayBuffer`
  */
 
 /*JSON{
@@ -614,9 +676,11 @@ void jswrap_arraybufferview_set(JsVar *parent, JsVar *arr, int offset) {
   "return_object" : "ArrayBufferView",
   "typescript" : "map(callbackfn: (value: number, index: number, array: T) => number, thisArg?: any): T;"
 }
-Return an array which is made from the following: ```A.map(function) = [function(A[0]), function(A[1]), ...]```
+Return an array which is made from the following: ```A.map(function) =
+[function(A[0]), function(A[1]), ...]```
 
- **Note:** This returns an `ArrayBuffer` of the same type it was called on. To get an `Array`, use `Array.map`, e.g. `[].map.call(myArray, x=>x+1)`
+ **Note:** This returns an `ArrayBuffer` of the same type it was called on. To
+ get an `Array`, use `Array.map`, e.g. `[].map.call(myArray, x=>x+1)`
  */
 JsVar *jswrap_arraybufferview_map(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   if (!jsvIsArrayBuffer(parent)) {
@@ -683,7 +747,8 @@ JsVar *jswrap_arraybufferview_map(JsVar *parent, JsVar *funcVar, JsVar *thisVar)
   "return_object" : "ArrayBufferView",
   "typescript" : "subarray(begin?: number, end?: number): T;"
 }
-Returns a smaller part of this array which references the same data (it doesn't copy it).
+Returns a smaller part of this array which references the same data (it doesn't
+copy it).
  */
 JsVar *jswrap_arraybufferview_subarray(JsVar *parent, JsVarInt begin, JsVar *endVar) {
   if (!jsvIsArrayBuffer(parent)) {
@@ -761,7 +826,8 @@ Return `true` if the array includes the value, `false` otherwise
   "return" : ["JsVar","A String representing the Joined array"],
   "typescript" : "join(separator?: string): string;"
 }
-Join all elements of this array together into one string, using 'separator' between them. e.g. ```[1,2,3].join(' ')=='1 2 3'```
+Join all elements of this array together into one string, using 'separator'
+between them. e.g. ```[1,2,3].join(' ')=='1 2 3'```
  */
 /*JSON{
   "type" : "method",
@@ -828,7 +894,9 @@ Executes a provided function once per array element.
   "return" : ["JsVar","The value returned by the last function called"],
   "typescript" : "reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: T) => number, initialValue?: number): number;"
 }
-Execute `previousValue=initialValue` and then `previousValue = callback(previousValue, currentValue, index, array)` for each element in the array, and finally return previousValue.
+Execute `previousValue=initialValue` and then `previousValue =
+callback(previousValue, currentValue, index, array)` for each element in the
+array, and finally return previousValue.
  */
 /*JSON{
   "type" : "method",
@@ -860,7 +928,8 @@ Fill this array with the given value, for every index `>= start` and `< end`
   "return" : ["JsVar","An array containing the results"],
   "typescript" : "filter(predicate: (value: number, index: number, array: T) => any, thisArg?: any): T;"
 }
-Return an array which contains only those elements for which the callback function returns 'true'
+Return an array which contains only those elements for which the callback
+function returns 'true'
  */
 /*JSON{
   "type" : "method",
@@ -874,7 +943,8 @@ Return an array which contains only those elements for which the callback functi
   "return" : ["JsVar","The array element where `function` returns `true`, or `undefined`"],
   "typescript" : "find(predicate: (value: number, index: number, obj: T) => boolean, thisArg?: any): number | undefined;"
 }
-Return the array element where `function` returns `true`, or `undefined` if it doesn't returns `true` for any element.
+Return the array element where `function` returns `true`, or `undefined` if it
+doesn't returns `true` for any element.
  */
 /*JSON{
   "type" : "method",
@@ -888,7 +958,8 @@ Return the array element where `function` returns `true`, or `undefined` if it d
   "return" : ["JsVar","The array element's index where `function` returns `true`, or `-1`"],
   "typescript" : "findIndex(predicate: (value: number, index: number, obj: T) => boolean, thisArg?: any): number;"
 }
-Return the array element's index where `function` returns `true`, or `-1` if it doesn't returns `true` for any element.
+Return the array element's index where `function` returns `true`, or `-1` if it
+doesn't returns `true` for any element.
  */
 /*JSON{
   "type" : "method",

--- a/src/jswrap_dataview.c
+++ b/src/jswrap_dataview.c
@@ -42,7 +42,8 @@ This class helps
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "new(buffer: ArrayBuffer, byteOffset?: number, byteLength?: number): DataView;"
 }
-Create a `DataView` object that can be used to access the data in an `ArrayBuffer`.
+Create a `DataView` object that can be used to access the data in an
+`ArrayBuffer`.
 
 ```
 var b = new ArrayBuffer(8)

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -223,13 +223,13 @@ static CalendarDate getCalendarDateFromDateVar(JsVar *date, bool forceGMT) {
 }
 The built-in class for handling Dates.
 
-**Note:** By default the time zone is GMT+0, however you can change the
-timezone using the `E.setTimeZone(...)` function.
+**Note:** By default the time zone is GMT+0, however you can change the timezone
+using the `E.setTimeZone(...)` function.
 
 For example `E.setTimeZone(1)` will be GMT+0100
 
-*However* if you have daylight savings time set with `E.setDST(...)` then the timezone set
-by `E.setTimeZone(...)` will be _ignored_.
+*However* if you have daylight savings time set with `E.setDST(...)` then the
+timezone set by `E.setTimeZone(...)` will be _ignored_.
 
  */
 
@@ -240,7 +240,8 @@ by `E.setTimeZone(...)` will be _ignored_.
   "generate" : "jswrap_date_now",
   "return" : ["float",""]
 }
-Get the number of milliseconds elapsed since 1970 (or on embedded platforms, since startup)
+Get the number of milliseconds elapsed since 1970 (or on embedded platforms,
+since startup)
  */
 JsVarFloat jswrap_date_now() {
   // Not quite sure why we need this, but (JsVarFloat)jshGetSystemTime() / (JsVarFloat)jshGetTimeFromMilliseconds(1) in inaccurate on STM32
@@ -676,7 +677,8 @@ JsVarFloat jswrap_date_setFullYear(JsVar *parent, int yearValue, JsVar *monthVal
 }
 Converts to a String, eg: `Fri Jun 20 2014 14:52:20 GMT+0000`
 
- **Note:** This uses whatever timezone was set with `E.setTimeZone()` or `E.setDST()`
+ **Note:** This uses whatever timezone was set with `E.setTimeZone()` or
+ `E.setDST()`
 */
 JsVar *jswrap_date_toString(JsVar *parent) {
   TimeInDay time = getTimeFromDateVar(parent, false/*system timezone*/);
@@ -752,7 +754,8 @@ JsVar *jswrap_date_toISOString(JsVar *parent) {
   "return" : ["JsVar","A String"],
   "typescript" : "toLocalISOString(): string;"
 }
-Converts to a ISO 8601 String (with timezone information), eg: `2014-06-20T14:52:20.123-0500`
+Converts to a ISO 8601 String (with timezone information), eg:
+`2014-06-20T14:52:20.123-0500`
  */
 JsVar *jswrap_date_toLocalISOString(JsVar *parent) {
   TimeInDay time = getTimeFromDateVar(parent, false/*system timezone*/);
@@ -834,7 +837,8 @@ static bool _parse_time(TimeInDay *time, int initialChars) {
   "return" : ["float","The number of milliseconds since 1970"],
   "typescript" : "parse(str: string): number;"
 }
-Parse a date string and return milliseconds since 1970. Data can be either '2011-10-20T14:48:00', '2011-10-20' or 'Mon, 25 Dec 1995 13:30:00 +0430' 
+Parse a date string and return milliseconds since 1970. Data can be either
+'2011-10-20T14:48:00', '2011-10-20' or 'Mon, 25 Dec 1995 13:30:00 +0430'
  */
 JsVarFloat jswrap_date_parse(JsVar *str) {
   if (!jsvIsString(str)) return 0;

--- a/src/jswrap_error.c
+++ b/src/jswrap_error.c
@@ -44,8 +44,8 @@ The base class for internal errors
   "type" : "class",
   "class" : "ReferenceError"
 }
-The base class for reference errors - where a variable
-which doesn't exist has been accessed.
+The base class for reference errors - where a variable which doesn't exist has
+been accessed.
  */
 
 JsVar *_jswrap_error_constructor(JsVar *msg, char *type) {

--- a/src/jswrap_espruino.c
+++ b/src/jswrap_espruino.c
@@ -68,9 +68,9 @@ E.on('kill', function() {
 });
 ```
 
-**NOTE:** This event is not called when the device is 'hard reset' - for
-example by removing power, hitting an actual reset button, or via
-a Watchdog timer reset.
+**NOTE:** This event is not called when the device is 'hard reset' - for example
+by removing power, hitting an actual reset button, or via a Watchdog timer
+reset.
 */
 
 /*JSON{
@@ -82,16 +82,15 @@ a Watchdog timer reset.
   ],
   "typescript" : "on(event: \"errorFlag\", callback: (errorFlags: ErrorFlag[]) => void): void;"
 }
-This event is called when an error is created by Espruino itself (rather
-than JS code) which changes the state of the error flags reported by
-`E.getErrorFlags()`
+This event is called when an error is created by Espruino itself (rather than JS
+code) which changes the state of the error flags reported by `E.getErrorFlags()`
 
 This could be low memory, full buffers, UART overflow, etc. `E.getErrorFlags()`
 has a full description of each type of error.
 
-This event will only be emitted when error flag is set. If the error
-flag was already set nothing will be emitted. To clear error flags
-so that you do get a callback each time a flag is set, call `E.getErrorFlags()`.
+This event will only be emitted when error flag is set. If the error flag was
+already set nothing will be emitted. To clear error flags so that you do get a
+callback each time a flag is set, call `E.getErrorFlags()`.
 */
 /*JSON{
   "type" : "event",
@@ -103,11 +102,11 @@ so that you do get a callback each time a flag is set, call `E.getErrorFlags()`.
     ["b","int","Touch count - 0 for released, 1 for pressed"]
   ]
 }
-This event is called when a full touchscreen device on an Espruino
-is interacted with.
+This event is called when a full touchscreen device on an Espruino is interacted
+with.
 
-**Note:** This event is not implemented on Bangle.js because
-it only has a two area touchscreen.
+**Note:** This event is not implemented on Bangle.js because it only has a two
+area touchscreen.
 
 To use the touchscreen to draw lines, you could do:
 
@@ -130,11 +129,16 @@ E.on('touch',t=>{
 }
 Use the microcontroller's internal thermistor to work out the temperature.
 
-On Puck.js v2.0 this will use the on-board PCT2075TP temperature sensor, but on other devices it may not be desperately well calibrated.
+On Puck.js v2.0 this will use the on-board PCT2075TP temperature sensor, but on
+other devices it may not be desperately well calibrated.
 
-While this is implemented on Espruino boards, it may not be implemented on other devices. If so it'll return NaN.
+While this is implemented on Espruino boards, it may not be implemented on other
+devices. If so it'll return NaN.
 
- **Note:** This is not entirely accurate and varies by a few degrees from chip to chip. It measures the **die temperature**, so when connected to USB it could be reading 10 over degrees C above ambient temperature. When running from battery with `setDeepSleep(true)` it is much more accurate though.
+ **Note:** This is not entirely accurate and varies by a few degrees from chip
+ to chip. It measures the **die temperature**, so when connected to USB it could
+ be reading 10 over degrees C above ambient temperature. When running from
+ battery with `setDeepSleep(true)` it is much more accurate though.
 */
 JsVarFloat jswrap_espruino_getTemperature() {
 #ifdef PUCKJS
@@ -152,13 +156,16 @@ JsVarFloat jswrap_espruino_getTemperature() {
   "generate_full" : "jshReadVRef()",
   "return" : ["float","The voltage (in Volts) that a reading of 1 from `analogRead` actually represents - usually around 3.3v"]
 }
-Check the internal voltage reference. To work out an actual voltage of an input pin, you can use `analogRead(pin)*E.getAnalogVRef()`
+Check the internal voltage reference. To work out an actual voltage of an input
+pin, you can use `analogRead(pin)*E.getAnalogVRef()`
 
- **Note:** This value is calculated by reading the voltage on an internal voltage reference with the ADC.
-It will be slightly noisy, so if you need this for accurate measurements we'd recommend that you call
-this function several times and average the results.
+ **Note:** This value is calculated by reading the voltage on an internal
+voltage reference with the ADC. It will be slightly noisy, so if you need this
+for accurate measurements we'd recommend that you call this function several
+times and average the results.
 
-While this is implemented on Espruino boards, it may not be implemented on other devices. If so it'll return NaN.
+While this is implemented on Espruino boards, it may not be implemented on other
+devices. If so it'll return NaN.
  */
 
 
@@ -195,15 +202,20 @@ int nativeCallGetCType() {
   "return" : ["JsVar","The native function"],
   "typescript" : "nativeCall(addr: number, sig: string, data?: string): any;"
 }
-ADVANCED: This is a great way to crash Espruino if you're not sure what you are doing
+ADVANCED: This is a great way to crash Espruino if you're not sure what you are
+doing
 
-Create a native function that executes the code at the given address, e.g. `E.nativeCall(0x08012345,'double (double,double)')(1.1, 2.2)`
+Create a native function that executes the code at the given address, e.g.
+`E.nativeCall(0x08012345,'double (double,double)')(1.1, 2.2)`
 
-If you're executing a thumb function, you'll almost certainly need to set the bottom bit of the address to 1.
+If you're executing a thumb function, you'll almost certainly need to set the
+bottom bit of the address to 1.
 
-Note it's not guaranteed that the call signature you provide can be used - there are limits on the number of arguments allowed.
+Note it's not guaranteed that the call signature you provide can be used - there
+are limits on the number of arguments allowed.
 
-When supplying `data`, if it is a 'flat string' then it will be used directly, otherwise it'll be converted to a flat string and used.
+When supplying `data`, if it is a 'flat string' then it will be used directly,
+otherwise it'll be converted to a flat string and used.
  */
 JsVar *jswrap_espruino_nativeCall(JsVarInt addr, JsVar *signature, JsVar *data) {
   unsigned int argTypes = 0;
@@ -316,7 +328,9 @@ JsVarFloat jswrap_espruino_sum(JsVar *arr) {
   "return" : ["float","The variance of the given buffer"],
   "typescript" : "variance(arr: string | number[] | ArrayBuffer, mean: number): number;"
 }
-Work out the variance of the contents of the given Array, String or ArrayBuffer and return the result. This is equivalent to `v=0;for (i in arr) v+=Math.pow(mean-arr[i],2)`
+Work out the variance of the contents of the given Array, String or ArrayBuffer
+and return the result. This is equivalent to `v=0;for (i in arr)
+v+=Math.pow(mean-arr[i],2)`
  */
 JsVarFloat jswrap_espruino_variance(JsVar *arr, JsVarFloat mean) {
   if (!(jsvIsIterable(arr))) {
@@ -351,7 +365,8 @@ JsVarFloat jswrap_espruino_variance(JsVar *arr, JsVarFloat mean) {
   "return" : ["float","The variance of the given buffer"],
   "typescript" : "convolve(arr1: string | number[] | ArrayBuffer, arr2: string | number[] | ArrayBuffer, offset: number): number;"
 }
-Convolve arr1 with arr2. This is equivalent to `v=0;for (i in arr1) v+=arr1[i] * arr2[(i+offset) % arr2.length]`
+Convolve arr1 with arr2. This is equivalent to `v=0;for (i in arr1) v+=arr1[i] *
+arr2[(i+offset) % arr2.length]`
  */
 JsVarFloat jswrap_espruino_convolve(JsVar *arr1, JsVar *arr2, int offset) {
   if (!(jsvIsIterable(arr1)) ||
@@ -485,16 +500,18 @@ short FFT(short int dir,long m,FFTDATATYPE *x,FFTDATATYPE *y)
   ],
   "typescript" : "FFT(arrReal: string | number[] | ArrayBuffer, arrImage?: string | number[] | ArrayBuffer, inverse?: boolean): any;"
 }
-Performs a Fast Fourier Transform (FFT) in 32 bit floats on the supplied data and writes it back into the
-original arrays. Note that if only one array is supplied, the data written back is the modulus of the complex
-result `sqrt(r*r+i*i)`.
+Performs a Fast Fourier Transform (FFT) in 32 bit floats on the supplied data
+and writes it back into the original arrays. Note that if only one array is
+supplied, the data written back is the modulus of the complex result
+`sqrt(r*r+i*i)`.
 
-In order to perform the FFT, there has to be enough room on the stack to allocate two arrays of 32 bit
-floating point numbers - this will limit the maximum size of FFT possible to around 1024 items on
-most platforms.
+In order to perform the FFT, there has to be enough room on the stack to
+allocate two arrays of 32 bit floating point numbers - this will limit the
+maximum size of FFT possible to around 1024 items on most platforms.
 
-**Note:** on the Original Espruino board, FFTs are performed in 64bit arithmetic as there isn't
-space to include the 32 bit maths routines (2x more RAM is required).
+**Note:** on the Original Espruino board, FFTs are performed in 64bit arithmetic
+as there isn't space to include the 32 bit maths routines (2x more RAM is
+required).
  */
 void _jswrap_espruino_FFT_getData(FFTDATATYPE *dst, JsVar *src, size_t length) {
   JsvIterator it;
@@ -578,9 +595,11 @@ void jswrap_espruino_FFT(JsVar *arrReal, JsVar *arrImag, bool inverse) {
   ],
   "typescript" : "enableWatchdog(timeout: number, isAuto?: boolean): void;"
 }
-Enable the watchdog timer. This will reset Espruino if it isn't able to return to the idle loop within the timeout.
+Enable the watchdog timer. This will reset Espruino if it isn't able to return
+to the idle loop within the timeout.
 
-If `isAuto` is false, you must call `E.kickWatchdog()` yourself every so often or the chip will reset.
+If `isAuto` is false, you must call `E.kickWatchdog()` yourself every so often
+or the chip will reset.
 
 ```
 E.enableWatchdog(0.5); // automatic mode                                                        
@@ -597,11 +616,13 @@ setInterval(function() {
 // or if the interval fails to be called 
 ```
 
-**NOTE:** This is only implemented on STM32 and nRF5x devices (all official Espruino boards).
+**NOTE:** This is only implemented on STM32 and nRF5x devices (all official
+Espruino boards).
 
 **NOTE:** On STM32 (Pico, WiFi, Original) with `setDeepSleep(1)` you need to
-explicitly wake Espruino up with an interval of less than the watchdog timeout or the watchdog will fire and
-the board will reboot. You can do this with `setInterval("", time_in_milliseconds)`.
+explicitly wake Espruino up with an interval of less than the watchdog timeout
+or the watchdog will fire and the board will reboot. You can do this with
+`setInterval("", time_in_milliseconds)`.
  */
 void jswrap_espruino_enableWatchdog(JsVarFloat time, JsVar *isAuto) {
   if (time<0 || isnan(time)) time=1;
@@ -622,7 +643,8 @@ void jswrap_espruino_enableWatchdog(JsVarFloat time, JsVar *isAuto) {
 Kicks a Watchdog timer set up with `E.enableWatchdog(..., false)`. See
 `E.enableWatchdog` for more information.
 
-**NOTE:** This is only implemented on STM32 and nRF5x devices (all official Espruino boards).
+**NOTE:** This is only implemented on STM32 and nRF5x devices (all official
+Espruino boards).
  */
 void jswrap_espruino_kickWatchdog() {
   jshKickWatchDog();
@@ -663,17 +685,23 @@ type ErrorFlag =
 }
 Get and reset the error flags. Returns an array that can contain:
 
-`'FIFO_FULL'`: The receive FIFO filled up and data was lost. This could be state transitions for setWatch, or received characters.
+`'FIFO_FULL'`: The receive FIFO filled up and data was lost. This could be state
+transitions for setWatch, or received characters.
 
-`'BUFFER_FULL'`: A buffer for a stream filled up and characters were lost. This can happen to any stream - Serial,HTTP,etc.
+`'BUFFER_FULL'`: A buffer for a stream filled up and characters were lost. This
+can happen to any stream - Serial,HTTP,etc.
 
-`'CALLBACK'`: A callback (`setWatch`, `setInterval`, `on('data',...)`) caused an error and so was removed.
+`'CALLBACK'`: A callback (`setWatch`, `setInterval`, `on('data',...)`) caused an
+error and so was removed.
 
-`'LOW_MEMORY'`: Memory is running low - Espruino had to run a garbage collection pass or remove some of the command history
+`'LOW_MEMORY'`: Memory is running low - Espruino had to run a garbage collection
+pass or remove some of the command history
 
-`'MEMORY'`: Espruino ran out of memory and was unable to allocate some data that it needed.
+`'MEMORY'`: Espruino ran out of memory and was unable to allocate some data that
+it needed.
 
-`'UART_OVERFLOW'` : A UART received data but it was not read in time and was lost
+`'UART_OVERFLOW'` : A UART received data but it was not read in time and was
+lost
  */
 JsVar *jswrap_espruino_getErrorFlags() {
   JsErrorFlags flags = jsErrorFlags;
@@ -697,12 +725,17 @@ type Flag =
   "return" : ["JsVar","An object containing flag names and their values"],
   "typescript" : "getFlags(): { [key in Flag]: boolean }"
 }
-Get Espruino's interpreter flags that control the way it handles your JavaScript code.
+Get Espruino's interpreter flags that control the way it handles your JavaScript
+code.
 
 * `deepSleep` - Allow deep sleep modes (also set by setDeepSleep)
-* `pretokenise` - When adding functions, pre-minify them and tokenise reserved words
-* `unsafeFlash` - Some platforms stop writes/erases to interpreter memory to stop you bricking the device accidentally - this removes that protection
-* `unsyncFiles` - When writing files, *don't* flush all data to the SD card after each command (the default is *to* flush). This is much faster, but can cause filesystem damage if power is lost without the filesystem unmounted.
+* `pretokenise` - When adding functions, pre-minify them and tokenise reserved
+  words
+* `unsafeFlash` - Some platforms stop writes/erases to interpreter memory to
+  stop you bricking the device accidentally - this removes that protection
+* `unsyncFiles` - When writing files, *don't* flush all data to the SD card
+  after each command (the default is *to* flush). This is much faster, but can
+  cause filesystem damage if power is lost without the filesystem unmounted.
 */
 /*JSON{
   "type" : "staticmethod",
@@ -714,9 +747,11 @@ Get Espruino's interpreter flags that control the way it handles your JavaScript
   ],
   "typescript" : "setFlags(flags: { [key in Flag]?: boolean }): void"
 }
-Set the Espruino interpreter flags that control the way it handles your JavaScript code.
+Set the Espruino interpreter flags that control the way it handles your
+JavaScript code.
 
-Run `E.getFlags()` and check its description for a list of available flags and their values.
+Run `E.getFlags()` and check its description for a list of available flags and
+their values.
 */
 
 // TODO Improve TypeScript declaration
@@ -746,9 +781,11 @@ Run `E.getFlags()` and check its description for a list of available flags and t
   "return_object" : "ArrayBufferView",
   "typescript" : "toArrayBuffer(str: string): ArrayBuffer;"
 }
-Create an ArrayBuffer from the given string. This is done via a reference, not a copy - so it is very fast and memory efficient.
+Create an ArrayBuffer from the given string. This is done via a reference, not a
+copy - so it is very fast and memory efficient.
 
-Note that this is an ArrayBuffer, not a Uint8Array. To get one of those, do: `new Uint8Array(E.toArrayBuffer('....'))`.
+Note that this is an ArrayBuffer, not a Uint8Array. To get one of those, do:
+`new Uint8Array(E.toArrayBuffer('....'))`.
  */
 JsVar *jswrap_espruino_toArrayBuffer(JsVar *str) {
   if (!jsvIsString(str)) return 0;
@@ -767,17 +804,17 @@ JsVar *jswrap_espruino_toArrayBuffer(JsVar *str) {
   "return_object" : "String",
   "typescript" : "toString(...args: any[]): string | undefined;"
 }
-Returns a 'flat' string representing the data in the arguments, or return `undefined`
-if a flat string cannot be created.
+Returns a 'flat' string representing the data in the arguments, or return
+`undefined` if a flat string cannot be created.
 
-This creates a string from the given arguments. If an argument is a String or an Array,
-each element is traversed and added as an 8 bit character. If it is anything else, it is
-converted to a character directly.
+This creates a string from the given arguments. If an argument is a String or an
+Array, each element is traversed and added as an 8 bit character. If it is
+anything else, it is converted to a character directly.
 
 In the case where there's one argument which is an 8 bit typed array backed by a
-flat string of the same length, the backing string will be returned without doing
-a copy or other allocation. The same applies if there's a single argument which
-is itself a flat string.
+flat string of the same length, the backing string will be returned without
+doing a copy or other allocation. The same applies if there's a single argument
+which is itself a flat string.
  */
 void (_jswrap_espruino_toString_char)(int ch,  JsvStringIterator *it) {
   jsvStringIteratorSetCharAndNext(it, (char)ch);
@@ -843,15 +880,19 @@ type Uint8ArrayResolvable =
   "return_object" : "Uint8Array",
   "typescript" : "toUint8Array(...args: Uint8ArrayResolvable[]): Uint8Array;"
 }
-This creates a Uint8Array from the given arguments. These are handled as follows:
+This creates a Uint8Array from the given arguments. These are handled as
+follows:
 
  * `Number` -> read as an integer, using the lowest 8 bits
- * `String` -> use each character's numeric value (e.g. `String.charCodeAt(...)`)
+ * `String` -> use each character's numeric value (e.g.
+   `String.charCodeAt(...)`)
  * `Array` -> Call itself on each element
  * `ArrayBuffer` or Typed Array -> use the lowest 8 bits of each element
  * `Object`:
-   * `{data:..., count: int}` -> call itself `object.count` times, on `object.data`
-   * `{callback : function}` -> call the given function, call itself on return value
+   * `{data:..., count: int}` -> call itself `object.count` times, on
+     `object.data`
+   * `{callback : function}` -> call the given function, call itself on return
+     value
 
 For example:
 
@@ -894,25 +935,24 @@ JsVar *jswrap_espruino_toUint8Array(JsVar *args) {
   "return" : ["JsVar","A String"],
   "return_object" : "String"
 }
-This performs the same basic function as `JSON.stringify`,
-however `JSON.stringify` adds extra characters to conform
-to the JSON spec which aren't required if outputting JS.
+This performs the same basic function as `JSON.stringify`, however
+`JSON.stringify` adds extra characters to conform to the JSON spec which aren't
+required if outputting JS.
 
-`E.toJS` will also stringify JS functions, whereas
-`JSON.stringify` ignores them.
+`E.toJS` will also stringify JS functions, whereas `JSON.stringify` ignores
+them.
 
 For example:
 
 * `JSON.stringify({a:1,b:2}) == '{"a":1,"b":2}'`
 * `E.toJS({a:1,b:2}) == '{a:1,b:2}'`
 
-**Note:** Strings generated with `E.toJS` can't be
-reliably parsed by `JSON.parse` - however they are
-valid JS so will work with `eval` (but this has security
-implications if you don't trust the source of the string).
+**Note:** Strings generated with `E.toJS` can't be reliably parsed by
+`JSON.parse` - however they are valid JS so will work with `eval` (but this has
+security implications if you don't trust the source of the string).
 
-On the desktop [JSON5 parsers](https://github.com/json5/json5)
-will parse the strings produced by `E.toJS` without trouble.
+On the desktop [JSON5 parsers](https://github.com/json5/json5) will parse the
+strings produced by `E.toJS` without trouble.
  */
 JsVar *jswrap_espruino_toJS(JsVar *v) {
   JSONFlags flags = JSON_DROP_QUOTES|JSON_NO_UNDEFINED|JSON_ARRAYBUFFER_AS_ARRAY;
@@ -935,13 +975,13 @@ JsVar *jswrap_espruino_toJS(JsVar *v) {
   "return" : ["JsVar","A String"],
   "return_object" : "String"
 }
-This creates and returns a special type of string, which actually references
-a specific memory address. It can be used in order to use sections of
-Flash memory directly in Espruino (for example to execute code straight
-from flash memory with `eval(E.memoryArea( ... ))`)
+This creates and returns a special type of string, which actually references a
+specific memory address. It can be used in order to use sections of Flash memory
+directly in Espruino (for example to execute code straight from flash memory
+with `eval(E.memoryArea( ... ))`)
 
-**Note:** This is only tested on STM32-based platforms (Espruino Original
-and Espruino Pico) at the moment.
+**Note:** This is only tested on STM32-based platforms (Espruino Original and
+Espruino Pico) at the moment.
 */
 JsVar *jswrap_espruino_memoryArea(int addr, int len) {
   if (len<0) return 0;
@@ -962,15 +1002,15 @@ JsVar *jswrap_espruino_memoryArea(int addr, int len) {
   "typescript" : "setBootCode(code: string, alwaysExec?: boolean): void;"
 }
 This writes JavaScript code into Espruino's flash memory, to be executed on
-startup. It differs from `save()` in that `save()` saves the whole state of
-the interpreter, whereas this just saves JS code that is executed at boot.
+startup. It differs from `save()` in that `save()` saves the whole state of the
+interpreter, whereas this just saves JS code that is executed at boot.
 
 Code will be executed before `onInit()` and `E.on('init', ...)`.
 
 If `alwaysExec` is `true`, the code will be executed even after a call to
-`reset()`. This is useful if you're making something that you want to
-program, but you want some code that is always built in (for instance
-setting up a display or keyboard).
+`reset()`. This is useful if you're making something that you want to program,
+but you want some code that is always built in (for instance setting up a
+display or keyboard).
 
 To remove boot code that has been saved previously, use `E.setBootCode("")`
 
@@ -996,8 +1036,8 @@ void jswrap_espruino_setBootCode(JsVar *code, bool alwaysExec) {
   "return" : ["int","The actual frequency the clock has been set to"],
   "typescript" : "setClock(options: number | { M: number, N: number, P: number, Q: number, latency?: number, PCLK?: number, PCLK2?: number }): number;"
 }
-This sets the clock frequency of Espruino's processor. It will return `0` if
-it is unimplemented or the clock speed cannot be changed.
+This sets the clock frequency of Espruino's processor. It will return `0` if it
+is unimplemented or the clock speed cannot be changed.
 
 **Note:** On pretty much all boards, UART, SPI, I2C, PWM, etc will change
 frequency and will need setting up again in order to work.
@@ -1016,14 +1056,14 @@ Optional arguments are:
 * `PCLK1` - Peripheral clock 1 divisor (default: 2)
 * `PCLK2` - Peripheral clock 2 divisor (default: 4)
 
-The Pico's default is `{M:8, N:336, P:4, Q:7, PCLK1:2, PCLK2:4}`, use
-`{M:8, N:336, P:8, Q:7, PCLK:1, PCLK2:2}` to halve the system clock speed
-while keeping the peripherals running at the same speed (omitting PCLK1/2
-will lead to the peripherals changing speed too).
+The Pico's default is `{M:8, N:336, P:4, Q:7, PCLK1:2, PCLK2:4}`, use `{M:8,
+N:336, P:8, Q:7, PCLK:1, PCLK2:2}` to halve the system clock speed while keeping
+the peripherals running at the same speed (omitting PCLK1/2 will lead to the
+peripherals changing speed too).
 
 On STM32F4 boards (e.g. Espruino Pico), the USB clock needs to be kept at 48Mhz
-or USB will fail to work. You'll also experience USB instability if the processor
-clock falls much below 48Mhz.
+or USB will fail to work. You'll also experience USB instability if the
+processor clock falls much below 48Mhz.
 
 ### ESP8266
 
@@ -1046,19 +1086,18 @@ int jswrap_espruino_setClock(JsVar *options) {
   ],
   "typescript" : "setConsole(device: \"Serial1\" | \"USB\" | \"Bluetooth\" | \"Telnet\" | \"Terminal\" | Serial | null, options?: { force?: boolean }): void;"
 }
-Changes the device that the JS console (otherwise known as the REPL)
-is attached to. If the console is on a device, that
-device can be used for programming Espruino.
+Changes the device that the JS console (otherwise known as the REPL) is attached
+to. If the console is on a device, that device can be used for programming
+Espruino.
 
 Rather than calling `Serial.setConsole` you can call
 `E.setConsole("DeviceName")`.
 
-This is particularly useful if you just want to
-remove the console. `E.setConsole(null)` will
-make the console completely inaccessible.
+This is particularly useful if you just want to remove the console.
+`E.setConsole(null)` will make the console completely inaccessible.
 
-`device` may be `"Serial1"`,`"USB"`,`"Bluetooth"`,`"Telnet"`,`"Terminal"`,
-any other *hardware* `Serial` device, or `null` to disable the console completely.
+`device` may be `"Serial1"`,`"USB"`,`"Bluetooth"`,`"Telnet"`,`"Terminal"`, any
+other *hardware* `Serial` device, or `null` to disable the console completely.
 
 `options` is of the form:
 
@@ -1131,7 +1170,8 @@ Reverse the 8 bits in a byte, swapping MSB and LSB.
 
 For example, `E.reverseByte(0b10010000) == 0b00001001`.
 
-Note that you can reverse all the bytes in an array with: `arr = arr.map(E.reverseByte)`
+Note that you can reverse all the bytes in an array with: `arr =
+arr.map(E.reverseByte)`
  */
 int jswrap_espruino_reverseByte(int v) {
   unsigned int b = v&0xFF;
@@ -1160,7 +1200,8 @@ void jswrap_espruino_dumpTimers() {
   "ifndef" : "RELEASE",
   "generate" : "jswrap_espruino_dumpLockedVars"
 }
-Dump any locked variables that aren't referenced from `global` - for debugging memory leaks only.
+Dump any locked variables that aren't referenced from `global` - for debugging
+memory leaks only.
 */
 #ifndef RELEASE
 void jswrap_espruino_dumpLockedVars() {
@@ -1175,7 +1216,8 @@ void jswrap_espruino_dumpLockedVars() {
   "ifndef" : "RELEASE",
   "generate" : "jswrap_espruino_dumpFreeList"
 }
-Dump any locked variables that aren't referenced from `global` - for debugging memory leaks only.
+Dump any locked variables that aren't referenced from `global` - for debugging
+memory leaks only.
 */
 #ifndef RELEASE
 void jswrap_espruino_dumpFreeList() {
@@ -1228,9 +1270,8 @@ void jswrap_e_dumpFragmentation() {
   "name" : "dumpVariables",
   "generate" : "jswrap_e_dumpVariables"
 }
-Dumps a comma-separated list of all allocated variables
-along with the variables they link to. Can be used
-to visualise where memory is used.
+Dumps a comma-separated list of all allocated variables along with the variables
+they link to. Can be used to visualise where memory is used.
  */
 void jswrap_e_dumpVariables() {
   jsiConsolePrintf("ref,size,flags,name,links...\n");
@@ -1317,12 +1358,12 @@ type VariableSizeInformation = {
   ]
 }
 Return the number of variable blocks used by the supplied variable. This is
-useful if you're running out of memory and you want to be able to see what
-is taking up most of the available space.
+useful if you're running out of memory and you want to be able to see what is
+taking up most of the available space.
 
-If `depth>0` and the variable can be recursed into, an array listing all property
-names (including internal Espruino names) and their sizes is returned. If
-`depth>1` there is also a `more` field that inspects the objects' children's
+If `depth>0` and the variable can be recursed into, an array listing all
+property names (including internal Espruino names) and their sizes is returned.
+If `depth>1` there is also a `more` field that inspects the objects' children's
 children.
 
 For instance `E.getSizeOf(function(a,b) { })` returns `5`.
@@ -1343,8 +1384,8 @@ But `E.getSizeOf(function(a,b) { }, 1)` returns:
  ]
 ```
 
-In this case setting depth to `2` will make no difference as there are
-no more children to traverse.
+In this case setting depth to `2` will make no difference as there are no more
+children to traverse.
 
 See http://www.espruino.com/Internals for more information
  */
@@ -1387,13 +1428,12 @@ JsVar *jswrap_espruino_getSizeOf(JsVar *v, int depth) {
   ],
   "return" : ["int","The address of the given variable"]
 }
-Return the address in memory of the given variable. This can then
-be used with `peek` and `poke` functions. However, changing data in
-JS variables directly (flatAddress=false) will most likely result in a crash.
+Return the address in memory of the given variable. This can then be used with
+`peek` and `poke` functions. However, changing data in JS variables directly
+(flatAddress=false) will most likely result in a crash.
 
-This functions exists to allow embedded targets to set up
-peripherals such as DMA so that they write directly to
-JS variables.
+This functions exists to allow embedded targets to set up peripherals such as
+DMA so that they write directly to JS variables.
 
 See http://www.espruino.com/Internals for more information
  */
@@ -1419,8 +1459,8 @@ JsVarInt jswrap_espruino_getAddressOf(JsVar *v, bool flatAddress) {
   ],
   "typescript" : "mapInPlace(from: ArrayBuffer, to: ArrayBuffer, map?: number[] | ((value: number, index: number) => number) | undefined, bits?: number): void;"
 }
-Take each element of the `from` array, look it up in `map` (or call `map(value,index)` 
-if it is a function), and write it into the corresponding
+Take each element of the `from` array, look it up in `map` (or call
+`map(value,index)` if it is a function), and write it into the corresponding
 element in the `to` array.
 
 You can use an array to map:
@@ -1566,7 +1606,8 @@ JsVar *jswrap_espruino_lookupNoCase(JsVar *haystack, JsVar *needle, bool returnK
   "return" : ["JsVar","A String"],
   "return_object" : "String"
 }
-Get the current interpreter state in a text form such that it can be copied to a new device
+Get the current interpreter state in a text form such that it can be copied to a
+new device
  */
 JsVar *jswrap_e_dumpStr() {
   JsVar *result = jsvNewFromEmptyString();
@@ -1599,10 +1640,9 @@ Set the seed for the random number generator used by `Math.random()`.
   "generate" : "jshGetRandomNumber",
   "return" : ["int32","A random number"]
 }
-Unlike 'Math.random()' which uses a pseudo-random number generator, this
-method reads from the internal voltage reference several times, XOR-ing and
-rotating to try and make a relatively random value from the noise in the
-signal.
+Unlike 'Math.random()' which uses a pseudo-random number generator, this method
+reads from the internal voltage reference several times, XOR-ing and rotating to
+try and make a relatively random value from the noise in the signal.
  */
 
 /*JSON{
@@ -1616,8 +1656,8 @@ signal.
   ],
   "return" : ["JsVar","The CRC of the supplied data"]
 }
-Perform a standard 32 bit CRC (Cyclic redundancy check) on the supplied data (one byte at a time)
-and return the result as an unsigned integer.
+Perform a standard 32 bit CRC (Cyclic redundancy check) on the supplied data
+(one byte at a time) and return the result as an unsigned integer.
  */
 JsVar *jswrap_espruino_CRC32(JsVar *data) {
   JsvIterator it;
@@ -1651,13 +1691,15 @@ JsVar *jswrap_espruino_CRC32(JsVar *data) {
     "HSBtoRGB(hue: number, sat: number, bri: number, asArray: true): [number, number, number];"
   ]
 }
-Convert hue, saturation and brightness to red, green and blue (packed into an integer if `asArray==false` or an array if `asArray==true`).
+Convert hue, saturation and brightness to red, green and blue (packed into an
+integer if `asArray==false` or an array if `asArray==true`).
 
-This replaces `Graphics.setColorHSB` and `Graphics.setBgColorHSB`. On devices with 24 bit colour it can
-be used as: `Graphics.setColor(E.HSBtoRGB(h, s, b))`
+This replaces `Graphics.setColorHSB` and `Graphics.setBgColorHSB`. On devices
+with 24 bit colour it can be used as: `Graphics.setColor(E.HSBtoRGB(h, s, b))`
 
-You can quickly set RGB items in an Array or Typed Array using `array.set(E.HSBtoRGB(h, s, b,true), offset)`,
-which can be useful with arrays used with `require("neopixel").write`.
+You can quickly set RGB items in an Array or Typed Array using
+`array.set(E.HSBtoRGB(h, s, b,true), offset)`, which can be useful with arrays
+used with `require("neopixel").write`.
  */
 int jswrap_espruino_HSBtoRGB_int(JsVarFloat hue, JsVarFloat sat, JsVarFloat bri) {
   int   r, g, b, hi, bi, x, y, z;
@@ -1715,17 +1757,17 @@ JsVar *jswrap_espruino_HSBtoRGB(JsVarFloat hue, JsVarFloat sat, JsVarFloat bri, 
   ],
   "typescript" : "setPassword(password: string): void;"
 }
-Set a password on the console (REPL). When powered on, Espruino will
-then demand a password before the console can be used. If you want to
-lock the console immediately after this you can call `E.lockConsole()`
+Set a password on the console (REPL). When powered on, Espruino will then demand
+a password before the console can be used. If you want to lock the console
+immediately after this you can call `E.lockConsole()`
 
 To remove the password, call this function with no arguments.
 
 **Note:** There is no protection against multiple password attempts, so someone
 could conceivably try every password in a dictionary.
 
-**Note:** This password is stored in memory in plain text. If someone is able
-to execute arbitrary JavaScript code on the device (e.g., you use `eval` on input
+**Note:** This password is stored in memory in plain text. If someone is able to
+execute arbitrary JavaScript code on the device (e.g., you use `eval` on input
 from unknown sources) or read the device's firmware then they may be able to
 obtain it.
  */
@@ -1741,8 +1783,8 @@ void jswrap_espruino_setPassword(JsVar *pwd) {
   "name" : "lockConsole",
   "generate" : "jswrap_espruino_lockConsole"
 }
-If a password has been set with `E.setPassword()`, this will lock the console
-so the password needs to be entered to unlock it.
+If a password has been set with `E.setPassword()`, this will lock the console so
+the password needs to be entered to unlock it.
 */
 void jswrap_espruino_lockConsole() {
   JsVar *pwd = jsvObjectGetChild(execInfo.hiddenRoot, PASSWORD_VARIABLE_NAME, 0);
@@ -1764,8 +1806,9 @@ Set the time zone to be used with `Date` objects.
 
 For example `E.setTimeZone(1)` will be GMT+0100
 
-Note that `E.setTimeZone()` will have no effect when daylight savings time rules have been set with `E.setDST()`. The
-timezone value will be stored, but never used so long as DST settings are in effect.
+Note that `E.setTimeZone()` will have no effect when daylight savings time rules
+have been set with `E.setDST()`. The timezone value will be stored, but never
+used so long as DST settings are in effect.
 
 Time can be set with `setTime`.
 */
@@ -1789,30 +1832,47 @@ void jswrap_espruino_setTimeZone(JsVarFloat zone) {
 Set the daylight savings time parameters to be used with `Date` objects.
 
 The parameters are
-- dstOffset: The number of minutes daylight savings time adds to the clock (usually 60) - set to 0 to disable DST
-- timezone: The time zone, in minutes, when DST is not in effect - positive east of Greenwich
-- startDowNumber: The index of the day-of-week in the month when DST starts - 0 for first, 1 for second, 2 for third, 3 for fourth and 4 for last
-- startDow: The day-of-week for the DST start calculation - 0 for Sunday, 6 for Saturday
-- startMonth: The number of the month that DST starts - 0 for January, 11 for December
-- startDayOffset: The number of days between the selected day-of-week and the actual day that DST starts - usually 0
+- dstOffset: The number of minutes daylight savings time adds to the clock
+  (usually 60) - set to 0 to disable DST
+- timezone: The time zone, in minutes, when DST is not in effect - positive east
+  of Greenwich
+- startDowNumber: The index of the day-of-week in the month when DST starts - 0
+  for first, 1 for second, 2 for third, 3 for fourth and 4 for last
+- startDow: The day-of-week for the DST start calculation - 0 for Sunday, 6 for
+  Saturday
+- startMonth: The number of the month that DST starts - 0 for January, 11 for
+  December
+- startDayOffset: The number of days between the selected day-of-week and the
+  actual day that DST starts - usually 0
 - startTimeOfDay: The number of minutes elapsed in the day before DST starts
-- endDowNumber: The index of the day-of-week in the month when DST ends - 0 for first, 1 for second, 2 for third, 3 for fourth and 4 for last
-- endDow: The day-of-week for the DST end calculation - 0 for Sunday, 6 for Saturday
-- endMonth: The number of the month that DST ends - 0 for January, 11 for December
-- endDayOffset: The number of days between the selected day-of-week and the actual day that DST ends - usually 0
+- endDowNumber: The index of the day-of-week in the month when DST ends - 0 for
+  first, 1 for second, 2 for third, 3 for fourth and 4 for last
+- endDow: The day-of-week for the DST end calculation - 0 for Sunday, 6 for
+  Saturday
+- endMonth: The number of the month that DST ends - 0 for January, 11 for
+  December
+- endDayOffset: The number of days between the selected day-of-week and the
+  actual day that DST ends - usually 0
 - endTimeOfDay: The number of minutes elapsed in the day before DST ends
 
-To determine what the `dowNumber, dow, month, dayOffset, timeOfDay` parameters should be, start with a sentence of the form
-"DST starts on the last Sunday of March (plus 0 days) at 03:00". Since it's the last Sunday, we have startDowNumber = 4, and since
-it's Sunday, we have startDow = 0. That it is March gives us startMonth = 2, and that the offset is zero days, we have
+To determine what the `dowNumber, dow, month, dayOffset, timeOfDay` parameters
+should be, start with a sentence of the form "DST starts on the last Sunday of
+March (plus 0 days) at 03:00". Since it's the last Sunday, we have
+startDowNumber = 4, and since it's Sunday, we have startDow = 0. That it is
+March gives us startMonth = 2, and that the offset is zero days, we have
 startDayOffset = 0. The time that DST starts gives us startTimeOfDay = 3*60.
 
-"DST ends on the Friday before the second Sunday in November at 02:00" would give us endDowNumber=1, endDow=0, endMonth=10, endDayOffset=-2 and endTimeOfDay=120.
+"DST ends on the Friday before the second Sunday in November at 02:00" would
+give us endDowNumber=1, endDow=0, endMonth=10, endDayOffset=-2 and
+endTimeOfDay=120.
 
-Using Ukraine as an example, we have a time which is 2 hours ahead of GMT in winter (EET) and 3 hours in summer (EEST). DST starts at 03:00 EET on the last Sunday in March,
-and ends at 04:00 EEST on the last Sunday in October. So someone in Ukraine might call `E.setDST(60,120,4,0,2,0,180,4,0,9,0,240);`
+Using Ukraine as an example, we have a time which is 2 hours ahead of GMT in
+winter (EET) and 3 hours in summer (EEST). DST starts at 03:00 EET on the last
+Sunday in March, and ends at 04:00 EEST on the last Sunday in October. So
+someone in Ukraine might call `E.setDST(60,120,4,0,2,0,180,4,0,9,0,240);`
 
-Note that when DST parameters are set (i.e. when `dstOffset` is not zero), `E.setTimeZone()` has no effect.
+Note that when DST parameters are set (i.e. when `dstOffset` is not zero),
+`E.setTimeZone()` has no effect.
 */
 void jswrap_espruino_setDST(JsVar *params) {
   JsVar *dst;
@@ -1839,8 +1899,8 @@ void jswrap_espruino_setDST(JsVar *params) {
   "return" : ["JsVar","An object where each field is memory-mapped to a register."],
   "typescript" : "memoryMap<T extends string>(baseAddress: number, registers: { [key in T]: number }): { [key in T]: number };"
 }
-Create an object where every field accesses a specific 32 bit address in the microcontroller's memory. This
-is perfect for accessing on-chip peripherals.
+Create an object where every field accesses a specific 32 bit address in the
+microcontroller's memory. This is perfect for accessing on-chip peripherals.
 
 ```
 // for NRF52 based chips
@@ -1880,11 +1940,12 @@ JsVar *jswrap_espruino_memoryMap(JsVar *baseAddress, JsVar *registers) {
 }
 Provide assembly to Espruino.
 
-**This function is not part of Espruino**. Instead, it is detected
-by the Espruino IDE (or command-line tools) at upload time and is
-replaced with machine code and an `E.nativeCall` call.
+**This function is not part of Espruino**. Instead, it is detected by the
+Espruino IDE (or command-line tools) at upload time and is replaced with machine
+code and an `E.nativeCall` call.
 
-See [the documentation on the Assembler](http://www.espruino.com/Assembler) for more information.
+See [the documentation on the Assembler](http://www.espruino.com/Assembler) for
+more information.
 */
 void jswrap_espruino_asm(JsVar *callspec, JsVar *args) {
   NOT_USED(callspec);
@@ -1905,12 +1966,12 @@ void jswrap_espruino_asm(JsVar *callspec, JsVar *args) {
 }
 Provides the ability to write C code inside your JavaScript file.
 
-**This function is not part of Espruino**. Instead, it is detected
-by the Espruino IDE (or command-line tools) at upload time, is sent
-to our web service to be compiled, and is replaced with machine code
-and an `E.nativeCall` call.
+**This function is not part of Espruino**. Instead, it is detected by the
+Espruino IDE (or command-line tools) at upload time, is sent to our web service
+to be compiled, and is replaced with machine code and an `E.nativeCall` call.
 
-See [the documentation on Inline C](http://www.espruino.com/InlineC) for more information and examples.
+See [the documentation on Inline C](http://www.espruino.com/InlineC) for more
+information and examples.
 */
 void jswrap_espruino_compiledC(JsVar *code) {
   NOT_USED(code);
@@ -1923,12 +1984,11 @@ void jswrap_espruino_compiledC(JsVar *code) {
   "name" : "reboot",
   "generate" : "jswrap_espruino_reboot"
 }
-Forces a hard reboot of the microcontroller - as close as possible
-to if the reset pin had been toggled.
+Forces a hard reboot of the microcontroller - as close as possible to if the
+reset pin had been toggled.
 
-**Note:** This is different to `reset()`, which performs a software
-reset of Espruino (resetting the interpreter and pin states, but not
-all the hardware)
+**Note:** This is different to `reset()`, which performs a software reset of
+Espruino (resetting the interpreter and pin states, but not all the hardware)
 */
 void jswrap_espruino_reboot() {
   // ensure `E.on('kill',...` gets called and everything is torn down correctly
@@ -1956,9 +2016,9 @@ void jswrap_espruino_reboot() {
   ],
   "typescript" : "setUSBHID(opts?: { reportDescriptor: any[] }): void;"
 }
-USB HID will only take effect next time you unplug and re-plug your Espruino. If you're
-disconnecting it from power you'll have to make sure you have `save()`d after calling
-this function.
+USB HID will only take effect next time you unplug and re-plug your Espruino. If
+you're disconnecting it from power you'll have to make sure you have `save()`d
+after calling this function.
  */
 void jswrap_espruino_setUSBHID(JsVar *arr) {
   if (jsvIsUndefined(arr)) {
@@ -2015,13 +2075,12 @@ bool jswrap_espruino_sendUSBHID(JsVar *arr) {
   "generate" : "jswrap_espruino_getBattery",
   "return" : ["int","A percentage between 0 and 100"]
 }
-In devices that come with batteries, this function returns
-the battery charge percentage as an integer between 0 and 100.
+In devices that come with batteries, this function returns the battery charge
+percentage as an integer between 0 and 100.
 
-**Note:** this is an estimation only, based on battery voltage.
-The temperature of the battery (as well as the load being drawn
-from it at the time `E.getBattery` is called) will affect the
-readings.
+**Note:** this is an estimation only, based on battery voltage. The temperature
+of the battery (as well as the load being drawn from it at the time
+`E.getBattery` is called) will affect the readings.
 */
 JsVarInt jswrap_espruino_getBattery() {
 #if defined(CUSTOM_GETBATTERY)
@@ -2042,26 +2101,30 @@ JsVarInt jswrap_espruino_getBattery() {
     ["prescaler","int","The amount of counts for one second of the RTC - this is a 15 bit integer value (0..32767)"]
   ]
 }
-Sets the RTC's prescaler's maximum value. This is the counter that counts up on each oscillation of the low
-speed oscillator. When the prescaler counts to the value supplied, one second is deemed to have passed.
+Sets the RTC's prescaler's maximum value. This is the counter that counts up on
+each oscillation of the low speed oscillator. When the prescaler counts to the
+value supplied, one second is deemed to have passed.
 
-By default this is set to the oscillator's average speed as specified in the datasheet, and usually that is
-fine. However on early [Espruino Pico](/Pico) boards the STM32F4's internal oscillator could vary by as
-much as 15% from the value in the datasheet. In that case you may want to alter this value to reflect the
-true RTC speed for more accurate timekeeping.
+By default this is set to the oscillator's average speed as specified in the
+datasheet, and usually that is fine. However on early [Espruino Pico](/Pico)
+boards the STM32F4's internal oscillator could vary by as much as 15% from the
+value in the datasheet. In that case you may want to alter this value to reflect
+the true RTC speed for more accurate timekeeping.
 
-To change the RTC's prescaler value to a computed value based on comparing against the high speed oscillator,
-just run the following command, making sure it's done a few seconds after the board starts up:
+To change the RTC's prescaler value to a computed value based on comparing
+against the high speed oscillator, just run the following command, making sure
+it's done a few seconds after the board starts up:
 
 ```
 E.setRTCPrescaler(E.getRTCPrescaler(true));
 ```
 
-When changing the RTC prescaler, the RTC 'follower' counters are reset and it can take a second or two before
-readings from getTime are stable again.
+When changing the RTC prescaler, the RTC 'follower' counters are reset and it
+can take a second or two before readings from getTime are stable again.
 
-To test, you can connect an input pin to a known frequency square wave and then use `setWatch`. If you don't
-have a frequency source handy, you can check against the high speed oscillator:
+To test, you can connect an input pin to a known frequency square wave and then
+use `setWatch`. If you don't have a frequency source handy, you can check
+against the high speed oscillator:
 
 ```
 // connect pin B3 to B4
@@ -2071,8 +2134,9 @@ setWatch(function(e) {
 }, B4, {repeat:true});
 ```
 
-**Note:** This is only used on official Espruino boards containing an STM32 microcontroller. Other boards
-(even those using an STM32) don't use the RTC and so this has no effect.
+**Note:** This is only used on official Espruino boards containing an STM32
+microcontroller. Other boards (even those using an STM32) don't use the RTC and
+so this has no effect.
  */
 void jswrap_espruino_setRTCPrescaler(int prescale) {
 #ifdef STM32
@@ -2100,8 +2164,9 @@ void jswrap_espruino_setRTCPrescaler(int prescale) {
 }
 Gets the RTC's current prescaler value if `calibrate` is undefined or false.
 
-If `calibrate` is true, the low speed oscillator's speed is calibrated against the high speed
-oscillator (usually +/- 20 ppm) and a suggested value to be fed into `E.setRTCPrescaler(...)` is returned.
+If `calibrate` is true, the low speed oscillator's speed is calibrated against
+the high speed oscillator (usually +/- 20 ppm) and a suggested value to be fed
+into `E.setRTCPrescaler(...)` is returned.
 
 See `E.setRTCPrescaler` for more information.
  */

--- a/src/jswrap_flash.c
+++ b/src/jswrap_flash.c
@@ -25,22 +25,24 @@
   "ifndef" : "SAVE_ON_FLASH"
 }
 
-This module allows you to read and write the nonvolatile flash memory of your device.
+This module allows you to read and write the nonvolatile flash memory of your
+device.
 
-Also see the `Storage` library, which provides a safer file-like
-interface to nonvolatile storage.
+Also see the `Storage` library, which provides a safer file-like interface to
+nonvolatile storage.
 
-It should be used with extreme caution, as it is easy to overwrite parts of Flash
-memory belonging to Espruino or even its bootloader. If you damage the bootloader
-then you may need external hardware such as a USB-TTL converter to restore it. For
-more information on restoring the bootloader see `Advanced Reflashing` in your
-board's reference pages.
+It should be used with extreme caution, as it is easy to overwrite parts of
+Flash memory belonging to Espruino or even its bootloader. If you damage the
+bootloader then you may need external hardware such as a USB-TTL converter to
+restore it. For more information on restoring the bootloader see `Advanced
+Reflashing` in your board's reference pages.
 
 To see which areas of memory you can and can't overwrite, look at the values
 reported by `process.memory()`.
 
 **Note:** On Nordic platforms there are checks in place to help you avoid
-'bricking' your device be damaging the bootloader. You can disable these with `E.setFlags({unsafeFlash:1})`
+'bricking' your device be damaging the bootloader. You can disable these with
+`E.setFlags({unsafeFlash:1})`
  */
 
 /*JSON{
@@ -75,12 +77,13 @@ JsVar *jswrap_flash_getPage(int addr) {
   "generate" : "jswrap_flash_getFree",
   "return"   : ["JsVar", "Array of objects with `addr` and `length` properties"]
 }
-This method returns an array of objects of the form `{addr : #, length : #}`, representing
-contiguous areas of flash memory in the chip that are not used for anything.
+This method returns an array of objects of the form `{addr : #, length : #}`,
+representing contiguous areas of flash memory in the chip that are not used for
+anything.
 
-The memory areas returned are on page boundaries. This means that you can
-safely erase the page containing any address here, and you won't risk
-deleting part of the Espruino firmware.
+The memory areas returned are on page boundaries. This means that you can safely
+erase the page containing any address here, and you won't risk deleting part of
+the Espruino firmware.
 */
 JsVar *jswrap_flash_getFree() {
   JsVar *arr = jshFlashGetFree();
@@ -123,8 +126,8 @@ Write data into memory at the given address
 
 In flash memory you may only turn bits that are 1 into bits that are 0. If
 you're writing data into an area that you have already written (so `read`
-doesn't return all `0xFF`) you'll need to call `erasePage` to clear the
-entire page.
+doesn't return all `0xFF`) you'll need to call `erasePage` to clear the entire
+page.
  */
 void jswrap_flash_write(JsVar *data, int addr) {
   if (jsvIsUndefined(data)) {

--- a/src/jswrap_functions.c
+++ b/src/jswrap_functions.c
@@ -37,11 +37,11 @@ hello("Test")  // 1 ["Test"]
 hello(1,2,3)   // 3 [1,2,3]
 ```
 
-**Note:** Due to the way Espruino works this is doesn't behave exactly
-the same as in normal JavaScript. The length of the arguments array
-will never be less than the number of arguments specified in the 
-function declaration: `(function(a){ return arguments.length; })() == 1`.
-Normal JavaScript interpreters would return `0` in the above case.
+**Note:** Due to the way Espruino works this is doesn't behave exactly the same
+as in normal JavaScript. The length of the arguments array will never be less
+than the number of arguments specified in the function declaration:
+`(function(a){ return arguments.length; })() == 1`. Normal JavaScript
+interpreters would return `0` in the above case.
 
  */
 extern JsExecInfo execInfo;
@@ -217,7 +217,8 @@ JsVarFloat jswrap_parseFloat(JsVar *v) {
   ],
   "return" : ["bool","True is the value is a Finite number, false if not."]
 }
-Is the parameter a finite num,ber or not? If needed, the parameter is first converted to a number.
+Is the parameter a finite num,ber or not? If needed, the parameter is first
+converted to a number.
  */
 bool jswrap_isFinite(JsVar *v) {
   JsVarFloat f = jsvGetFloat(v);
@@ -401,7 +402,8 @@ JsVar *jswrap_atob(JsVar *base64Data) {
   ],
   "return" : ["JsVar","A string containing the encoded data"]
 }
-Convert a string with any character not alphanumeric or `- _ . ! ~ * ' ( )` converted to the form `%XY` where `XY` is its hexadecimal representation
+Convert a string with any character not alphanumeric or `- _ . ! ~ * ' ( )`
+converted to the form `%XY` where `XY` is its hexadecimal representation
  */
 JsVar *jswrap_encodeURIComponent(JsVar *arg) {
   JsVar *v = jsvAsString(arg);
@@ -449,7 +451,8 @@ JsVar *jswrap_encodeURIComponent(JsVar *arg) {
   ],
   "return" : ["JsVar","A string containing the decoded data"]
 }
-Convert any groups of characters of the form '%ZZ', into characters with hex code '0xZZ'
+Convert any groups of characters of the form '%ZZ', into characters with hex
+code '0xZZ'
  */
 JsVar *jswrap_decodeURIComponent(JsVar *arg) {
   JsVar *v = jsvAsString(arg);

--- a/src/jswrap_interactive.c
+++ b/src/jswrap_interactive.c
@@ -47,7 +47,8 @@ A reference to the global scope, where everything is defined.
     ["pin","JsVar",""]
   ]
 }
-When Espruino is busy, set the pin specified here high. Set this to undefined to disable the feature.
+When Espruino is busy, set the pin specified here high. Set this to undefined to
+disable the feature.
  */
 #ifndef SAVE_ON_FLASH
 void jswrap_interface_setBusyIndicator(JsVar *pinVar) {
@@ -70,7 +71,8 @@ void jswrap_interface_setBusyIndicator(JsVar *pinVar) {
     ["pin","JsVar",""]
   ]
 }
-When Espruino is asleep, set the pin specified here low (when it's awake, set it high). Set this to undefined to disable the feature.
+When Espruino is asleep, set the pin specified here low (when it's awake, set it
+high). Set this to undefined to disable the feature.
 
 Please see http://www.espruino.com/Power+Consumption for more details on this.
  */
@@ -95,7 +97,9 @@ void jswrap_interface_setSleepIndicator(JsVar *pinVar) {
     ["sleep","bool",""]
   ]
 }
-Set whether we can enter deep sleep mode, which reduces power consumption to around 100uA. This only works on STM32 Espruino Boards (nRF52 boards sleep automatically).
+Set whether we can enter deep sleep mode, which reduces power consumption to
+around 100uA. This only works on STM32 Espruino Boards (nRF52 boards sleep
+automatically).
 
 Please see http://www.espruino.com/Power+Consumption for more details on this.
  */
@@ -115,7 +119,8 @@ void jswrap_interface_setDeepSleep(bool sleep) {
 }
 Output debugging information
 
-Note: This is not included on boards with low amounts of flash memory, or the Espruino board.
+Note: This is not included on boards with low amounts of flash memory, or the
+Espruino board.
  */
 void jswrap_interface_trace(JsVar *root) {
   #ifdef ESPRUINOBOARD
@@ -137,11 +142,16 @@ void jswrap_interface_trace(JsVar *root) {
   "ifndef" : "SAVE_ON_FLASH",
   "generate_full" : "jsiDumpState((vcbprintf_callback)jsiConsolePrintString, 0)"
 }
-Output current interpreter state in a text form such that it can be copied to a new device
+Output current interpreter state in a text form such that it can be copied to a
+new device
 
-Espruino keeps its current state in RAM (even if the function code is stored in Flash). When you type `dump()` it dumps the current state of code in RAM plus the hardware state, then if there's code saved in flash it writes "// Code saved with E.setBootCode" and dumps that too.
+Espruino keeps its current state in RAM (even if the function code is stored in
+Flash). When you type `dump()` it dumps the current state of code in RAM plus
+the hardware state, then if there's code saved in flash it writes "// Code saved
+with E.setBootCode" and dumps that too.
 
-**Note:** 'Internal' functions are currently not handled correctly. You will need to recreate these in the `onInit` function.
+**Note:** 'Internal' functions are currently not handled correctly. You will
+need to recreate these in the `onInit` function.
  */
 /*JSON{
   "type" : "function",
@@ -159,14 +169,15 @@ This command only executes when the Interpreter returns to the Idle state - for
 instance ```a=1;load();a=2;``` will still leave 'a' as undefined (or what it was
 set to in the saved program).
 
-Espruino will resume from where it was when you last typed `save()`.
-If you want code to be executed right after loading (for instance to initialise
-devices connected to Espruino), add an `init` event handler to `E` with
-`E.on('init', function() { ... your_code ... });`. This will then be automatically
-executed by Espruino every time it starts.
+Espruino will resume from where it was when you last typed `save()`. If you want
+code to be executed right after loading (for instance to initialise devices
+connected to Espruino), add an `init` event handler to `E` with `E.on('init',
+function() { ... your_code ... });`. This will then be automatically executed by
+Espruino every time it starts.
 
-**If you specify a filename in the argument then that file will be loaded
-from Storage after reset** in much the same way as calling `reset()` then `eval(require("Storage").read(filename))`
+**If you specify a filename in the argument then that file will be loaded from
+Storage after reset** in much the same way as calling `reset()` then
+`eval(require("Storage").read(filename))`
  */
 void jswrap_interface_load(JsVar *storageName) {
   jsiStatus |= JSIS_TODO_FLASH_LOAD;
@@ -181,27 +192,31 @@ void jswrap_interface_load(JsVar *storageName) {
   "#if" : "!defined(BANGLEJS)"
 }
 Save the state of the interpreter into flash (including the results of calling
-`setWatch`, `setInterval`, `pinMode`, and any listeners). The state will then be loaded automatically
- every time Espruino powers on or is hard-reset. To see what will get saved you can call `dump()`.
+`setWatch`, `setInterval`, `pinMode`, and any listeners). The state will then be
+loaded automatically every time Espruino powers on or is hard-reset. To see what
+will get saved you can call `dump()`.
 
-**Note:** If you set up intervals/etc in `onInit()` and you have already called `onInit`
-before running `save()`, when Espruino resumes there will be two copies of your intervals -
-the ones from before the save, and the ones from after - which may cause you problems.
+**Note:** If you set up intervals/etc in `onInit()` and you have already called
+`onInit` before running `save()`, when Espruino resumes there will be two copies
+of your intervals - the ones from before the save, and the ones from after -
+which may cause you problems.
 
-For more information about this and other options for saving, please see
-the [Saving code on Espruino](https://www.espruino.com/Saving) page.
+For more information about this and other options for saving, please see the
+[Saving code on Espruino](https://www.espruino.com/Saving) page.
 
 This command only executes when the Interpreter returns to the Idle state - for
 instance ```a=1;save();a=2;``` will save 'a' as 2.
 
-When Espruino powers on, it will resume from where it was when you typed `save()`.
-If you want code to be executed right after loading (for instance to initialise
-devices connected to Espruino), add a function called `onInit`, or add a `init`
-event handler to `E` with `E.on('init', function() { ... your_code ... });`.
-This will then be automatically executed by Espruino every time it starts.
+When Espruino powers on, it will resume from where it was when you typed
+`save()`. If you want code to be executed right after loading (for instance to
+initialise devices connected to Espruino), add a function called `onInit`, or
+add a `init` event handler to `E` with `E.on('init', function() { ... your_code
+... });`. This will then be automatically executed by Espruino every time it
+starts.
 
 In order to stop the program saved with this command being loaded automatically,
-check out [the Troubleshooting guide](https://www.espruino.com/Troubleshooting#espruino-stopped-working-after-i-typed-save-)
+check out [the Troubleshooting
+guide](https://www.espruino.com/Troubleshooting#espruino-stopped-working-after-i-typed-save-)
  */
 /*JSON{
   "type" : "function",
@@ -211,18 +226,21 @@ check out [the Troubleshooting guide](https://www.espruino.com/Troubleshooting#e
     ["clearFlash","bool","Remove saved code from flash as well"]
   ]
 }
-Reset the interpreter - clear program memory in RAM, and do not load a saved program from flash. This does NOT reset the underlying hardware (which allows you to reset the device without it disconnecting from USB).
+Reset the interpreter - clear program memory in RAM, and do not load a saved
+program from flash. This does NOT reset the underlying hardware (which allows
+you to reset the device without it disconnecting from USB).
 
-This command only executes when the Interpreter returns to the Idle state - for instance ```a=1;reset();a=2;``` will still leave 'a' as undefined.
+This command only executes when the Interpreter returns to the Idle state - for
+instance ```a=1;reset();a=2;``` will still leave 'a' as undefined.
 
 The safest way to do a full reset is to hit the reset button.
 
-If `reset()` is called with no arguments, it will reset the board's state in
-RAM but will not reset the state in flash. When next powered on (or when
-`load()` is called) the board will load the previously saved code.
+If `reset()` is called with no arguments, it will reset the board's state in RAM
+but will not reset the state in flash. When next powered on (or when `load()` is
+called) the board will load the previously saved code.
 
-Calling `reset(true)` will cause *all saved code in flash memory to
-be cleared as well*.
+Calling `reset(true)` will cause *all saved code in flash memory to be cleared
+as well*.
 
 */
 void jswrap_interface_reset(bool clearFlash) {
@@ -240,7 +258,10 @@ void jswrap_interface_reset(bool clearFlash) {
 }
 Print the supplied string(s) to the console
 
- **Note:** If you're connected to a computer (not a wall adaptor) via USB but **you are not running a terminal app** then when you print data Espruino may pause execution and wait until the computer requests the data it is trying to print.
+ **Note:** If you're connected to a computer (not a wall adaptor) via USB but
+ **you are not running a terminal app** then when you print data Espruino may
+ pause execution and wait until the computer requests the data it is trying to
+ print.
  */
 /*JSON{
   "type" : "staticmethod",
@@ -253,7 +274,10 @@ Print the supplied string(s) to the console
 }
 Print the supplied string(s) to the console
 
- **Note:** If you're connected to a computer (not a wall adaptor) via USB but **you are not running a terminal app** then when you print data Espruino may pause execution and wait until the computer requests the data it is trying to print.
+ **Note:** If you're connected to a computer (not a wall adaptor) via USB but
+ **you are not running a terminal app** then when you print data Espruino may
+ pause execution and wait until the computer requests the data it is trying to
+ print.
  */
 void jswrap_interface_print(JsVar *v) {
   assert(jsvIsArray(v));
@@ -287,7 +311,8 @@ void jswrap_interface_print(JsVar *v) {
 }
 Fill the console with the contents of the given function, so you can edit it.
 
-NOTE: This is a convenience function - it will not edit 'inner functions'. For that, you must edit the 'outer function' and re-execute it.
+NOTE: This is a convenience function - it will not edit 'inner functions'. For
+that, you must edit the 'outer function' and re-execute it.
  */
 void jswrap_interface_edit(JsVar *funcName) {
   JsVar *func = 0;
@@ -351,7 +376,9 @@ void jswrap_interface_edit(JsVar *funcName) {
     ["echoOn","bool",""]
   ]
 }
-Should Espruino echo what you type back to you? true = yes (Default), false = no. When echo is off, the result of executing a command is not returned. Instead, you must use 'print' to send output.
+Should Espruino echo what you type back to you? true = yes (Default), false =
+no. When echo is off, the result of executing a command is not returned.
+Instead, you must use 'print' to send output.
  */
 void jswrap_interface_echo(bool echoOn) {
   if (echoOn)
@@ -377,14 +404,13 @@ Return the current system time in Seconds (as a floating point number)
     ["time","float",""]
   ]
 }
-Set the current system time in seconds (`time` can be a floating
-point value).
+Set the current system time in seconds (`time` can be a floating point value).
 
-This is used with `getTime`, the time reported from `setWatch`, as
-well as when using `new Date()`.
+This is used with `getTime`, the time reported from `setWatch`, as well as when
+using `new Date()`.
 
-`Date.prototype.getTime()` reports the time in milliseconds, so
-you can set the time to a `Date` object using:
+`Date.prototype.getTime()` reports the time in milliseconds, so you can set the
+time to a `Date` object using:
 
 ```
 setTime((new Date("Tue, 19 Feb 2019 10:57")).getTime()/1000)
@@ -440,7 +466,8 @@ JsVar *jswrap_interface_getSerial() {
   ],
   "return" : ["JsVar","An ID that can be passed to clearInterval"]
 }
-Call the function (or evaluate the string) specified REPEATEDLY after the timeout in milliseconds.
+Call the function (or evaluate the string) specified REPEATEDLY after the
+timeout in milliseconds.
 
 For instance:
 
@@ -453,7 +480,8 @@ setInterval('console.log("Hello World");', 1000);
 // both print 'Hello World' every second
 ```
 
-You can also specify extra arguments that will be sent to the function when it is executed. For example:
+You can also specify extra arguments that will be sent to the function when it
+is executed. For example:
 
 ```
 setInterval(function (a,b) {
@@ -462,10 +490,13 @@ setInterval(function (a,b) {
 // prints 'Hello World' every second
 ```
 
-If you want to stop your function from being called, pass the number that
-was returned by `setInterval` into the `clearInterval` function.
+If you want to stop your function from being called, pass the number that was
+returned by `setInterval` into the `clearInterval` function.
 
- **Note:** If `setDeepSleep(true)` has been called and the interval is greater than 5 seconds, Espruino may execute the interval up to 1 second late. This is because Espruino can only wake from deep sleep every second - and waking early would cause Espruino to waste power while it waited for the correct time.
+ **Note:** If `setDeepSleep(true)` has been called and the interval is greater
+ than 5 seconds, Espruino may execute the interval up to 1 second late. This is
+ because Espruino can only wake from deep sleep every second - and waking early
+ would cause Espruino to waste power while it waited for the correct time.
  */
 /*JSON{
   "type" : "function",
@@ -478,7 +509,8 @@ was returned by `setInterval` into the `clearInterval` function.
   ],
   "return" : ["JsVar","An ID that can be passed to clearTimeout"]
 }
-Call the function (or evaluate the string) specified ONCE after the timeout in milliseconds.
+Call the function (or evaluate the string) specified ONCE after the timeout in
+milliseconds.
 
 For instance:
 
@@ -491,7 +523,8 @@ setTimeout('console.log("Hello World");', 1000);
 // both print 'Hello World' after a second
 ```
 
-You can also specify extra arguments that will be sent to the function when it is executed. For example:
+You can also specify extra arguments that will be sent to the function when it
+is executed. For example:
 
 ```
 setTimeout(function (a,b) {
@@ -500,10 +533,13 @@ setTimeout(function (a,b) {
 // prints 'Hello World' after 1 second
 ```
 
-If you want to stop the function from being called, pass the number that
-was returned by `setTimeout` into the `clearTimeout` function.
+If you want to stop the function from being called, pass the number that was
+returned by `setTimeout` into the `clearTimeout` function.
 
- **Note:** If `setDeepSleep(true)` has been called and the interval is greater than 5 seconds, Espruino may execute the interval up to 1 second late. This is because Espruino can only wake from deep sleep every second - and waking early would cause Espruino to waste power while it waited for the correct time.
+ **Note:** If `setDeepSleep(true)` has been called and the interval is greater
+ than 5 seconds, Espruino may execute the interval up to 1 second late. This is
+ because Espruino can only wake from deep sleep every second - and waking early
+ would cause Espruino to waste power while it waited for the correct time.
  */
 JsVar *_jswrap_interface_setTimeoutOrInterval(JsVar *func, JsVarFloat interval, JsVar *args, bool isTimeout) {
   // NOTE: The 5 sec delay mentioned in the description is handled by jshSleep
@@ -633,8 +669,8 @@ Change the Interval on a callback created with `setInterval`, for example:
 ```changeInterval(id, 1500); // now runs every 1.5 seconds```
 
 This takes effect immediately and resets the timeout, so in the example above,
-regardless of when you call `changeInterval`, the next interval will occur 1500ms
-after it.
+regardless of when you call `changeInterval`, the next interval will occur
+1500ms after it.
  */
 void jswrap_interface_changeInterval(JsVar *idVar, JsVarFloat interval) {
   JsVar *timerArrayPtr = jsvLock(timerArray);

--- a/src/jswrap_io.c
+++ b/src/jswrap_io.c
@@ -164,7 +164,8 @@ This is different to Arduino which only returns an integer between 0 and 1023
 
 However only pins connected to an ADC will work (see the datasheet)
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset pin's state to `"analog"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset pin's state to `"analog"`
  */
 /*JSON{
   "type" : "function",
@@ -180,11 +181,14 @@ Set the analog Value of a pin. It will be output using PWM.
 
 Objects can contain:
 
-* `freq` - pulse frequency in Hz, eg. ```analogWrite(A0,0.5,{ freq : 10 });``` - specifying a frequency will force PWM output, even if the pin has a DAC
+* `freq` - pulse frequency in Hz, eg. ```analogWrite(A0,0.5,{ freq : 10 });``` -
+  specifying a frequency will force PWM output, even if the pin has a DAC
 * `soft` - boolean, If true software PWM is used if hardware is not available.
-* `forceSoft` - boolean, If true software PWM is used even if hardware PWM or a DAC is available
+* `forceSoft` - boolean, If true software PWM is used even if hardware PWM or a
+  DAC is available
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset pin's state to `"output"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset pin's state to `"output"`
  */
 void jswrap_io_analogWrite(Pin pin, JsVarFloat value, JsVar *options) {
   JsVarFloat freq = 0;
@@ -210,13 +214,20 @@ void jswrap_io_analogWrite(Pin pin, JsVarFloat value, JsVar *options) {
     ["time","JsVar","A time in milliseconds, or an array of times (in which case a square wave will be output starting with a pulse of 'value')"]
   ]
 }
-Pulse the pin with the value for the given time in milliseconds. It uses a hardware timer to produce accurate pulses, and returns immediately (before the pulse has finished). Use `digitalPulse(A0,1,0)` to wait until a previous pulse has finished.
+Pulse the pin with the value for the given time in milliseconds. It uses a
+hardware timer to produce accurate pulses, and returns immediately (before the
+pulse has finished). Use `digitalPulse(A0,1,0)` to wait until a previous pulse
+has finished.
 
-eg. `digitalPulse(A0,1,5);` pulses A0 high for 5ms. `digitalPulse(A0,1,[5,2,4]);` pulses A0 high for 5ms, low for 2ms, and high for 4ms
+eg. `digitalPulse(A0,1,5);` pulses A0 high for 5ms.
+`digitalPulse(A0,1,[5,2,4]);` pulses A0 high for 5ms, low for 2ms, and high for
+4ms
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset pin's state to `"output"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset pin's state to `"output"`
 
-digitalPulse is for SHORT pulses that need to be very accurate. If you're doing anything over a few milliseconds, use setTimeout instead.
+digitalPulse is for SHORT pulses that need to be very accurate. If you're doing
+anything over a few milliseconds, use setTimeout instead.
  */
 void jswrap_io_digitalPulse(Pin pin, bool value, JsVar *times) {
   if (!jshIsPinValid(pin)) {
@@ -271,14 +282,17 @@ void jswrap_io_digitalPulse(Pin pin, bool value, JsVar *times) {
 }
 Set the digital value of the given pin.
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset pin's state to `"output"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset pin's state to `"output"`
 
-If pin argument is an array of pins (eg. `[A2,A1,A0]`) the value argument will be treated
-as an array of bits where the last array element is the least significant bit.
+If pin argument is an array of pins (eg. `[A2,A1,A0]`) the value argument will
+be treated as an array of bits where the last array element is the least
+significant bit.
 
-In this case, pin values are set least significant bit first (from the right-hand side
-of the array of pins). This means you can use the same pin multiple times, for
-example `digitalWrite([A1,A1,A0,A0],0b0101)` would pulse A0 followed by A1.
+In this case, pin values are set least significant bit first (from the
+right-hand side of the array of pins). This means you can use the same pin
+multiple times, for example `digitalWrite([A1,A1,A0,A0],0b0101)` would pulse A0
+followed by A1.
 
 If the pin argument is an object with a `write` method, the `write` method will
 be called with the value passed through.
@@ -326,13 +340,15 @@ void jswrap_io_digitalWrite(
 }
 Get the digital value of the given pin.
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset pin's state to `"input"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset pin's state to `"input"`
 
-If the pin argument is an array of pins (eg. `[A2,A1,A0]`) the value returned will be an number where
-the last array element is the least significant bit, for example if `A0=A1=1` and `A2=0`, `digitalRead([A2,A1,A0]) == 0b011`
+If the pin argument is an array of pins (eg. `[A2,A1,A0]`) the value returned
+will be an number where the last array element is the least significant bit, for
+example if `A0=A1=1` and `A2=0`, `digitalRead([A2,A1,A0]) == 0b011`
 
-If the pin argument is an object with a `read` method, the `read` method will be called and the integer value it returns
-passed back.
+If the pin argument is an object with a `read` method, the `read` method will be
+called and the integer value it returns passed back.
 */
 JsVarInt jswrap_io_digitalRead(JsVar *pinVar) {
   // Hadnle the case where it is an array of pins.
@@ -378,21 +394,27 @@ JsVarInt jswrap_io_digitalRead(JsVar *pinVar) {
 }
 Set the mode of the given pin.
 
- * `auto`/`undefined` - Don't change state, but allow `digitalWrite`/etc to automatically change state as appropriate
+ * `auto`/`undefined` - Don't change state, but allow `digitalWrite`/etc to
+   automatically change state as appropriate
  * `analog` - Analog input
  * `input` - Digital input
  * `input_pullup` - Digital input with internal ~40k pull-up resistor
  * `input_pulldown` - Digital input with internal ~40k pull-down resistor
  * `output` - Digital output
- * `opendrain` - Digital output that only ever pulls down to 0v. Sending a logical `1` leaves the pin open circuit
- * `opendrain_pullup` - Digital output that pulls down to 0v. Sending a logical `1` enables internal ~40k pull-up resistor
+ * `opendrain` - Digital output that only ever pulls down to 0v. Sending a
+   logical `1` leaves the pin open circuit
+ * `opendrain_pullup` - Digital output that pulls down to 0v. Sending a logical
+   `1` enables internal ~40k pull-up resistor
  * `af_output` - Digital output from built-in peripheral
- * `af_opendrain` - Digital output from built-in peripheral that only ever pulls down to 0v. Sending a logical `1` leaves the pin open circuit
+ * `af_opendrain` - Digital output from built-in peripheral that only ever pulls
+   down to 0v. Sending a logical `1` leaves the pin open circuit
 
- **Note:** `digitalRead`/`digitalWrite`/etc set the pin mode automatically *unless* `pinMode` has been called first.
-If you want `digitalRead`/etc to set the pin mode automatically after you have called `pinMode`, simply call it again
-with no mode argument (`pinMode(pin)`), `auto` as the argument (`pinMode(pin, "auto")`), or with the 3rd 'automatic'
-argument set to true (`pinMode(pin, "output", true)`).
+ **Note:** `digitalRead`/`digitalWrite`/etc set the pin mode automatically
+*unless* `pinMode` has been called first. If you want `digitalRead`/etc to set
+the pin mode automatically after you have called `pinMode`, simply call it again
+with no mode argument (`pinMode(pin)`), `auto` as the argument (`pinMode(pin,
+"auto")`), or with the 3rd 'automatic' argument set to true (`pinMode(pin,
+"output", true)`).
 */
 void jswrap_io_pinMode(
     Pin pin,
@@ -436,7 +458,8 @@ void jswrap_io_pinMode(
   ],
   "return" : ["JsVar","The pin mode, as a string"]
 }
-Return the current mode of the given pin. See `pinMode` for more information on returned values.
+Return the current mode of the given pin. See `pinMode` for more information on
+returned values.
  */
 JsVar *jswrap_io_getPinMode(Pin pin) {
   if (!jshIsPinValid(pin)) {
@@ -514,8 +537,8 @@ void jswrap_io_shiftOutCallback(int val, void *data) {
     ["data","JsVar","The data to shift out (see `E.toUint8Array` for info on the forms this can take)"]
   ]
 }
-Shift an array of data out using the pins supplied *least significant bit first*,
-for example:
+Shift an array of data out using the pins supplied *least significant bit
+first*, for example:
 
 ```
 // shift out to single clk+data
@@ -542,9 +565,9 @@ shiftOut([A3,A2,A1,A0], { clk : A4 }, [1,2,3,4]);
 }
 ```
 
-Each item in the `data` array will be output to the pins, with the first
-pin in the array being the MSB and the last the LSB, then the clock will be
-pulsed in the polarity given.
+Each item in the `data` array will be output to the pins, with the first pin in
+the array being the MSB and the last the LSB, then the clock will be pulsed in
+the polarity given.
 
 `repeat` is the amount of times shift data out for each array item. For instance
 we may want to shift 8 bits out through 2 pins - in which case we need to set
@@ -625,9 +648,11 @@ void jswrap_io_shiftOut(JsVar *pins, JsVar *options, JsVar *data) {
   ],
   "return" : ["JsVar","An ID that can be passed to clearWatch"]
 }
-Call the function specified when the pin changes. Watches set with `setWatch` can be removed using `clearWatch`.
+Call the function specified when the pin changes. Watches set with `setWatch`
+can be removed using `clearWatch`.
 
-If the `options` parameter is an object, it can contain the following information (all optional):
+If the `options` parameter is an object, it can contain the following
+information (all optional):
 
 ```
 {
@@ -652,30 +677,39 @@ If the `options` parameter is an object, it can contain the following informatio
 }
 ```
 
-The `function` callback is called with an argument, which is an object of type `{state:bool, time:float, lastTime:float}`.
+The `function` callback is called with an argument, which is an object of type
+`{state:bool, time:float, lastTime:float}`.
 
  * `state` is whether the pin is currently a `1` or a `0`
  * `time` is the time in seconds at which the pin changed state
- * `lastTime` is the time in seconds at which the **pin last changed state**. When using `edge:'rising'` or `edge:'falling'`, this is not the same as when the function was last called.
- * `data` is included if `data:pin` was specified in the options, and can be used for reading in clocked data
+ * `lastTime` is the time in seconds at which the **pin last changed state**.
+   When using `edge:'rising'` or `edge:'falling'`, this is not the same as when
+   the function was last called.
+ * `data` is included if `data:pin` was specified in the options, and can be
+   used for reading in clocked data
 
-For instance, if you want to measure the length of a positive pulse you could use `setWatch(function(e) { console.log(e.time-e.lastTime); }, BTN, { repeat:true, edge:'falling' });`.
-This will only be called on the falling edge of the pulse, but will be able to measure the width of the pulse because `e.lastTime` is the time of the rising edge.
+For instance, if you want to measure the length of a positive pulse you could
+use `setWatch(function(e) { console.log(e.time-e.lastTime); }, BTN, {
+repeat:true, edge:'falling' });`. This will only be called on the falling edge
+of the pulse, but will be able to measure the width of the pulse because
+`e.lastTime` is the time of the rising edge.
 
-Internally, an interrupt writes the time of the pin's state change into a queue with the exact
-time that it happened, and the function supplied to `setWatch` is executed only from the main
-message loop. However, if the callback is a native function `void (bool state)` then you can
-add `irq:true` to options, which will cause the function to be called from within the IRQ.
-When doing this, interrupts will happen on both edges and there will be no debouncing.
+Internally, an interrupt writes the time of the pin's state change into a queue
+with the exact time that it happened, and the function supplied to `setWatch` is
+executed only from the main message loop. However, if the callback is a native
+function `void (bool state)` then you can add `irq:true` to options, which will
+cause the function to be called from within the IRQ. When doing this, interrupts
+will happen on both edges and there will be no debouncing.
 
-**Note:** if you didn't call `pinMode` beforehand then this function will reset pin's state to `"input"`
+**Note:** if you didn't call `pinMode` beforehand then this function will reset
+pin's state to `"input"`
 
-**Note:** The STM32 chip (used in the [Espruino Board](/EspruinoBoard) and [Pico](/Pico)) cannot
-watch two pins with the same number - eg `A0` and `B0`.
+**Note:** The STM32 chip (used in the [Espruino Board](/EspruinoBoard) and
+[Pico](/Pico)) cannot watch two pins with the same number - eg `A0` and `B0`.
 
-**Note:** On nRF52 chips (used in Puck.js, Pixl.js, MDBT42Q) `setWatch` disables the GPIO
-output on that pin. In order to be able to write to the pin again you need to disable
-the watch with `clearWatch`.
+**Note:** On nRF52 chips (used in Puck.js, Pixl.js, MDBT42Q) `setWatch` disables
+the GPIO output on that pin. In order to be able to write to the pin again you
+need to disable the watch with `clearWatch`.
 
  */
 JsVar *jswrap_interface_setWatch(

--- a/src/jswrap_json.c
+++ b/src/jswrap_json.c
@@ -46,12 +46,14 @@ An Object that handles conversion to and from the JSON data interchange format
   ],
   "return" : ["JsVar","A JSON string"]
 }
-Convert the given object into a JSON string which can subsequently be parsed with JSON.parse or eval.
+Convert the given object into a JSON string which can subsequently be parsed
+with JSON.parse or eval.
 
 **Note:** This differs from JavaScript's standard `JSON.stringify` in that:
 
 * The `replacer` argument is ignored
-* Typed arrays like `new Uint8Array(5)` will be dumped as if they were arrays, not as if they were objects (since it is more compact)
+* Typed arrays like `new Uint8Array(5)` will be dumped as if they were arrays,
+  not as if they were objects (since it is more compact)
  */
 JsVar *jswrap_json_stringify(JsVar *v, JsVar *replacer, JsVar *space) {
   NOT_USED(replacer);
@@ -169,7 +171,8 @@ JsVar *jswrap_json_parse_internal() {
 }
 Parse the given JSON string into a JavaScript object
 
-NOTE: This implementation uses eval() internally, and as such it is unsafe as it can allow arbitrary JS commands to be executed.
+NOTE: This implementation uses eval() internally, and as such it is unsafe as it
+can allow arbitrary JS commands to be executed.
  */
 JsVar *jswrap_json_parse(JsVar *v) {
   JsLex lex;

--- a/src/jswrap_modules.c
+++ b/src/jswrap_modules.c
@@ -59,8 +59,8 @@ print(s.read("test"));
 // prints "hello world"
 ```
 
-Check out [the page on Modules](/Modules) for an explanation
-of what modules are and how you can use them.
+Check out [the page on Modules](/Modules) for an explanation of what modules are
+and how you can use them.
  */
 JsVar *jswrap_require(JsVar *moduleName) {
   if (!jsvIsString(moduleName)) {

--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -168,7 +168,8 @@ Return all enumerable keys of the given object
   ],
   "return" : ["JsVar","An array of the Object's own properties"]
 }
-Returns an array of all properties (enumerable or not) found directly on a given object.
+Returns an array of all properties (enumerable or not) found directly on a given
+object.
 */
 
 static void _jswrap_object_keys_or_property_names_iterator(
@@ -360,7 +361,8 @@ JsVar *jswrap_object_values_or_entries(JsVar *object, bool returnEntries) {
   ],
   "return" : ["JsVar","A new object"]
 }
-Creates a new object with the specified prototype object and properties. properties are currently unsupported.
+Creates a new object with the specified prototype object and properties.
+properties are currently unsupported.
  */
 JsVar *jswrap_object_create(JsVar *proto, JsVar *propertiesObject) {
   if (!jsvIsObject(proto) && !jsvIsNull(proto)) {
@@ -444,7 +446,8 @@ JsVar *jswrap_object_getOwnPropertyDescriptor(JsVar *parent, JsVar *name) {
 }
 Return true if the object (not its prototype) has the given property.
 
-NOTE: This currently returns false-positives for built-in functions in prototypes
+NOTE: This currently returns false-positives for built-in functions in
+prototypes
  */
 bool jswrap_object_hasOwnProperty(JsVar *parent, JsVar *name) {
   JsVar *propName = jsvAsArrayIndex(name);
@@ -491,14 +494,20 @@ bool jswrap_object_hasOwnProperty(JsVar *parent, JsVar *name) {
 }
 Add a new property to the Object. 'Desc' is an object with the following fields:
 
-* `configurable` (bool = false) - can this property be changed/deleted (not implemented)
-* `enumerable` (bool = false) - can this property be enumerated (not implemented)
+* `configurable` (bool = false) - can this property be changed/deleted (not
+  implemented)
+* `enumerable` (bool = false) - can this property be enumerated (not
+  implemented)
 * `value` (anything) - the value of this property
-* `writable` (bool = false) - can the value be changed with the assignment operator?
-* `get` (function) - the getter function, or undefined if no getter (only supported on some platforms)
-* `set` (function) - the setter function, or undefined if no setter (only supported on some platforms)
+* `writable` (bool = false) - can the value be changed with the assignment
+  operator?
+* `get` (function) - the getter function, or undefined if no getter (only
+  supported on some platforms)
+* `set` (function) - the setter function, or undefined if no setter (only
+  supported on some platforms)
 
-**Note:** `configurable`, `enumerable` and `writable` are not implemented and will be ignored.
+**Note:** `configurable`, `enumerable` and `writable` are not implemented and
+will be ignored.
 
  */
 JsVar *jswrap_object_defineProperty(JsVar *parent, JsVar *propName, JsVar *desc) {
@@ -552,7 +561,8 @@ JsVar *jswrap_object_defineProperty(JsVar *parent, JsVar *propName, JsVar *desc)
   ],
   "return" : ["JsVar","The object, obj."]
 }
-Adds new properties to the Object. See `Object.defineProperty` for more information
+Adds new properties to the Object. See `Object.defineProperty` for more
+information
  */
 JsVar *jswrap_object_defineProperties(JsVar *parent, JsVar *props) {
   if (!jsvIsObject(parent)) {
@@ -605,8 +615,8 @@ JsVar *jswrap_object_getPrototypeOf(JsVar *object) {
   ],
   "return" : ["JsVar","The object passed in"]
 }
-Set the prototype of the given object - this is like writing
-`object.__proto__ = prototype` but is the 'proper' ES6 way of doing it
+Set the prototype of the given object - this is like writing `object.__proto__ =
+prototype` but is the 'proper' ES6 way of doing it
  */
 JsVar *jswrap_object_setPrototypeOf(JsVar *object, JsVar *proto) {
   JsVar *v = (jsvIsFunction(object)||jsvIsObject(object)) ? jsvFindChildFromString(object, "__proto__", true) : 0;
@@ -700,10 +710,11 @@ void jswrap_object_addEventListener(JsVar *parent, const char *eventName, void (
     ["listener","JsVar","The listener to call when this event is received"]
   ]
 }
-Register an event listener for this object, for instance `Serial1.on('data', function(d) {...})`.
+Register an event listener for this object, for instance `Serial1.on('data',
+function(d) {...})`.
 
-This is the same as Node.js's [EventEmitter](https://nodejs.org/api/events.html) but on Espruino
-the functionality is built into every object:
+This is the same as Node.js's [EventEmitter](https://nodejs.org/api/events.html)
+but on Espruino the functionality is built into every object:
 
 * `Object.on`
 * `Object.emit`
@@ -794,7 +805,8 @@ void jswrap_object_on(JsVar *parent, JsVar *event, JsVar *listener) {
     ["args","JsVarArray","Optional arguments"]
   ]
 }
-Call any event listeners that were added to this object with `Object.on`, for instance `obj.emit('data', 'Foo')`.
+Call any event listeners that were added to this object with `Object.on`, for
+instance `obj.emit('data', 'Foo')`.
 
 For more information see `Object.on`
  */
@@ -967,8 +979,9 @@ void jswrap_object_removeAllListeners_cstr(JsVar *parent, const char *event) {
     ["newFunc","JsVar","The new function to replace this function with"]
   ]
 }
-This replaces the function with the one in the argument - while keeping the old function's scope.
-This allows inner functions to be edited, and is used when edit() is called on an inner function.
+This replaces the function with the one in the argument - while keeping the old
+function's scope. This allows inner functions to be edited, and is used when
+edit() is called on an inner function.
  */
 void jswrap_function_replaceWith(JsVar *oldFunc, JsVar *newFunc) {
   if ((!jsvIsFunction(oldFunc)) || (!jsvIsFunction(newFunc))) {

--- a/src/jswrap_onewire.c
+++ b/src/jswrap_onewire.c
@@ -21,7 +21,8 @@
   "type" : "class",
   "class" : "OneWire"
 }
-This class provides a software-defined OneWire master. It is designed to be similar to Arduino's OneWire library.
+This class provides a software-defined OneWire master. It is designed to be
+similar to Arduino's OneWire library.
  */
 
 static Pin onewire_getpin(JsVar *parent) {

--- a/src/jswrap_pin.c
+++ b/src/jswrap_pin.c
@@ -24,7 +24,8 @@
 }
 This is the built-in class for Pins, such as D0,D1,LED1, or BTN
 
-You can call the methods on Pin, or you can use Wiring-style functions such as digitalWrite
+You can call the methods on Pin, or you can use Wiring-style functions such as
+digitalWrite
 */
 
 /*JSON{
@@ -59,7 +60,8 @@ JsVar *jswrap_pin_constructor(JsVar *val) {
 }
 Returns the input state of the pin as a boolean.
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset the pin's state to `"input"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset the pin's state to `"input"`
 */
 bool jswrap_pin_read(JsVar *parent) {
   Pin pin = jshGetPinFromVar(parent);
@@ -74,7 +76,8 @@ bool jswrap_pin_read(JsVar *parent) {
 }
 Sets the output state of the pin to a 1
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset the pin's state to `"output"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset the pin's state to `"output"`
  */
 void jswrap_pin_set(JsVar *parent) {
   Pin pin = jshGetPinFromVar(parent);
@@ -89,7 +92,8 @@ void jswrap_pin_set(JsVar *parent) {
 }
 Sets the output state of the pin to a 0
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset the pin's state to `"output"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset the pin's state to `"output"`
  */
 void jswrap_pin_reset(JsVar *parent) {
   Pin pin = jshGetPinFromVar(parent);
@@ -107,7 +111,8 @@ void jswrap_pin_reset(JsVar *parent) {
 }
 Sets the output state of the pin to the parameter given
 
- **Note:** if you didn't call `pinMode` beforehand then this function will also reset the pin's state to `"output"`
+ **Note:** if you didn't call `pinMode` beforehand then this function will also
+ reset the pin's state to `"output"`
  */
 void jswrap_pin_write(
     JsVar *parent, //!< The class instance representing the Pin.
@@ -130,7 +135,8 @@ void jswrap_pin_write(
 }
 Sets the output state of the pin to the parameter given at the specified time.
 
- **Note:** this **doesn't** change the mode of the pin to an output. To do that, you need to use `pin.write(0)` or `pinMode(pin, 'output')` first.
+ **Note:** this **doesn't** change the mode of the pin to an output. To do that,
+ you need to use `pin.write(0)` or `pinMode(pin, 'output')` first.
  */
 void jswrap_pin_writeAtTime(JsVar *parent, bool value, JsVarFloat time) {
   Pin pin = jshGetPinFromVar(parent);
@@ -161,7 +167,8 @@ JsVar *jswrap_pin_getMode(JsVar *parent) {
     ["mode", "JsVar", "The mode - a string that is either 'analog', 'input', 'input_pullup', 'input_pulldown', 'output', 'opendrain', 'af_output' or 'af_opendrain'. Do not include this argument if you want to revert to automatic pin mode setting."]
   ]
 }
-Set the mode of the given pin. See [`pinMode`](#l__global_pinMode) for more information on pin modes.
+Set the mode of the given pin. See [`pinMode`](#l__global_pinMode) for more
+information on pin modes.
  */
 void jswrap_pin_mode(JsVar *parent, JsVar *mode) {
   jswrap_io_pinMode(jshGetPinFromVar(parent), mode, false);
@@ -178,7 +185,8 @@ Toggles the state of the pin from off to on, or from on to off.
 
 **Note:** This method doesn't currently work on the ESP8266 port of Espruino.
 
-**Note:** if you didn't call `pinMode` beforehand then this function will also reset the pin's state to `"output"`
+**Note:** if you didn't call `pinMode` beforehand then this function will also
+reset the pin's state to `"output"`
 */
 bool jswrap_pin_toggle(JsVar *parent) {
   Pin pin = jshGetPinFromVar(parent);

--- a/src/jswrap_process.c
+++ b/src/jswrap_process.c
@@ -37,10 +37,12 @@ This class contains information about Espruino itself
   "name" : "uncaughtException",
   "params" : [["exception","JsVar","The uncaught exception"]]
 }
-This event is called when an exception gets thrown and isn't caught (eg. it gets all the way back to the event loop).
+This event is called when an exception gets thrown and isn't caught (eg. it gets
+all the way back to the event loop).
 
-You can use this for logging potential problems that might occur during execution when you
-might not be able to see what is written to the console, for example:
+You can use this for logging potential problems that might occur during
+execution when you might not be able to see what is written to the console, for
+example:
 
 ```
 var lastError;
@@ -54,8 +56,8 @@ function checkError() {
 }
 ```
 
-**Note:** When this is used, exceptions will cease to be reported on the console - which
-may make debugging difficult!
+**Note:** When this is used, exceptions will cease to be reported on the
+console - which may make debugging difficult!
 */
 
 /*JSON{
@@ -108,15 +110,21 @@ Returns an Object containing various pre-defined variables.
 * `RAM` - total amount of on-chip RAM in bytes
 * `FLASH` - total amount of on-chip flash memory in bytes
 * `SPIFLASH` - (on Bangle.js) total amount of off-chip flash memory in bytes
-* `HWVERSION` - For Puck.js this is the board revision (1, 2, 2.1), or for Bangle.js it's 1 or 2
+* `HWVERSION` - For Puck.js this is the board revision (1, 2, 2.1), or for
+  Bangle.js it's 1 or 2
 * `STORAGE` - memory in bytes dedicated to the `Storage` module
 * `SERIAL` - the serial number of this chip
-* `CONSOLE` - the name of the current console device being used (`Serial1`, `USB`, `Bluetooth`, etc)
+* `CONSOLE` - the name of the current console device being used (`Serial1`,
+  `USB`, `Bluetooth`, etc)
 * `MODULES` - a list of built-in modules separated by commas
-* `EXPTR` - The address of the `exportPtrs` structure in flash (this includes links to built-in functions that compiled JS code needs)
-* `APP_RAM_BASE` - On nRF5x boards, this is the RAM required by the Softdevice *if it doesn't exactly match what was allocated*. You can use this to update `LD_APP_RAM_BASE` in the `BOARD.py` file
+* `EXPTR` - The address of the `exportPtrs` structure in flash (this includes
+  links to built-in functions that compiled JS code needs)
+* `APP_RAM_BASE` - On nRF5x boards, this is the RAM required by the Softdevice
+  *if it doesn't exactly match what was allocated*. You can use this to update
+  `LD_APP_RAM_BASE` in the `BOARD.py` file
 
-For example, to get a list of built-in modules, you can use `process.env.MODULES.split(',')`
+For example, to get a list of built-in modules, you can use
+`process.env.MODULES.split(',')`
 */
 JsVar *jswrap_process_env() {
   JsVar *obj = jsvNewObject();
@@ -163,22 +171,33 @@ JsVar *jswrap_process_env() {
   ],
   "return" : ["JsVar","Information about memory usage"]
 }
-Run a Garbage Collection pass, and return an object containing information on memory usage.
+Run a Garbage Collection pass, and return an object containing information on
+memory usage.
 
-* `free`  : Memory that is available to be used (in blocks)
+* `free` : Memory that is available to be used (in blocks)
 * `usage` : Memory that has been used (in blocks)
 * `total` : Total memory (in blocks)
-* `history` : Memory used for command history - that is freed if memory is low. Note that this is INCLUDED in the figure for 'free'
-* `gc`      : Memory freed during the GC pass
-* `gctime`  : Time taken for GC pass (in milliseconds)
+* `history` : Memory used for command history - that is freed if memory is low.
+  Note that this is INCLUDED in the figure for 'free'
+* `gc` : Memory freed during the GC pass
+* `gctime` : Time taken for GC pass (in milliseconds)
 * `blocksize` : Size of a block (variable) in bytes
-* `stackEndAddress` : (on ARM) the address (that can be used with peek/poke/etc) of the END of the stack. The stack grows down, so unless you do a lot of recursion the bytes above this can be used.
-* `flash_start`      : (on ARM) the address of the start of flash memory (usually `0x8000000`)
-* `flash_binary_end` : (on ARM) the address in flash memory of the end of Espruino's firmware.
-* `flash_code_start` : (on ARM) the address in flash memory of pages that store any code that you save with `save()`.
-* `flash_length` : (on ARM) the amount of flash memory this firmware was built for (in bytes). **Note:** Some STM32 chips actually have more memory than is advertised.
+* `stackEndAddress` : (on ARM) the address (that can be used with peek/poke/etc)
+  of the END of the stack. The stack grows down, so unless you do a lot of
+  recursion the bytes above this can be used.
+* `flash_start` : (on ARM) the address of the start of flash memory (usually
+  `0x8000000`)
+* `flash_binary_end` : (on ARM) the address in flash memory of the end of
+  Espruino's firmware.
+* `flash_code_start` : (on ARM) the address in flash memory of pages that store
+  any code that you save with `save()`.
+* `flash_length` : (on ARM) the amount of flash memory this firmware was built
+  for (in bytes). **Note:** Some STM32 chips actually have more memory than is
+  advertised.
 
-Memory units are specified in 'blocks', which are around 16 bytes each (depending on your device). The actual size is available in `blocksize`. See http://www.espruino.com/Performance for more information.
+Memory units are specified in 'blocks', which are around 16 bytes each
+(depending on your device). The actual size is available in `blocksize`. See
+http://www.espruino.com/Performance for more information.
 
 **Note:** To find free areas of flash memory, see `require('Flash').getFree()`
  */

--- a/src/jswrap_promise.c
+++ b/src/jswrap_promise.c
@@ -207,8 +207,8 @@ void jspromise_reject(JsVar *promise, JsVar *data) {
   "return" : ["JsVar","A Promise"],
   "typescript": "new<T>(executor: (resolve: (value: T) => void, reject: (reason?: any) => void) => void): Promise<T>;"
 }
-Create a new Promise. The executor function is executed immediately (before the constructor even returns)
-and
+Create a new Promise. The executor function is executed immediately (before the
+constructor even returns) and
  */
 JsVar *jswrap_promise_constructor(JsVar *executor) {
   JsVar *obj = jspromise_create();
@@ -247,8 +247,8 @@ JsVar *jswrap_promise_constructor(JsVar *executor) {
   "return" : ["JsVar","A new Promise"],
   "typescript": "all(promises: Promise<any>[]): Promise<void>;"
 }
-Return a new promise that is resolved when all promises in the supplied
-array are resolved.
+Return a new promise that is resolved when all promises in the supplied array
+are resolved.
 */
 JsVar *jswrap_promise_all(JsVar *arr) {
   if (!jsvIsIterable(arr)) {
@@ -305,8 +305,7 @@ JsVar *jswrap_promise_all(JsVar *arr) {
   "return" : ["JsVar","A new Promise"],
   "typescript": "resolve<T extends any>(promises: T): Promise<T>;"
 }
-Return a new promise that is already resolved (at idle it'll
-call `.then`)
+Return a new promise that is already resolved (at idle it'll call `.then`)
 */
 JsVar *jswrap_promise_resolve(JsVar *data) {
   JsVar *promise = 0;
@@ -340,8 +339,7 @@ JsVar *jswrap_promise_resolve(JsVar *data) {
   ],
   "return" : ["JsVar","A new Promise"]
 }
-Return a new promise that is already rejected (at idle it'll
-call `.catch`)
+Return a new promise that is already rejected (at idle it'll call `.catch`)
 */
 JsVar *jswrap_promise_reject(JsVar *data) {
   JsVar *promise = jspromise_create();

--- a/src/jswrap_regexp.c
+++ b/src/jswrap_regexp.c
@@ -275,7 +275,8 @@ static JsVar *matchhere(char *regexp, JsvStringIterator *txtIt, matchInfo info) 
 The built-in class for handling Regular Expressions
 
 **Note:** Espruino's regular expression parser does not contain all the features
-present in a full ES6 JS engine. However it does contain support for the all the basics.
+present in a full ES6 JS engine. However it does contain support for the all the
+basics.
 */
 
 /*JSON{
@@ -321,7 +322,8 @@ JsVar *jswrap_regexp_constructor(JsVar *str, JsVar *flags) {
   "generate" : "jswrap_regexp_exec",
   "return" : ["JsVar","A result array, or null"]
 }
-Test this regex on a string - returns a result array on success, or `null` otherwise.
+Test this regex on a string - returns a result array on success, or `null`
+otherwise.
 
 
 `/Wo/.exec("Hello World")` will return:
@@ -391,7 +393,8 @@ JsVar *jswrap_regexp_exec(JsVar *parent, JsVar *arg) {
   "generate" : "jswrap_regexp_test",
   "return" : ["bool","true for a match, or false"]
 }
-Test this regex on a string - returns `true` on a successful match, or `false` otherwise
+Test this regex on a string - returns `true` on a successful match, or `false`
+otherwise
  */
 bool jswrap_regexp_test(JsVar *parent, JsVar *str) {
   JsVar *v = jswrap_regexp_exec(parent, str);

--- a/src/jswrap_serial.c
+++ b/src/jswrap_serial.c
@@ -24,7 +24,10 @@
 }
 This class allows use of the built-in USARTs
 
-Methods may be called on the `USB`, `Serial1`, `Serial2`, `Serial3`, `Serial4`, `Serial5` and `Serial6` objects. While different processors provide different numbers of USARTs, on official Espruino boards you can always rely on at least `Serial1` being available
+Methods may be called on the `USB`, `Serial1`, `Serial2`, `Serial3`, `Serial4`,
+`Serial5` and `Serial6` objects. While different processors provide different
+numbers of USARTs, on official Espruino boards you can always rely on at least
+`Serial1` being available
  */
 /*JSON{
   "type" : "constructor",
@@ -33,7 +36,8 @@ Methods may be called on the `USB`, `Serial1`, `Serial2`, `Serial3`, `Serial4`, 
   "generate" : "jswrap_serial_constructor",
   "return" : ["JsVar","A Serial object"]
 }
-Create a software Serial port. This has limited functionality (only low baud rates), but it can work on any pins.
+Create a software Serial port. This has limited functionality (only low baud
+rates), but it can work on any pins.
 
 Use `Serial.setup` to configure this port.
  */
@@ -48,7 +52,9 @@ JsVar *jswrap_serial_constructor() {
     ["data","JsVar","A string containing one or more characters of received data"]
   ]
 }
-The `data` event is called when data is received. If a handler is defined with `X.on('data', function(data) { ... })` then it will be called, otherwise data will be stored in an internal buffer, where it can be retrieved with `X.read()`
+The `data` event is called when data is received. If a handler is defined with
+`X.on('data', function(data) { ... })` then it will be called, otherwise data
+will be stored in an internal buffer, where it can be retrieved with `X.read()`
  */
 
 /*JSON{
@@ -57,31 +63,34 @@ The `data` event is called when data is received. If a handler is defined with `
   "name" : "framing"
 }
 The `framing` event is called when there was activity on the input to the UART
-but the `STOP` bit wasn't in the correct place. This is either because there
-was noise on the line, or the line has been pulled to 0 for a long period
-of time.
+but the `STOP` bit wasn't in the correct place. This is either because there was
+noise on the line, or the line has been pulled to 0 for a long period of time.
 
-To enable this, you must initialise Serial with `SerialX.setup(..., { ..., errors:true });`
+To enable this, you must initialise Serial with `SerialX.setup(..., { ...,
+errors:true });`
 
 **Note:** Even though there was an error, the byte will still be received and
 passed to the `data` handler.
 
-**Note:** This only works on STM32 and NRF52 based devices (eg. all official Espruino boards)
+**Note:** This only works on STM32 and NRF52 based devices (eg. all official
+Espruino boards)
  */
 /*JSON{
   "type" : "event",
   "class" : "Serial",
   "name" : "parity"
 }
-The `parity` event is called when the UART was configured with a parity bit,
-and this doesn't match the bits that have actually been received.
+The `parity` event is called when the UART was configured with a parity bit, and
+this doesn't match the bits that have actually been received.
 
-To enable this, you must initialise Serial with `SerialX.setup(..., { ..., errors:true });`
+To enable this, you must initialise Serial with `SerialX.setup(..., { ...,
+errors:true });`
 
 **Note:** Even though there was an error, the byte will still be received and
 passed to the `data` handler.
 
-**Note:** This only works on STM32 and NRF52 based devices (eg. all official Espruino boards)
+**Note:** This only works on STM32 and NRF52 based devices (eg. all official
+Espruino boards)
  */
 // this is created in jsiIdle based on EV_SERIALx_STATUS ecents
 
@@ -95,7 +104,8 @@ passed to the `data` handler.
   ],
   "return" : ["JsVar","An object of type `Serial`, or `undefined` if one couldn't be found."]
 }
-Try and find a USART (Serial) hardware device that will work on this pin (eg. `Serial1`)
+Try and find a USART (Serial) hardware device that will work on this pin (eg.
+`Serial1`)
 
 May return undefined if no device can be found.
 */
@@ -163,14 +173,16 @@ The sixth Serial (USART) port
   "name" : "LoopbackA",
   "instanceof" : "Serial"
 }
-A loopback serial device. Data sent to `LoopbackA` comes out of `LoopbackB` and vice versa
+A loopback serial device. Data sent to `LoopbackA` comes out of `LoopbackB` and
+vice versa
  */
 /*JSON{
   "type" : "object",
   "name" : "LoopbackB",
   "instanceof" : "Serial"
 }
-A loopback serial device. Data sent to `LoopbackA` comes out of `LoopbackB` and vice versa
+A loopback serial device. Data sent to `LoopbackA` comes out of `LoopbackB` and
+vice versa
  */
 /*JSON{
   "type" : "object",
@@ -178,7 +190,8 @@ A loopback serial device. Data sent to `LoopbackA` comes out of `LoopbackB` and 
   "instanceof" : "Serial",
   "#if" : "defined(USE_TELNET)"
 }
-A telnet serial device that maps to the built-in telnet console server (devices that have built-in wifi only).
+A telnet serial device that maps to the built-in telnet console server (devices
+that have built-in wifi only).
  */
 
 
@@ -194,8 +207,8 @@ A telnet serial device that maps to the built-in telnet console server (devices 
 }
 Set this Serial port as the port for the JavaScript console (REPL).
 
-Unless `force` is set to true, changes in the connection state of the board
-(for instance plugging in USB) will cause the console to change.
+Unless `force` is set to true, changes in the connection state of the board (for
+instance plugging in USB) will cause the console to change.
 
 See `E.setConsole` for a more flexible version of this function.
  */
@@ -244,31 +257,31 @@ The second argument can contain:
 }
 ```
 
-You can find out which pins to use by looking at [your board's reference page](#boards) 
-and searching for pins with the `UART`/`USART` markers.
+You can find out which pins to use by looking at [your board's reference
+page](#boards) and searching for pins with the `UART`/`USART` markers.
 
-If not specified in options, the default pins are used for rx and tx
-(usually the lowest numbered pins on the lowest port that supports 
-this peripheral). `ck` and `cts` are not used unless specified.
+If not specified in options, the default pins are used for rx and tx (usually
+the lowest numbered pins on the lowest port that supports this peripheral). `ck`
+and `cts` are not used unless specified.
 
-Note that even after changing the RX and TX pins, if you have called setup 
+Note that even after changing the RX and TX pins, if you have called setup
 before then the previous RX and TX pins will still be connected to the Serial
 port as well - until you set them to something else using `digitalWrite` or
 `pinMode`.
 
-Flow control can be xOn/xOff (`flow:'xon'`) or hardware flow control
-(receive only) if `cts` is specified. If `cts` is set to a pin, the
-pin's value will be 0 when Espruino is ready for data and 1 when it isn't.
+Flow control can be xOn/xOff (`flow:'xon'`) or hardware flow control (receive
+only) if `cts` is specified. If `cts` is set to a pin, the pin's value will be 0
+when Espruino is ready for data and 1 when it isn't.
 
 By default, framing or parity errors don't create `framing` or `parity` events
-on the `Serial` object because storing these errors uses up additional
-storage in the queue. If you're intending to receive a lot of malformed
-data then the queue might overflow `E.getErrorFlags()` would return `FIFO_FULL`.
-However if you need to respond to `framing` or `parity` errors then 
-you'll need to use `errors:true` when initialising serial.
+on the `Serial` object because storing these errors uses up additional storage
+in the queue. If you're intending to receive a lot of malformed data then the
+queue might overflow `E.getErrorFlags()` would return `FIFO_FULL`. However if
+you need to respond to `framing` or `parity` errors then you'll need to use
+`errors:true` when initialising serial.
 
-On Linux builds there is no default Serial device, so you must specify
-a path to a device - for instance: `Serial1.setup(9600,{path:"/dev/ttyACM0"})`
+On Linux builds there is no default Serial device, so you must specify a path to
+a device - for instance: `Serial1.setup(9600,{path:"/dev/ttyACM0"})`
 
 You can also set up 'software serial' using code like:
 
@@ -277,7 +290,8 @@ var s = new Serial();
 s.setup(9600,{rx:a_pin, tx:a_pin});
 ```
 
-However software serial doesn't use `ck`, `cts`, `parity`, `flow` or `errors` parts of the initialisation object.
+However software serial doesn't use `ck`, `cts`, `parity`, `flow` or `errors`
+parts of the initialisation object.
 */
 void jswrap_serial_setup(JsVar *parent, JsVar *baud, JsVar *options) {
   if (!jsvIsObject(parent)) return;
@@ -338,8 +352,7 @@ void jswrap_serial_setup(JsVar *parent, JsVar *baud, JsVar *options) {
   "name" : "unsetup",
   "generate" : "jswrap_serial_unsetup"
 }
-If the serial (or software serial) device was set up,
-uninitialise it.
+If the serial (or software serial) device was set up, uninitialise it.
 */
 #ifndef SAVE_ON_FLASH
 void jswrap_serial_unsetup(JsVar *parent) {
@@ -413,7 +426,8 @@ void _jswrap_serial_print(JsVar *parent, JsVar *arg, bool isPrint, bool newLine)
 }
 Print a string to the serial port - without a line feed
 
- **Note:** This function replaces any occurances of `\n` in the string with `\r\n`. To avoid this, use `Serial.write`.
+ **Note:** This function replaces any occurances of `\n` in the string with
+ `\r\n`. To avoid this, use `Serial.write`.
  */
 /*JSON{
   "type" : "method",
@@ -426,7 +440,9 @@ Print a string to the serial port - without a line feed
 }
 Print a line to the serial port with a newline (`\r\n`) at the end of it.
 
- **Note:** This function converts data to a string first, eg `Serial.print([1,2,3])` is equivalent to `Serial.print("1,2,3"). If you'd like to write raw bytes, use `Serial.write`.
+ **Note:** This function converts data to a string first, eg
+ `Serial.print([1,2,3])` is equivalent to `Serial.print("1,2,3"). If you'd like
+ to write raw bytes, use `Serial.write`.
  */
 void jswrap_serial_print(JsVar *parent, JsVar *str) {
   _jswrap_serial_print(parent, str, true, false);
@@ -445,7 +461,9 @@ void jswrap_serial_println(JsVar *parent,  JsVar *str) {
 }
 Write a character or array of data to the serial port
 
-This method writes unmodified data, eg `Serial.write([1,2,3])` is equivalent to `Serial.write("\1\2\3")`. If you'd like data converted to a string first, use `Serial.print`.
+This method writes unmodified data, eg `Serial.write([1,2,3])` is equivalent to
+`Serial.write("\1\2\3")`. If you'd like data converted to a string first, use
+`Serial.print`.
  */
 void jswrap_serial_write(JsVar *parent, JsVar *args) {
   _jswrap_serial_print(parent, args, false, false);
@@ -470,8 +488,8 @@ Serial1.inject('Hello World');
 // prints "Got Hel","Got lo World" (characters can be split over multiple callbacks)
 ```
 
-This is most useful if you wish to send characters to Espruino's
-REPL (console) while it is on another device.
+This is most useful if you wish to send characters to Espruino's REPL (console)
+while it is on another device.
  */
 static void _jswrap_serial_inject_cb(int data, void *userData) {
   IOEventFlags device = *(IOEventFlags*)userData;
@@ -490,7 +508,8 @@ void jswrap_serial_inject(JsVar *parent, JsVar *args) {
   "generate" : "jswrap_stream_available",
   "return" : ["int","How many bytes are available"]
 }
-Return how many bytes are available to read. If there is already a listener for data, this will always return 0.
+Return how many bytes are available to read. If there is already a listener for
+data, this will always return 0.
  */
 
 /*JSON{

--- a/src/jswrap_spi_i2c.c
+++ b/src/jswrap_spi_i2c.c
@@ -24,7 +24,8 @@
   "type" : "class",
   "class" : "SPI"
 }
-This class allows use of the built-in SPI ports. Currently it is SPI master only.
+This class allows use of the built-in SPI ports. Currently it is SPI master
+only.
  */
 
 /*JSON{
@@ -59,7 +60,8 @@ The third SPI port
   "generate" : "jswrap_spi_constructor",
   "return" : ["JsVar","A SPI object"]
 }
-Create a software SPI port. This has limited functionality (no baud rate), but it can work on any pins.
+Create a software SPI port. This has limited functionality (no baud rate), but
+it can work on any pins.
 
 Use `SPI.setup` to configure this port.
  */
@@ -107,13 +109,21 @@ Options can contain the following (defaults are shown where relevant):
 }
 ```
 
-If `sck`,`miso` and `mosi` are left out, they will automatically be chosen. However if one or more is specified then the unspecified pins will not be set up.
+If `sck`,`miso` and `mosi` are left out, they will automatically be chosen.
+However if one or more is specified then the unspecified pins will not be set
+up.
 
-You can find out which pins to use by looking at [your board's reference page](#boards) and searching for pins with the `SPI` marker. Some boards such as those based on `nRF52` chips can have SPI on any pins, so don't have specific markings.
+You can find out which pins to use by looking at [your board's reference
+page](#boards) and searching for pins with the `SPI` marker. Some boards such as
+those based on `nRF52` chips can have SPI on any pins, so don't have specific
+markings.
 
-The SPI `mode` is between 0 and 3 - see http://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase
+The SPI `mode` is between 0 and 3 - see
+http://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase
 
-On STM32F1-based parts, you cannot mix AF and non-AF pins (SPI pins are usually grouped on the chip - and you can't mix pins from two groups). Espruino will not warn you about this.
+On STM32F1-based parts, you cannot mix AF and non-AF pins (SPI pins are usually
+grouped on the chip - and you can't mix pins from two groups). Espruino will not
+warn you about this.
 */
 void jswrap_spi_setup(
     JsVar *parent, //!< The variable that is the class instance of this function.
@@ -168,11 +178,16 @@ void jswrap_spi_setup(
   ],
   "return" : ["JsVar","The data that was returned"]
 }
-Send data down SPI, and return the result. Sending an integer will return an integer, a String will return a String, and anything else will return a Uint8Array.
+Send data down SPI, and return the result. Sending an integer will return an
+integer, a String will return a String, and anything else will return a
+Uint8Array.
 
-Sending multiple bytes in one call to send is preferable as they can then be transmitted end to end. Using multiple calls to send() will result in significantly slower transmission speeds.
+Sending multiple bytes in one call to send is preferable as they can then be
+transmitted end to end. Using multiple calls to send() will result in
+significantly slower transmission speeds.
 
-For maximum speeds, please pass either Strings or Typed Arrays as arguments. Note that you can even pass arrays of arrays, like `[1,[2,3,4],5]`
+For maximum speeds, please pass either Strings or Typed Arrays as arguments.
+Note that you can even pass arrays of arrays, like `[1,[2,3,4],5]`
 
  */
 typedef struct {
@@ -299,7 +314,8 @@ void jswrap_spi_write_cb(
     ["data","JsVarArray",["One or more items to write. May be ints, strings, arrays, or special objects (see `E.toUint8Array` for more info).","If the last argument is a pin, it is taken to be the NSS pin"]]
   ]
 }
-Write a character or array of characters to SPI - without reading the result back.
+Write a character or array of characters to SPI - without reading the result
+back.
 
 For maximum speeds, please pass either Strings or Typed Arrays as arguments.
  */
@@ -357,9 +373,12 @@ void jswrap_spi_write(
     ["nss_pin","pin","An nSS pin - this will be lowered before SPI output and raised afterwards (optional). There will be a small delay between when this is lowered and when sending starts, and also between sending finishing and it being raised."]
   ]
 }
-Send data down SPI, using 4 bits for each 'real' bit (MSB first). This can be useful for faking one-wire style protocols
+Send data down SPI, using 4 bits for each 'real' bit (MSB first). This can be
+useful for faking one-wire style protocols
 
-Sending multiple bytes in one call to send is preferable as they can then be transmitted end to end. Using multiple calls to send() will result in significantly slower transmission speeds.
+Sending multiple bytes in one call to send is preferable as they can then be
+transmitted end to end. Using multiple calls to send() will result in
+significantly slower transmission speeds.
  */
 void jswrap_spi_send4bit(JsVar *parent, JsVar *srcdata, int bit0, int bit1, Pin nss_pin) {
   if (!jsvIsObject(parent)) return;
@@ -427,9 +446,12 @@ void jswrap_spi_send4bit(JsVar *parent, JsVar *srcdata, int bit0, int bit1, Pin 
     ["nss_pin","pin","An nSS pin - this will be lowered before SPI output and raised afterwards (optional). There will be a small delay between when this is lowered and when sending starts, and also between sending finishing and it being raised"]
   ]
 }
-Send data down SPI, using 8 bits for each 'real' bit (MSB first). This can be useful for faking one-wire style protocols
+Send data down SPI, using 8 bits for each 'real' bit (MSB first). This can be
+useful for faking one-wire style protocols
 
-Sending multiple bytes in one call to send is preferable as they can then be transmitted end to end. Using multiple calls to send() will result in significantly slower transmission speeds.
+Sending multiple bytes in one call to send is preferable as they can then be
+transmitted end to end. Using multiple calls to send() will result in
+significantly slower transmission speeds.
  */
 void jswrap_spi_send8bit(JsVar *parent, JsVar *srcdata, int bit0, int bit1, Pin nss_pin) {
   if (!jsvIsObject(parent)) return;
@@ -487,9 +509,11 @@ void jswrap_spi_send8bit(JsVar *parent, JsVar *srcdata, int bit0, int bit1, Pin 
   "type" : "class",
   "class" : "I2C"
 }
-This class allows use of the built-in I2C ports. Currently it allows I2C Master mode only.
+This class allows use of the built-in I2C ports. Currently it allows I2C Master
+mode only.
 
-All addresses are in 7 bit format. If you have an 8 bit address then you need to shift it one bit to the right.
+All addresses are in 7 bit format. If you have an 8 bit address then you need to
+shift it one bit to the right.
  */
 /*JSON{
   "type" : "constructor",
@@ -498,7 +522,8 @@ All addresses are in 7 bit format. If you have an 8 bit address then you need to
   "generate" : "jswrap_i2c_constructor",
   "return" : ["JsVar","An I2C object"]
 }
-Create a software I2C port. This has limited functionality (no baud rate), but it can work on any pins.
+Create a software I2C port. This has limited functionality (no baud rate), but
+it can work on any pins.
 
 Use `I2C.setup` to configure this port.
  */
@@ -559,7 +584,8 @@ The third I2C port
 }
 Set up this I2C port
 
-If not specified in options, the default pins are used (usually the lowest numbered pins on the lowest port that supports this peripheral)
+If not specified in options, the default pins are used (usually the lowest
+numbered pins on the lowest port that supports this peripheral)
  */
 void jswrap_i2c_setup(JsVar *parent, JsVar *options) {
   if (!jsvIsObject(parent)) return;
@@ -621,7 +647,8 @@ static NO_INLINE int i2c_get_address(JsVar *address, bool *sendStop) {
     ["data","JsVarArray","One or more items to write. May be ints, strings, arrays, or special objects (see `E.toUint8Array` for more info)."]
   ]
 }
-Transmit to the slave device with the given address. This is like Arduino's beginTransmission, write, and endTransmission rolled up into one.
+Transmit to the slave device with the given address. This is like Arduino's
+beginTransmission, write, and endTransmission rolled up into one.
  */
 
 void jswrap_i2c_writeTo(JsVar *parent, JsVar *addressVar, JsVar *args) {
@@ -663,7 +690,9 @@ void jswrap_i2c_writeTo(JsVar *parent, JsVar *addressVar, JsVar *args) {
   "return" : ["JsVar","The data that was returned - as a Uint8Array"],
   "return_object" : "Uint8Array"
 }
-Request bytes from the given slave device, and return them as a Uint8Array (packed array of bytes). This is like using Arduino Wire's requestFrom, available and read functions.  Sends a STOP
+Request bytes from the given slave device, and return them as a Uint8Array
+(packed array of bytes). This is like using Arduino Wire's requestFrom,
+available and read functions. Sends a STOP
  */
 JsVar *jswrap_i2c_readFrom(JsVar *parent, JsVar *addressVar, int nBytes) {
   if (!jsvIsObject(parent)) return 0;

--- a/src/jswrap_storage.c
+++ b/src/jswrap_storage.c
@@ -44,25 +44,26 @@ const int STORAGEFILE_CHUNKSIZE =
   "class" : "Storage"
 }
 
-This module allows you to read and write part of the nonvolatile flash
-memory of your device using a filesystem-like API.
+This module allows you to read and write part of the nonvolatile flash memory of
+your device using a filesystem-like API.
 
-Also see the `Flash` library, which provides a low level, more dangerous way
-to access all parts of your flash memory.
+Also see the `Flash` library, which provides a low level, more dangerous way to
+access all parts of your flash memory.
 
 The `Storage` library provides two distinct types of file:
 
-* `require("Storage").write(...)`/`require("Storage").read(...)`/etc create simple
-contiguous files of fixed length. This is the recommended file type.
-* `require("Storage").open(...)` creates a `StorageFile`, which stores the file in
-numbered chunks (`"filename\1"`/`"filename\2"`/etc). It allows data to be appended
-and for the file to be read line by line.
+* `require("Storage").write(...)`/`require("Storage").read(...)`/etc create
+simple contiguous files of fixed length. This is the recommended file type.
+* `require("Storage").open(...)` creates a `StorageFile`, which stores the file
+in numbered chunks (`"filename\1"`/`"filename\2"`/etc). It allows data to be
+appended and for the file to be read line by line.
 
-You must read a file using the same method you used to write it - eg. you can't create a
-file with `require("Storage").open(...)` and then read it with `require("Storage").read(...)`.
+You must read a file using the same method you used to write it - eg. you can't
+create a file with `require("Storage").open(...)` and then read it with
+`require("Storage").read(...)`.
 
-**Note:** In firmware 2v05 and later, the maximum length for filenames
-is 28 characters. However in 2v04 and earlier the max length is 8.
+**Note:** In firmware 2v05 and later, the maximum length for filenames is 28
+characters. However in 2v04 and earlier the max length is 8.
 */
 
 /*JSON{
@@ -71,9 +72,9 @@ is 28 characters. However in 2v04 and earlier the max length is 8.
   "name" : "eraseAll",
   "generate" : "jswrap_storage_eraseAll"
 }
-Erase the flash storage area. This will remove all files
-created with `require("Storage").write(...)` as well
-as any code saved with `save()` or `E.setBootCode()`.
+Erase the flash storage area. This will remove all files created with
+`require("Storage").write(...)` as well as any code saved with `save()` or
+`E.setBootCode()`.
  */
 void jswrap_storage_eraseAll() {
   jsfEraseAll();
@@ -91,8 +92,8 @@ void jswrap_storage_eraseAll() {
 }
 Erase a single file from the flash storage area.
 
-**Note:** This function should be used with normal files, and not
-`StorageFile`s created with `require("Storage").open(filename, ...)`
+**Note:** This function should be used with normal files, and not `StorageFile`s
+created with `require("Storage").open(filename, ...)`
  */
 void jswrap_storage_erase(JsVar *name) {
   jsfEraseFile(jsfNameFromVar(name));
@@ -111,20 +112,20 @@ void jswrap_storage_erase(JsVar *name) {
   "return" : ["JsVar","A string of data, or `undefined` if the file is not found"],
   "typescript" : "read(name: string, offset?: number, length?: number): string | undefined;"
 }
-Read a file from the flash storage area that has
-been written with `require("Storage").write(...)`.
+Read a file from the flash storage area that has been written with
+`require("Storage").write(...)`.
 
-This function returns a memory-mapped String that points to the actual
-memory area in read-only memory, so it won't use up RAM.
+This function returns a memory-mapped String that points to the actual memory
+area in read-only memory, so it won't use up RAM.
 
-As such you can check if a file exists efficiently using `require("Storage").read(filename)!==undefined`.
+As such you can check if a file exists efficiently using
+`require("Storage").read(filename)!==undefined`.
 
-If you evaluate this string with `eval`, any functions
-contained in the String will keep their code stored
-in flash memory.
+If you evaluate this string with `eval`, any functions contained in the String
+will keep their code stored in flash memory.
 
-**Note:** This function should be used with normal files, and not
-`StorageFile`s created with `require("Storage").open(filename, ...)`
+**Note:** This function should be used with normal files, and not `StorageFile`s
+created with `require("Storage").open(filename, ...)`
 */
 JsVar *jswrap_storage_read(JsVar *name, int offset, int length) {
   return jsfReadFile(jsfNameFromVar(name), offset, length);
@@ -143,16 +144,14 @@ JsVar *jswrap_storage_read(JsVar *name, int offset, int length) {
   "return" : ["JsVar","An object containing parsed JSON from the file, or undefined"],
   "typescript" : "readJSON(name: string, noExceptions: boolean): any;"
 }
-Read a file from the flash storage area that has
-been written with `require("Storage").write(...)`,
-and parse JSON in it into a JavaScript object.
+Read a file from the flash storage area that has been written with
+`require("Storage").write(...)`, and parse JSON in it into a JavaScript object.
 
-This is identical to `JSON.parse(require("Storage").read(...))`.
-It will throw an exception if the data in the file is not
-valid JSON.
+This is identical to `JSON.parse(require("Storage").read(...))`. It will throw
+an exception if the data in the file is not valid JSON.
 
-**Note:** This function should be used with normal files, and not
-`StorageFile`s created with `require("Storage").open(filename, ...)`
+**Note:** This function should be used with normal files, and not `StorageFile`s
+created with `require("Storage").open(filename, ...)`
 */
 JsVar *jswrap_storage_readJSON(JsVar *name, bool noExceptions) {
   JsVar *v = jsfReadFile(jsfNameFromVar(name),0,0);
@@ -178,17 +177,18 @@ JsVar *jswrap_storage_readJSON(JsVar *name, bool noExceptions) {
   "return" : ["JsVar","An ArrayBuffer containing data from the file, or undefined"],
   "typescript" : "readArrayBuffer(name: string): ArrayBuffer | undefined;"
 }
-Read a file from the flash storage area that has
-been written with `require("Storage").write(...)`,
-and return the raw binary data as an ArrayBuffer.
+Read a file from the flash storage area that has been written with
+`require("Storage").write(...)`, and return the raw binary data as an
+ArrayBuffer.
 
 This can be used:
 
 * In a `DataView` with `new DataView(require("Storage").readArrayBuffer("x"))`
-* In a `Uint8Array/Float32Array/etc` with `new Uint8Array(require("Storage").readArrayBuffer("x"))`
+* In a `Uint8Array/Float32Array/etc` with `new
+  Uint8Array(require("Storage").readArrayBuffer("x"))`
 
-**Note:** This function should be used with normal files, and not
-`StorageFile`s created with `require("Storage").open(filename, ...)`
+**Note:** This function should be used with normal files, and not `StorageFile`s
+created with `require("Storage").open(filename, ...)`
 */
 JsVar *jswrap_storage_readArrayBuffer(JsVar *name) {
   JsVar *v = jsfReadFile(jsfNameFromVar(name),0,0);
@@ -212,25 +212,24 @@ JsVar *jswrap_storage_readArrayBuffer(JsVar *name) {
   "return" : ["bool","True on success, false on failure"],
   "typescript" : "write(name: string | ArrayBuffer | ArrayBufferView | number[] | object, data: any, offset?: number, size?: number): boolean;"
 }
-Write/create a file in the flash storage area. This is
-nonvolatile and will not disappear when the device resets
-or power is lost.
+Write/create a file in the flash storage area. This is nonvolatile and will not
+disappear when the device resets or power is lost.
 
-Simply write `require("Storage").write("MyFile", "Some data")` to write
-a new file, and `require("Storage").read("MyFile")` to read it.
+Simply write `require("Storage").write("MyFile", "Some data")` to write a new
+file, and `require("Storage").read("MyFile")` to read it.
 
 If you supply:
 
 * A String, it will be written as-is
 * An array, will be written as a byte array (but read back as a String)
-* An object, it will automatically be converted to
-a JSON string before being written.
+* An object, it will automatically be converted to a JSON string before being
+written.
 
-**Note:** If an array is supplied it will not be converted to JSON.
-To be explicit about the conversion you can use `Storage.writeJSON`
+**Note:** If an array is supplied it will not be converted to JSON. To be
+explicit about the conversion you can use `Storage.writeJSON`
 
-You may also create a file and then populate data later **as long as you
-don't try and overwrite data that already exists**. For instance:
+You may also create a file and then populate data later **as long as you don't
+try and overwrite data that already exists**. For instance:
 
 ```
 var f = require("Storage");
@@ -242,12 +241,12 @@ f.write("a"," ",0); // Writing to location 0 again will cause the file to be re-
 print(f.read("a")); // " "
 ```
 
-This can be useful if you've got more data to write than you
-have RAM available - for instance the Web IDE uses this method
-to write large files into onboard storage.
+This can be useful if you've got more data to write than you have RAM
+available - for instance the Web IDE uses this method to write large files into
+onboard storage.
 
-**Note:** This function should be used with normal files, and not
-`StorageFile`s created with `require("Storage").open(filename, ...)`
+**Note:** This function should be used with normal files, and not `StorageFile`s
+created with `require("Storage").open(filename, ...)`
 */
 bool jswrap_storage_write(JsVar *name, JsVar *data, JsVarInt offset, JsVarInt _size) {
   JsVar *d;
@@ -276,17 +275,16 @@ bool jswrap_storage_write(JsVar *name, JsVar *data, JsVarInt offset, JsVarInt _s
   "return" : ["bool","True on success, false on failure"],
   "typescript" : "writeJSON(name: string, data: any): boolean;"
 }
-Write/create a file in the flash storage area. This is
-nonvolatile and will not disappear when the device resets
-or power is lost.
+Write/create a file in the flash storage area. This is nonvolatile and will not
+disappear when the device resets or power is lost.
 
-Simply write `require("Storage").writeJSON("MyFile", [1,2,3])` to write
-a new file, and `require("Storage").readJSON("MyFile")` to read it.
+Simply write `require("Storage").writeJSON("MyFile", [1,2,3])` to write a new
+file, and `require("Storage").readJSON("MyFile")` to read it.
 
 This is equivalent to: `require("Storage").write(name, JSON.stringify(data))`
 
-**Note:** This function should be used with normal files, and not
-`StorageFile`s created with `require("Storage").open(filename, ...)`
+**Note:** This function should be used with normal files, and not `StorageFile`s
+created with `require("Storage").open(filename, ...)`
 */
 bool jswrap_storage_writeJSON(JsVar *name, JsVar *data) {
   JsVar *d = jswrap_json_stringify(data,0,0);
@@ -323,8 +321,8 @@ require("Storage").list(undefined, {sf:true})
 require("Storage").list(undefined, {sf:false})
 ```
 
-**Note:** This will output system files (eg. saved code) as well as
-files that you may have written.
+**Note:** This will output system files (eg. saved code) as well as files that
+you may have written.
  */
 JsVar *jswrap_storage_list(JsVar *regex, JsVar *filter) {
   JsfFileFlags containing = 0;
@@ -353,11 +351,12 @@ JsVar *jswrap_storage_list(JsVar *regex, JsVar *filter) {
   "return" : ["int","A hash of the files matching"],
   "typescript" : "hash(regex: RegExp): number;"
 }
-List all files in the flash storage area matching the specfied regex (ignores StorageFiles),
-and then hash their filenames *and* file locations.
+List all files in the flash storage area matching the specfied regex (ignores
+StorageFiles), and then hash their filenames *and* file locations.
 
-Identical files may have different hashes (eg. if Storage is compacted and the file moves) but
-the changes of different files having the same hash are extremely small.
+Identical files may have different hashes (eg. if Storage is compacted and the
+file moves) but the changes of different files having the same hash are
+extremely small.
 
 ```
 // Hash files
@@ -366,10 +365,9 @@ require("Storage").hash()
 require("Storage").hash(/\.boot\.js$/)
 ```
 
-**Note:** This function is used by Bangle.js as a way to cache files.
-For instance the bootloader will add all `.boot.js` files together into
-a single `.boot0` file, but it needs to know quickly whether anything has
-changed.
+**Note:** This function is used by Bangle.js as a way to cache files. For
+instance the bootloader will add all `.boot.js` files together into a single
+`.boot0` file, but it needs to know quickly whether anything has changed.
  */
 JsVarInt jswrap_storage_hash(JsVar *regex) {
   return jsfHashFiles(regex, 0, JSFF_STORAGEFILE);
@@ -382,21 +380,19 @@ JsVarInt jswrap_storage_hash(JsVar *regex) {
   "name" : "compact",
   "generate" : "jswrap_storage_compact"
 }
-The Flash Storage system is journaling. To make the most of the limited
-write cycles of Flash memory, Espruino marks deleted/replaced files as
-garbage and moves on to a fresh part of flash memory. Espruino only
-fully erases those files when it is running low on flash, or when
-`compact` is called.
+The Flash Storage system is journaling. To make the most of the limited write
+cycles of Flash memory, Espruino marks deleted/replaced files as garbage and
+moves on to a fresh part of flash memory. Espruino only fully erases those files
+when it is running low on flash, or when `compact` is called.
 
-`compact` may fail if there isn't enough RAM free on the stack to
-use as swap space, however in this case it will not lose data.
+`compact` may fail if there isn't enough RAM free on the stack to use as swap
+space, however in this case it will not lose data.
 
-**Note:** `compact` rearranges the contents of memory. If code is
-referencing that memory (eg. functions that have their code stored in flash)
-then they may become garbled when compaction happens. To avoid this,
-call `eraseFiles` before uploading data that you intend to reference to
-ensure that uploaded files are right at the start of flash and cannot be
-compacted further.
+**Note:** `compact` rearranges the contents of memory. If code is referencing
+that memory (eg. functions that have their code stored in flash) then they may
+become garbled when compaction happens. To avoid this, call `eraseFiles` before
+uploading data that you intend to reference to ensure that uploaded files are
+right at the start of flash and cannot be compacted further.
  */
 void jswrap_storage_compact() {
   jsfCompact();
@@ -409,9 +405,8 @@ void jswrap_storage_compact() {
   "name" : "debug",
   "generate" : "jswrap_storage_debug"
 }
-This writes information about all blocks in flash
-memory to the console - and is only useful for debugging
-flash storage.
+This writes information about all blocks in flash memory to the console - and is
+only useful for debugging flash storage.
  */
 void jswrap_storage_debug() {
   jsfDebugFiles();
@@ -425,10 +420,9 @@ void jswrap_storage_debug() {
   "generate" : "jswrap_storage_getFree",
   "return" : ["int","The amount of free bytes"]
 }
-Return the amount of free bytes available in
-Storage. Due to fragmentation there may be more
-bytes available, but this represents the maximum
-size of file that can be written.
+Return the amount of free bytes available in Storage. Due to fragmentation there
+may be more bytes available, but this represents the maximum size of file that
+can be written.
  */
 int jswrap_storage_getFree() {
   return (int)jsfGetStorageStats(0,true).free;
@@ -475,8 +469,8 @@ JsVar *jswrap_storage_getStats() {
   "name" : "optimise",
   "generate" : "jswrap_storage_optimise"
 }
-Writes a lookup table for files into Bangle.js's storage. This allows any file stored
-up to that point to be accessed quickly.
+Writes a lookup table for files into Bangle.js's storage. This allows any file
+stored up to that point to be accessed quickly.
  */
 void jswrap_storage_optimise() {
 #ifdef ESPR_STORAGE_FILENAME_TABLE
@@ -594,22 +588,20 @@ JsVar *jswrap_storage_open(JsVar *name, JsVar *modeVar) {
   "ifndef" : "SAVE_ON_FLASH"
 }
 
-These objects are created from `require("Storage").open`
-and allow Storage items to be read/written.
+These objects are created from `require("Storage").open` and allow Storage items
+to be read/written.
 
-The `Storage` library writes into Flash memory (which
-can only be erased in chunks), and unlike a normal filesystem
-it allocates files in one long contiguous area to allow them
-to be accessed easily from Espruino.
+The `Storage` library writes into Flash memory (which can only be erased in
+chunks), and unlike a normal filesystem it allocates files in one long
+contiguous area to allow them to be accessed easily from Espruino.
 
-This presents a challenge for `StorageFile` which allows you
-to append to a file, so instead `StorageFile` stores files
-in chunks. It uses the last character of the filename
-to denote the chunk number (eg `"foobar\1"`, `"foobar\2"`, etc).
+This presents a challenge for `StorageFile` which allows you to append to a
+file, so instead `StorageFile` stores files in chunks. It uses the last
+character of the filename to denote the chunk number (eg `"foobar\1"`,
+`"foobar\2"`, etc).
 
-This means that while `StorageFile` files exist in the same
-area as those from `Storage`, they should be
-read using `Storage.open` (and not `Storage.read`).
+This means that while `StorageFile` files exist in the same area as those from
+`Storage`, they should be read using `Storage.open` (and not `Storage.read`).
 
 ```
 f = s.open("foobar","w");
@@ -636,9 +628,9 @@ f.readLine() // undefined
 f.erase();
 ```
 
-**Note:** `StorageFile` uses the fact that all bits of erased flash memory
-are 1 to detect the end of a file. As such you should not write character
-code 255 (`"\xFF"`) to these files.
+**Note:** `StorageFile` uses the fact that all bits of erased flash memory are 1
+to detect the end of a file. As such you should not write character code 255
+(`"\xFF"`) to these files.
 */
 
 JsVar *jswrap_storagefile_read_internal(JsVar *f, int len) {
@@ -731,10 +723,11 @@ JsVar *jswrap_storagefile_read_internal(JsVar *f, int len) {
   "return" : ["JsVar","A String, or undefined "],
   "return_object" : "String"
 }
-Read 'len' bytes of data from the file, and return a String containing those bytes.
+Read 'len' bytes of data from the file, and return a String containing those
+bytes.
 
-If the end of the file is reached, the String may be smaller than the amount of bytes
-requested, or if the file is already at the end, `undefined` is returned.
+If the end of the file is reached, the String may be smaller than the amount of
+bytes requested, or if the file is already at the end, `undefined` is returned.
 */
 JsVar *jswrap_storagefile_read(JsVar *f, int len) {
   if (len<0) len=0;
@@ -764,8 +757,8 @@ JsVar *jswrap_storagefile_readLine(JsVar *f) {
 }
 Return the length of the current file.
 
-This requires Espruino to read the file from scratch,
-which is not a fast operation.
+This requires Espruino to read the file from scratch, which is not a fast
+operation.
 */
 int jswrap_storagefile_getLength(JsVar *f) {
   // Get name and position of name digit
@@ -830,7 +823,8 @@ int jswrap_storagefile_getLength(JsVar *f) {
   ],
   "typescript" : "write(data: string): void;"
 }
-Append the given data to a file. You should not attempt to append  `"\xFF"` (character code 255).
+Append the given data to a file. You should not attempt to append `"\xFF"`
+(character code 255).
 */
 void jswrap_storagefile_write(JsVar *f, JsVar *_data) {
   char mode = (char)jsvGetIntegerAndUnLock(jsvObjectGetChild(f,"mode",0));

--- a/src/jswrap_string.c
+++ b/src/jswrap_string.c
@@ -27,7 +27,8 @@
 }
 This is the built-in class for Text Strings.
 
-Text Strings in Espruino are not zero-terminated, so you can store zeros in them.
+Text Strings in Espruino are not zero-terminated, so you can store zeros in
+them.
  */
 
 /*JSON{
@@ -125,7 +126,8 @@ JsVar *jswrap_string_charAt(JsVar *parent, JsVarInt idx) {
   ],
   "return" : ["int32","The integer value of a character in the string"]
 }
-Return the integer value of a single character at the given position in the String.
+Return the integer value of a single character at the given position in the
+String.
 
 Note that this returns 0 not 'NaN' for out of bounds characters
  */
@@ -303,7 +305,9 @@ JsVar *jswrap_string_match(JsVar *parent, JsVar *subStr) {
   ],
   "return" : ["JsVar","This string with `subStr` replaced"]
 }
-Search and replace ONE occurrance of `subStr` with `newSubStr` and return the result. This doesn't alter the original string. Regular expressions not supported.
+Search and replace ONE occurrance of `subStr` with `newSubStr` and return the
+result. This doesn't alter the original string. Regular expressions not
+supported.
  */
 JsVar *jswrap_string_replace(JsVar *parent, JsVar *subStr, JsVar *newSubStr) {
   JsVar *str = jsvAsString(parent);
@@ -476,9 +480,11 @@ JsVar *jswrap_string_slice(JsVar *parent, JsVarInt pStart, JsVar *vEnd) {
   ],
   "return" : ["JsVar","Part of this string from start for len characters"]
 }
-Return an array made by splitting this string up by the separator. eg. ```'1,2,3'.split(',')==['1', '2', '3']```
+Return an array made by splitting this string up by the separator. eg.
+```'1,2,3'.split(',')==['1', '2', '3']```
 
-Regular Expressions can also be used to split strings, eg. `'1a2b3 4'.split(/[^0-9]/)==['1', '2', '3', '4']`.
+Regular Expressions can also be used to split strings, eg. `'1a2b3
+4'.split(/[^0-9]/)==['1', '2', '3', '4']`.
  */
 JsVar *jswrap_string_split(JsVar *parent, JsVar *split) {
   if (!jsvIsString(parent)) return 0;
@@ -636,7 +642,8 @@ JsVar *jswrap_string_trim(JsVar *parent) {
   ],
   "return" : ["JsVar","The result of appending all arguments to this string"]
 }
-Append all arguments to this `String` and return the result. Does not modify the original `String`.
+Append all arguments to this `String` and return the result. Does not modify the
+original `String`.
 */
 JsVar *jswrap_string_concat(JsVar *parent, JsVar *args) {
   if (!jsvIsString(parent)) return 0;

--- a/src/jswrap_waveform.c
+++ b/src/jswrap_waveform.c
@@ -29,7 +29,8 @@
   "ifndef" : "SAVE_ON_FLASH",
   "class" : "Waveform"
 }
-This class handles waveforms. In Espruino, a Waveform is a set of data that you want to input or output.
+This class handles waveforms. In Espruino, a Waveform is a set of data that you
+want to input or output.
  */
 
 static JsVar *jswrap_waveform_getBuffer(JsVar *waveform, int bufferNumber, bool *is16Bit) {
@@ -145,9 +146,13 @@ void jswrap_waveform_kill() { // be sure to remove all waveforms...
   ],
   "return" : ["JsVar","An Waveform object"]
 }
-Create a waveform class. This allows high speed input and output of waveforms. It has an internal variable called `buffer` (as well as `buffer2` when double-buffered - see `options` below) which contains the data to input/output.
+Create a waveform class. This allows high speed input and output of waveforms.
+It has an internal variable called `buffer` (as well as `buffer2` when
+double-buffered - see `options` below) which contains the data to input/output.
 
-When double-buffered, a 'buffer' event will be emitted each time a buffer is finished with (the argument is that buffer). When the recording stops, a 'finish' event will be emitted (with the first argument as the buffer).
+When double-buffered, a 'buffer' event will be emitted each time a buffer is
+finished with (the argument is that buffer). When the recording stops, a
+'finish' event will be emitted (with the first argument as the buffer).
  */
 JsVar *jswrap_waveform_constructor(int samples, JsVar *options) {
   if (samples<=0) {
@@ -253,7 +258,9 @@ static void jswrap_waveform_start(JsVar *waveform, Pin pin, JsVarFloat freq, JsV
     ["options","JsVar","Optional options struct `{time:float,repeat:bool}` where: `time` is the that the waveform with start output at, e.g. `getTime()+1` (otherwise it is immediate), `repeat` is a boolean specifying whether to repeat the give sample"]
   ]
 }
-Will start outputting the waveform on the given pin - the pin must have previously been initialised with analogWrite. If not repeating, it'll emit a `finish` event when it is done.
+Will start outputting the waveform on the given pin - the pin must have
+previously been initialised with analogWrite. If not repeating, it'll emit a
+`finish` event when it is done.
  */
 void jswrap_waveform_startOutput(JsVar *waveform, Pin pin, JsVarFloat freq, JsVar *options) {
   jswrap_waveform_start(waveform, pin, freq, options, true/*write*/);
@@ -271,7 +278,8 @@ void jswrap_waveform_startOutput(JsVar *waveform, Pin pin, JsVarFloat freq, JsVa
     ["options","JsVar","Optional options struct `{time:float,repeat:bool}` where: `time` is the that the waveform with start output at, e.g. `getTime()+1` (otherwise it is immediate), `repeat` is a boolean specifying whether to repeat the give sample"]
   ]
 }
-Will start inputting the waveform on the given pin that supports analog. If not repeating, it'll emit a `finish` event when it is done.
+Will start inputting the waveform on the given pin that supports analog. If not
+repeating, it'll emit a `finish` event when it is done.
  */
 void jswrap_waveform_startInput(JsVar *waveform, Pin pin, JsVarFloat freq, JsVar *options) {
   // Setup analog, and also bail out on failure

--- a/targets/esp32/jswrap_esp32.c
+++ b/targets/esp32/jswrap_esp32.c
@@ -38,7 +38,8 @@
   "class" : "ESP32",
   "ifdef" : "ESP32"
 }
-Class containing utility functions for the [ESP32](http://www.espruino.com/ESP32)
+Class containing utility functions for the
+[ESP32](http://www.espruino.com/ESP32)
 */
 
 /*JSON{
@@ -95,13 +96,14 @@ void jswrap_ESP32_deepSleep(int us) {
   "generate" : "jswrap_ESP32_getState",
   "return"   : ["JsVar", "The state of the ESP32"]
 }
-Returns an object that contains details about the state of the ESP32 with the following fields:
+Returns an object that contains details about the state of the ESP32 with the
+following fields:
 
-* `sdkVersion`   - Version of the SDK.
-* `freeHeap`     - Amount of free heap in bytes.
-* `BLE`			 - Status of BLE, enabled if true.
-* `Wifi`		 - Status of Wifi, enabled if true.
-* `minHeap`      - Minimum heap, calculated by heap_caps_get_minimum_free_size
+* `sdkVersion` - Version of the SDK.
+* `freeHeap` - Amount of free heap in bytes.
+* `BLE` - Status of BLE, enabled if true.
+* `Wifi` - Status of Wifi, enabled if true.
+* `minHeap` - Minimum heap, calculated by heap_caps_get_minimum_free_size
 
 */
 JsVar *jswrap_ESP32_getState() {
@@ -144,8 +146,8 @@ void jswrap_ESP32_setBLE_Debug(int level){
  ],
  "ifdef"	: "BLUETOOTH" 
 }
-Switches Bluetooth off/on, removes saved code from Flash, resets the board, 
-and on restart creates jsVars depending on available heap (actual additional 1800)
+Switches Bluetooth off/on, removes saved code from Flash, resets the board, and
+on restart creates jsVars depending on available heap (actual additional 1800)
 */
 void jswrap_ESP32_enableBLE(bool enable){ //may be later, we will support BLEenable(ALL/SERVER/CLIENT)
   ESP32_Set_NVS_Status(ESP_NETWORK_BLE,enable);
@@ -163,8 +165,8 @@ void jswrap_ESP32_enableBLE(bool enable){ //may be later, we will support BLEena
    ["enable", "bool", "switches Wifi on or off" ]
  ] 
 }
-Switches Wifi off/on, removes saved code from Flash, resets the board, 
-and on restart creates jsVars depending on available heap (actual additional 3900)
+Switches Wifi off/on, removes saved code from Flash, resets the board, and on
+restart creates jsVars depending on available heap (actual additional 3900)
 */
 void jswrap_ESP32_enableWifi(bool enable){ //may be later, we will support BLEenable(ALL/SERVER/CLIENT)
   ESP32_Set_NVS_Status(ESP_NETWORK_WIFI,enable);

--- a/targets/esp8266/jswrap_esp8266.c
+++ b/targets/esp8266/jswrap_esp8266.c
@@ -40,7 +40,8 @@ typedef long long int64_t;
   "class" : "ESP8266",
   "ifdef" : "ESP8266"
 }
-Class containing utility functions for the [ESP8266](http://www.espruino.com/EspruinoESP8266)
+Class containing utility functions for the
+[ESP8266](http://www.espruino.com/EspruinoESP8266)
 */
 
 // ESP8266.reboot
@@ -72,9 +73,11 @@ void jswrap_ESP8266_reboot() {
   "generate" : "jswrap_ESP8266_getResetInfo",
   "return"   : ["JsVar","An object with the reset cause information"]
 }
-At boot time the esp8266's firmware captures the cause of the reset/reboot. This function returns this information in an object with the following fields:
+At boot time the esp8266's firmware captures the cause of the reset/reboot. This
+function returns this information in an object with the following fields:
 
-* `reason`: "power on", "wdt reset", "exception", "soft wdt", "restart", "deep sleep", or "reset pin"
+* `reason`: "power on", "wdt reset", "exception", "soft wdt", "restart", "deep
+  sleep", or "reset pin"
 * `exccause`: exception cause
 * `epc1`, `epc2`, `epc3`: instruction pointers
 * `excvaddr`: address being accessed
@@ -108,7 +111,9 @@ JsVar *jswrap_ESP8266_getResetInfo() {
     ["enable", "bool", "Enable or disable the debug logging."]
   ]
 }
-Enable or disable the logging of debug information. A value of `true` enables debug logging while a value of `false` disables debug logging. Debug output is sent to UART1 (gpio2).
+Enable or disable the logging of debug information. A value of `true` enables
+debug logging while a value of `false` disables debug logging. Debug output is
+sent to UART1 (gpio2).
  */
 void jswrap_ESP8266_logDebug(bool enable) {
   os_printf("ESP8266.logDebug, enable=%d\n", enable);
@@ -125,7 +130,8 @@ void jswrap_ESP8266_logDebug(bool enable) {
     ["mode", "int", "Debug log mode: 0=off, 1=in-memory only, 2=in-mem and uart0, 3=in-mem and uart1."]
   ]
 }
-Set the debug logging mode. It can be disabled (which frees ~1.2KB of heap), enabled in-memory only, or in-memory and output to a UART.
+Set the debug logging mode. It can be disabled (which frees ~1.2KB of heap),
+enabled in-memory only, or in-memory and output to a UART.
  */
 void jswrap_ESP8266_setLog(int mode) {
   os_printf("ESP8266 setLog, mode=%d\n", mode);
@@ -171,7 +177,8 @@ Returns one line from the log or up to 128 characters.
   "name"     : "dumpSocketInfo",
   "generate" : "jswrap_ESP8266_dumpSocketInfo"
 }
-Dumps info about all sockets to the log. This is for troubleshooting the socket implementation.
+Dumps info about all sockets to the log. This is for troubleshooting the socket
+implementation.
  */
 void jswrap_ESP8266_dumpSocketInfo(void) {
   esp8266_dumpAllSocketData();
@@ -189,11 +196,12 @@ void jswrap_ESP8266_dumpSocketInfo(void) {
     ["freq", "JsVar", "Desired frequency - either 80 or 160."]
   ]
 }
-**Note:** This is deprecated. Use `E.setClock(80/160)`
-**Note:**
-Set the operating frequency of the ESP8266 processor. The default is 160Mhz.
+**Note:** This is deprecated. Use `E.setClock(80/160)` **Note:** Set the
+operating frequency of the ESP8266 processor. The default is 160Mhz.
 
-**Warning**: changing the cpu frequency affects the timing of some I/O operations, notably of software SPI and I2C, so things may be a bit slower at 80Mhz.
+**Warning**: changing the cpu frequency affects the timing of some I/O
+operations, notably of software SPI and I2C, so things may be a bit slower at
+80Mhz.
 
 */
 void jswrap_ESP8266_setCPUFreq(
@@ -212,15 +220,17 @@ void jswrap_ESP8266_setCPUFreq(
   "generate" : "jswrap_ESP8266_getState",
   "return"   : ["JsVar", "The state of the ESP8266"]
 }
-Returns an object that contains details about the state of the ESP8266 with the following fields:
+Returns an object that contains details about the state of the ESP8266 with the
+following fields:
 
-* `sdkVersion`   - Version of the SDK.
+* `sdkVersion` - Version of the SDK.
 * `cpuFrequency` - CPU operating frequency in Mhz.
-* `freeHeap`     - Amount of free heap in bytes.
-* `maxCon`       - Maximum number of concurrent connections.
-* `flashMap`     - Configured flash size&map: '512KB:256/256' .. '4MB:512/512'
-* `flashKB`      - Configured flash size in KB as integer
-* `flashChip`    - Type of flash chip as string with manufacturer & chip, ex: '0xEF 0x4016`
+* `freeHeap` - Amount of free heap in bytes.
+* `maxCon` - Maximum number of concurrent connections.
+* `flashMap` - Configured flash size&map: '512KB:256/256' .. '4MB:512/512'
+* `flashKB` - Configured flash size in KB as integer
+* `flashChip` - Type of flash chip as string with manufacturer & chip, ex: '0xEF
+  0x4016`
 
 */
 JsVar *jswrap_ESP8266_getState() {
@@ -331,7 +341,8 @@ JsVar *jswrap_ESP8266_crc32(JsVar *jsData) {
  ]
 }
 
-**This function is deprecated.** Please use `require("neopixel").write(pin, data)` instead
+**This function is deprecated.** Please use `require("neopixel").write(pin,
+data)` instead
 */
 void jswrap_ESP8266_neopixelWrite(Pin pin, JsVar *jsArrayOfData) {
   jswrap_neopixel_write(pin, jsArrayOfData);
@@ -349,12 +360,13 @@ void jswrap_ESP8266_neopixelWrite(Pin pin, JsVar *jsArrayOfData) {
     ["option", "JsVar", "posible values are 0, 1, 2 or 4"]
   ]
 }
-Put the ESP8266 into 'deep sleep' for the given number of microseconds, 
-reducing power consumption drastically. 
+Put the ESP8266 into 'deep sleep' for the given number of microseconds, reducing
+power consumption drastically.
 
 meaning of option values:
 
-0 - the 108th Byte of init parameter decides whether RF calibration will be performed or not.
+0 - the 108th Byte of init parameter decides whether RF calibration will be
+performed or not.
 
 1 - run RF calibration after waking up. Power consumption is high.
 
@@ -362,10 +374,13 @@ meaning of option values:
 
 4 - no RF after waking up. Power consumption is the lowest.
 
-**Note:** unlike normal Espruino boards' 'deep sleep' mode, ESP8266 deep sleep actually turns off the processor. After the given number of microseconds have elapsed, the ESP8266 will restart as if power had been turned off and then back on. *All contents of RAM will be lost*. 
-Connect GPIO 16 to RST to enable wakeup.
+**Note:** unlike normal Espruino boards' 'deep sleep' mode, ESP8266 deep sleep
+actually turns off the processor. After the given number of microseconds have
+elapsed, the ESP8266 will restart as if power had been turned off and then back
+on. *All contents of RAM will be lost*. Connect GPIO 16 to RST to enable wakeup.
 
-**Special:** 0 microseconds cause sleep forever until external wakeup RST pull down occurs.
+**Special:** 0 microseconds cause sleep forever until external wakeup RST pull
+down occurs.
 
 */
 void   jswrap_ESP8266_deepSleep(JsVar *jsMicros, JsVar *jsOption) {

--- a/targets/esp8266/jswrap_nodemcu.c
+++ b/targets/esp8266/jswrap_nodemcu.c
@@ -20,7 +20,8 @@
   "type" : "class",
   "class" : "NodeMCU"
 }
-This is a built-in class to allow you to use the ESP8266 NodeMCU boards's pin namings to access pins. It is only available on ESP8266-based boards.
+This is a built-in class to allow you to use the ESP8266 NodeMCU boards's pin
+namings to access pins. It is only available on ESP8266-based boards.
 */
 
 // TODO: Sigh - because everyone is using `Pin(..)` now, we can't have a proper 'A0' pin defined because it'd shift all the pins created by`Pin(..)`


### PR DESCRIPTION
Tested with `make docs` and `functions.html` did not change at all!

Made an Emacs Lisp script to do this automatically, don't know if it's worth putting that in the repository too.