### PR TITLE
ESP32: Take advantage of JsVars being smaller.

### DIFF
--- a/boards/ESP32.py
+++ b/boards/ESP32.py
@@ -25,15 +25,19 @@
 # This setting will chose the optimum JsVar format for a given number
 # of JsVars.
 
-# If you add PSRAM to your ESP32 or compile without disused modules, you
+# If you add PSRAM to your ESP32 or compile with modules removed, you
 # may wish to select a value using this table:
 #
-# Value |  Max JsVars  | Bytes per JsVar |
-# ------+--------------+-----------------+
-# 4095  |         4095 |              13 |
-# 8191  |         8191 |              14 |
-# 65535 |        65535 |              16 |
-# ------+--------------+-----------------+
+# Value |  Max JsVars  | Bytes per JsVar | Maximum References |
+# ------+--------------+-----------------+--------------------+
+# 4095  |         4095 |              13 |               255  |
+# 8191  |         8191 |              13 |                 7  |
+# 16383 |        16383 |              14 |               255  |
+# 65535 |        65535 |              16 |               255  |
+# ------+--------------+-----------------+--------------------+
+
+# CAUTION: Chosing 8191 only allows 7 references to a variable. This
+# may be too restrictive to run some code.
 
 # Using too large a JsVar format may limit how many JsVars can fit into
 # available memory. Using too small a JsVar format will under utilise

--- a/boards/ESP32.py
+++ b/boards/ESP32.py
@@ -13,13 +13,40 @@
 # as various source and header files for Espruino.
 # ----------------------------------------------------------------------------------------
 
+
+
+# A Note about the 'variables' parameter on ESP32 Builds
+# ------------------------------------------------------
+# 
+# For the ESP32 build, the number of JsVars is governed by two factors:
+#     * Available memory
+#     * Maximum number of JsVars for the used JsVar format
+#
+# This setting will chose the optimum JsVar format for a given number
+# of JsVars.
+
+# If you add PSRAM to your ESP32 or compile without disused modules, you
+# may wish to select a value using this table:
+#
+# Value |  Max JsVars  | Bytes per JsVar |
+# ------+--------------+-----------------+
+# 4095  |         4095 |              13 |
+# 8191  |         8191 |              14 |
+# 65535 |        65535 |              16 |
+# ------+--------------+-----------------+
+
+# Using too large a JsVar format may limit how many JsVars can fit into
+# available memory. Using too small a JsVar format will under utilise
+# available memory.
+
+
 import pinutils;
 info = {
  'name'                     : "ESP32",
  'espruino_page_link'       : 'ESP32',
  'default_console'          : "EV_SERIAL1",
  'default_console_baudrate' : "115200",
- 'variables'                : 2500, # JSVAR_MALLOC is defined below - so this can vary depending on what is initialised
+ 'variables'                : 4095, # See note above 
  'binary_name'              : 'espruino_%v_esp32.bin',
  'build' : {
    'optimizeflags' : '-Og',

--- a/boards/ESP32.py
+++ b/boards/ESP32.py
@@ -31,12 +31,12 @@
 # Value |  Max JsVars  | Bytes per JsVar | Maximum References |
 # ------+--------------+-----------------+--------------------+
 # 4095  |         4095 |              13 |               255  |
-# 8191  |         8191 |              13 |                 7  |
+# 8191  |         8191 |              13 |                15  |
 # 16383 |        16383 |              14 |               255  |
 # 65535 |        65535 |              16 |               255  |
 # ------+--------------+-----------------+--------------------+
 
-# CAUTION: Chosing 8191 only allows 7 references to a variable. This
+# CAUTION: Chosing 8191 only allows 15 references to a variable. This
 # may be too restrictive to run some code.
 
 # Using too large a JsVar format may limit how many JsVars can fit into

--- a/src/jsutils.h
+++ b/src/jsutils.h
@@ -222,6 +222,11 @@ See comments after JsVar in jsvar.c for more info.
     #define JSVARREFCOUNT_BITS 4 // 56 - 13*4
     typedef uint16_t JsVarRef;
     typedef int16_t JsVarRefSigned;
+  #elif JSVAR_CACHE_SIZE <= 16383 // 14 bytes
+    #define JSVARREF_BITS 14
+    #define JSVARREFCOUNT_BITS 8 // 64 - 13*4
+    typedef uint16_t JsVarRef;
+    typedef int16_t JsVarRefSigned;
   #elif JSVAR_CACHE_SIZE <= 65535 // 16 bytes
     #define JSVARREF_BITS 16
     #define JSVARREFCOUNT_BITS 8

--- a/targets/esp32/main.c
+++ b/targets/esp32/main.c
@@ -60,7 +60,7 @@ static void espruinoTask(void *data) {
   initADC(1);
   jshInit();     // Initialize the hardware
   jswHWInit();
-  heapVars = (esp_get_free_heap_size() - 40000) / 16;  //calculate space for jsVars
+  heapVars = (esp_get_free_heap_size() - 40000) / sizeof(JsVar);  //calculate space for jsVars
   heapVars = heapVars - heapVars % 100; //round to 100
   if(heapVars > 20000) heapVars = 20000;  //WROVER boards have much more RAM, so we set a limit
   jsvInit(heapVars);     // Initialize the variables

--- a/targets/esp32/main.c
+++ b/targets/esp32/main.c
@@ -47,12 +47,9 @@ static void uartTask(void *data) {
 static void espruinoTask(void *data) {
   int heapVars;
 
-#ifdef ESP32
-    espruino_stackHighPtr = &heapVars;  //Ignore the name, 'heapVars' is on the stack!
-                          //I didn't use another variable becaue this function never ends so
-                          //all variables declared here consume stack space that is never freed. 
-#endif
-
+  espruino_stackHighPtr = &heapVars;  //Ignore the name, 'heapVars' is on the stack!
+                        //I didn't use another variable becaue this function never ends so
+                        //all variables declared here consume stack space that is never freed. 
 
   PWMInit();
   RMTInit();
@@ -60,10 +57,22 @@ static void espruinoTask(void *data) {
   initADC(1);
   jshInit();     // Initialize the hardware
   jswHWInit();
+
+
   heapVars = (esp_get_free_heap_size() - 40000) / sizeof(JsVar);  //calculate space for jsVars
-  heapVars = heapVars - heapVars % 100; //round to 100
-  if(heapVars > 20000) heapVars = 20000;  //WROVER boards have much more RAM, so we set a limit
+
+  //Limit number of JsVars to maximum addressable. Can otherwise be
+  //breached by builds with modules removed or boards using PSRAM.
+  {
+    int maxVars = (1 << JSVARREF_BITS) - 1;
+    
+    if (heapVars > maxVars) {
+      heapVars = maxVars;
+    }
+  }
+
   jsvInit(heapVars);     // Initialize the variables
+
   // not sure why this delay is needed?
   vTaskDelay(200 / portTICK_PERIOD_MS);
   jsiInit(true); // Initialize the interactive subsystem


### PR DESCRIPTION
ESP32 builds did not gain more JsVars when JsVars shrank in size because of the use of a literal in a calculation.