### PR TITLE
strip file names and line numbers from tensorflow error messages for release build

### DIFF
--- a/libs/tensorflow/patches/02-ndebug-omit-file-line-logging.diff
+++ b/libs/tensorflow/patches/02-ndebug-omit-file-line-logging.diff
@@ -1,0 +1,61 @@
+diff --git a/libs/tensorflow/tensorflow/lite/c/common.h b/libs/tensorflow/tensorflow/lite/c/common.h
+index 18997298d..4a7ba8bb6 100644
+--- a/libs/tensorflow/tensorflow/lite/c/common.h
++++ b/libs/tensorflow/tensorflow/lite/c/common.h
+@@ -173,12 +173,22 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
+ #define TF_LITE_MAYBE_KERNEL_LOG(context, ...)
+ #endif  // TF_LITE_STRIP_ERROR_STRINGS
+ 
++#ifdef NDEBUG
++#define TF_DEBUG_FILE ""
++#define TF_DEBUG_FMT ""
++#define TF_DEBUG_PARAMS
++#else
++#define TF_DEBUG_FILE __FILE__ " "
++#define TF_DEBUG_FMT "%s:%d "
++#define TF_DEBUG_PARAMS ,__FILE__,__LINE__
++#endif
++
+ // Check whether value is true, and if not return kTfLiteError from
+ // the current function (and report the error string msg).
+ #define TF_LITE_ENSURE_MSG(context, value, msg)        \
+   do {                                                 \
+     if (!(value)) {                                    \
+-      TF_LITE_KERNEL_LOG((context), __FILE__ " " msg); \
++      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FILE msg); \
+       return kTfLiteError;                             \
+     }                                                  \
+   } while (0)
+@@ -188,8 +198,8 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
+ #define TF_LITE_ENSURE(context, a)                                      \
+   do {                                                                  \
+     if (!(a)) {                                                         \
+-      TF_LITE_KERNEL_LOG((context), "%s:%d %s was not true.", __FILE__, \
+-                         __LINE__, #a);                                 \
++      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FMT "%s was not true." TF_DEBUG_PARAMS, \
++                         #a);                                 \
+       return kTfLiteError;                                              \
+     }                                                                   \
+   } while (0)
+@@ -210,8 +220,8 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
+ #define TF_LITE_ENSURE_EQ(context, a, b)                                   \
+   do {                                                                     \
+     if ((a) != (b)) {                                                      \
+-      TF_LITE_KERNEL_LOG((context), "%s:%d %s != %s (%d != %d)", __FILE__, \
+-                         __LINE__, #a, #b, (a), (b));                      \
++      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FMT "%s != %s (%d != %d)" TF_DEBUG_PARAMS, \
++                         #a, #b, (a), (b));                      \
+       return kTfLiteError;                                                 \
+     }                                                                      \
+   } while (0)
+@@ -219,8 +229,8 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
+ #define TF_LITE_ENSURE_TYPES_EQ(context, a, b)                             \
+   do {                                                                     \
+     if ((a) != (b)) {                                                      \
+-      TF_LITE_KERNEL_LOG((context), "%s:%d %s != %s (%s != %s)", __FILE__, \
+-                         __LINE__, #a, #b, TfLiteTypeGetName(a),           \
++      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FMT "%s != %s (%s != %s)" TF_DEBUG_PARAMS, \
++                         #a, #b, TfLiteTypeGetName(a),           \
+                          TfLiteTypeGetName(b));                            \
+       return kTfLiteError;                                                 \
+     }                                                                      \

--- a/libs/tensorflow/tensorflow/lite/c/common.h
+++ b/libs/tensorflow/tensorflow/lite/c/common.h
@@ -173,12 +173,22 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
 #define TF_LITE_MAYBE_KERNEL_LOG(context, ...)
 #endif  // TF_LITE_STRIP_ERROR_STRINGS
 
+#ifdef NDEBUG
+#define TF_DEBUG_FILE ""
+#define TF_DEBUG_FMT ""
+#define TF_DEBUG_PARAMS
+#else
+#define TF_DEBUG_FILE __FILE__ " "
+#define TF_DEBUG_FMT "%s:%d "
+#define TF_DEBUG_PARAMS ,__FILE__,__LINE__
+#endif
+
 // Check whether value is true, and if not return kTfLiteError from
 // the current function (and report the error string msg).
 #define TF_LITE_ENSURE_MSG(context, value, msg)        \
   do {                                                 \
     if (!(value)) {                                    \
-      TF_LITE_KERNEL_LOG((context), __FILE__ " " msg); \
+      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FILE msg); \
       return kTfLiteError;                             \
     }                                                  \
   } while (0)
@@ -188,8 +198,8 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
 #define TF_LITE_ENSURE(context, a)                                      \
   do {                                                                  \
     if (!(a)) {                                                         \
-      TF_LITE_KERNEL_LOG((context), "%s:%d %s was not true.", __FILE__, \
-                         __LINE__, #a);                                 \
+      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FMT "%s was not true." TF_DEBUG_PARAMS, \
+                         #a);                                 \
       return kTfLiteError;                                              \
     }                                                                   \
   } while (0)
@@ -210,8 +220,8 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
 #define TF_LITE_ENSURE_EQ(context, a, b)                                   \
   do {                                                                     \
     if ((a) != (b)) {                                                      \
-      TF_LITE_KERNEL_LOG((context), "%s:%d %s != %s (%d != %d)", __FILE__, \
-                         __LINE__, #a, #b, (a), (b));                      \
+      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FMT "%s != %s (%d != %d)" TF_DEBUG_PARAMS, \
+                         #a, #b, (a), (b));                      \
       return kTfLiteError;                                                 \
     }                                                                      \
   } while (0)
@@ -219,8 +229,8 @@ void TfLiteFloatArrayFree(TfLiteFloatArray* a);
 #define TF_LITE_ENSURE_TYPES_EQ(context, a, b)                             \
   do {                                                                     \
     if ((a) != (b)) {                                                      \
-      TF_LITE_KERNEL_LOG((context), "%s:%d %s != %s (%s != %s)", __FILE__, \
-                         __LINE__, #a, #b, TfLiteTypeGetName(a),           \
+      TF_LITE_KERNEL_LOG((context), TF_DEBUG_FMT "%s != %s (%s != %s)" TF_DEBUG_PARAMS, \
+                         #a, #b, TfLiteTypeGetName(a),           \
                          TfLiteTypeGetName(b));                            \
       return kTfLiteError;                                                 \
     }                                                                      \

--- a/make/misc/tensorflow.make
+++ b/make/misc/tensorflow.make
@@ -69,5 +69,9 @@ INCLUDE += \
 -I$(TENSOR_ROOT)/third_party/flatbuffers/include \
 -I$(TENSOR_ROOT)/third_party/ruy
 
-CCFLAGS += -DNDEBUG -g -DTF_LITE_STATIC_MEMORY --std=c++11 -g -fno-rtti -fpermissive -Wno-sign-compare -Wno-conversion -Wno-sign-conversion -Wno-missing-field-initializers -Wno-type-limits -Wno-unused-parameter -Wno-unused-variable
+ifdef RELEASE
+CCFLAGS += -DNDEBUG
+# to strip all error messages add -DTF_LITE_STRIP_ERROR_STRINGS
+endif
+CCFLAGS += -g -DTF_LITE_STATIC_MEMORY --std=c++11 -g -fno-rtti -fpermissive -Wno-sign-compare -Wno-conversion -Wno-sign-conversion -Wno-missing-field-initializers -Wno-type-limits -Wno-unused-parameter -Wno-unused-variable
 DEFINES += -DUSE_TENSORFLOW=1

--- a/make/misc/tensorflow.make
+++ b/make/misc/tensorflow.make
@@ -73,5 +73,5 @@ ifdef RELEASE
 CCFLAGS += -DNDEBUG
 # to strip all error messages add -DTF_LITE_STRIP_ERROR_STRINGS
 endif
-CCFLAGS += -g -DTF_LITE_STATIC_MEMORY --std=c++11 -g -fno-rtti -fpermissive -Wno-sign-compare -Wno-conversion -Wno-sign-conversion -Wno-missing-field-initializers -Wno-type-limits -Wno-unused-parameter -Wno-unused-variable
+CCFLAGS += -fmacro-prefix-map=$(TENSOR_ROOT)/= -g -DTF_LITE_STATIC_MEMORY --std=c++11 -g -fno-rtti -fpermissive -Wno-sign-compare -Wno-conversion -Wno-sign-conversion -Wno-missing-field-initializers -Wno-type-limits -Wno-unused-parameter -Wno-unused-variable
 DEFINES += -DUSE_TENSORFLOW=1


### PR DESCRIPTION
- add gcc option to strip build folder absolute path from __FILE__ macro
- make tensorflow NDEBUG dependent on RELEASE - may enable more debug stuff for non-release builds
- disable logging lines and source file names based on NDEBUG