### PR TITLE
Fixed round 1.5 bug

### DIFF
--- a/libs/math/jswrap_math.c
+++ b/libs/math/jswrap_math.c
@@ -356,7 +356,7 @@ double jswrap_math_pow(double x, double y) {
 }*/
 JsVar *jswrap_math_round(double x) {
   if (!isfinite(x) || isNegativeZero(x)) return jsvNewFromFloat(x);
-  x += (x<0) ? -0.4999999999 : 0.4999999999;
+  x += (x<0) ? -0.5 : 0.5;
   long long i = (long long)x;
   if (i==0 && (x<0))
     return jsvNewFromFloat(-0.0); // pass -0 through


### PR DESCRIPTION
Solving the following issue https://github.com/espruino/Espruino/issues/2258
by changing the value added to x by 0.5 (or -0.5 if negative) instead of 0.4999999999 previously.
In this case, the number 1.5 will be updated to 2 (and after cast will remain 2),
 whereas 1.49 will be updated to 1.99 (and will be floored to 1).