### PR TITLE
Fixed lexer bug for non UTF-8 characters

### DIFF
--- a/src/jslex.c
+++ b/src/jslex.c
@@ -437,6 +437,13 @@ void jslGetNextToken() {
   // record beginning of this token
   lex->tokenLastStart = lex->tokenStart;
   unsigned char jumpCh = (unsigned char)lex->currCh;
+
+  // lexer must stop parsing for a variable name if the current char is not UTF-8
+  if ((jumpCh < 0x20 || jumpCh > 0x7e) && jumpCh != 0x00) {
+    jsError("Non UTF-8 character detected.");
+    exit(1);
+  }
+
   if (jumpCh > jslJumpTableEnd) jumpCh = 0; // which also happens to be JSLJT_SINGLE_CHAR - what we want.
   jslGetNextToken_start:
   lex->tokenStart = jsvStringIteratorGetIndex(&lex->it) - 1;


### PR DESCRIPTION
With the following file Espruino crashes with a SEGFAULT:
```js
깵੬
```
Here are the hexdump of the file + its base64:

```hex
00000000: 75ae 6c0a                                u.l.
```

`da5sCg==`

To crash the program:

```sh
echo 'da5sCg==' | base64 -d > crash.js
espruino crash.js
```

The root cause of the crash is at https://github.com/espruino/Espruino/blob/master/src/jsparse.c#L2297
Because the lexer did not sanitize/stopped on non parsed character, thus `*lastDefined` points to address `0` which crashes the program.

I don't know if my way of stopping the execution is the best but it worked on my computer.