### PR TITLE
fix LINUX crash on reset() with fixed variables size

### DIFF
--- a/src/jsvar.c
+++ b/src/jsvar.c
@@ -333,6 +333,7 @@ void jsvInit(unsigned int size) {
   jsVarBlocks[0] = malloc(sizeof(JsVar) * JSVAR_BLOCK_SIZE);
 #endif
 #elif defined(JSVAR_MALLOC)
+  jsVarsSize = JSVAR_CACHE_SIZE;
   if (size) jsVarsSize = size;
 #if defined(ESPR_JIT) && defined(LINUX)
   if (!jsVars)


### PR DESCRIPTION
LINUX defines JSVAR_MALLOC even for fixed variables and at reset() time jsvInit is called with size 0 so we need jsVarsSize filled with default value to malloc right size

alternatively we could avoid it by not defining JSVAR_MALLOC when variable size is fixed for LINUX here https://github.com/espruino/Espruino/blob/master/scripts/build_platform_config.py#L285
that seem to not trigger this bug 