### PR TITLE
[Bangle_setUI_Q3.js] Back does not override other btn function

### DIFF
--- a/libs/js/banglejs/Bangle_setUI_Q3.js
+++ b/libs/js/banglejs/Bangle_setUI_Q3.js
@@ -123,7 +123,6 @@
       };
       Bangle.on("touch", Bangle.touchHandler);
     }
-    
     if (!options.btn) { // Back function does not override if other function has been assigned to btn
       var btnWatch = setWatch(function() {
         btnWatch = undefined;

--- a/libs/js/banglejs/Bangle_setUI_Q3.js
+++ b/libs/js/banglejs/Bangle_setUI_Q3.js
@@ -123,10 +123,13 @@
       };
       Bangle.on("touch", Bangle.touchHandler);
     }
-    var btnWatch = setWatch(function() {
-      btnWatch = undefined;
-      options.back();
-    }, BTN1, {edge:"falling"});
+    
+    if (!options.btn) { // Back function does not override if other function has been assigned to btn
+      var btnWatch = setWatch(function() {
+        btnWatch = undefined;
+        options.back();
+      }, BTN1, {edge:"falling"});
+    }
     WIDGETS = Object.assign({back:{ 
       area:"tl", width:24, 
       draw:e=>g.reset().setColor("#f00").drawImage(atob("GBiBAAAYAAH/gAf/4A//8B//+D///D///H/P/n+H/n8P/n4f/vwAP/wAP34f/n8P/n+H/n/P/j///D///B//+A//8Af/4AH/gAAYAA=="),e.x,e.y),


### PR DESCRIPTION
'back' function currently overrides (or rather adds to) a defined 'btn' function. I think it makes sense for it to not do that, as with 'clock' (highlighted in the description from the [the hardware reference](http://www.espruino.com/Reference#l_Bangle_setUI) below).
>Bangle.setUI({
  mode : "custom",
  back : function() {}, // optional - add a 'back' icon in top-left widget area and call this function when it is pressed
  touch : function(n,e) {}, // optional - handler for 'touch' events
  swipe : function(dir) {}, // optional - handler for 'swipe' events
  drag : function(e) {}, // optional - handler for 'drag' events (Bangle.js 2 only)
  btn : function(n) {}, // optional - handler for 'button' events (n==1 on Bangle.js 2, n==1/2/3 depending on button for Bangle.js 1)
  clock : 0 // optional - if set the behavior of 'clock' mode is added **(does not override btn if defined)**
});

If this PR gets merged in i suggest updating the hardware reference like this:
>Bangle.setUI({
  mode : "custom",
  back : function() {}, // optional - add a 'back' icon in top-left widget area and call this function when it is pressed, **also call the function when the hardware button is clicked (does not override btn if defined)**
  touch : function(n,e) {}, // optional - handler for 'touch' events
  swipe : function(dir) {}, // optional - handler for 'swipe' events
  drag : function(e) {}, // optional - handler for 'drag' events (Bangle.js 2 only)
  btn : function(n) {}, // optional - handler for 'button' events (n==1 on Bangle.js 2, n==1/2/3 depending on button for Bangle.js 1)
  clock : 0 // optional - if set the behavior of 'clock' mode is added (does not override btn if defined)
});

I would do a pull request for the hardware reference as well, but I don't know where.

I have not tested this change.