### PR TITLE
Clear only the corners containing widgets.

### DIFF
--- a/libs/js/banglejs/Bangle_drawWidgets_Q3.js
+++ b/libs/js/banglejs/Bangle_drawWidgets_Q3.js
@@ -15,7 +15,9 @@
   	p.c++;
   }
   g.reset();
-  if (pos.tl.c || pos.tr.c) g.clearRect(0,0,w-1,23);
-  if (pos.bl.c || pos.br.c) g.clearRect(0,h-24,w-1,h-1);
+  if (pos.tl.c) g.clearRect(0,0,pos.tl.x,23);
+  if (pos.tr.c) g.clearRect(pos.tr.x,0,w-1,23);
+  if (pos.bl.c) g.clearRect(0,h-24,pos.bl.x,h-1);
+  if (pos.br.c) g.clearRect(pos.br.x,h-24,w-1,h-1);
   try { for (wd of WIDGETS) wd.draw(wd); } catch(e) {print(e);}
 })


### PR DESCRIPTION
Before, the whole top and bottom twenty-four vertical pixels of the screen were cleared whenever any widget appeared.  Now, only the area containing the widgets that appear is cleared.