### PR TITLE
Documentation/generated typescript updates - Object, Bangle and optionals

### DIFF
--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -5203,7 +5203,7 @@ Load the Bangle.js clock - this has the same effect as calling `Bangle.load()`.
     "name" : "load",
     "generate_js" : "libs/js/banglejs/Bangle_load.min.js",
     "params" : [
-      ["file","JsVar","(optional) A string containing the file name for the app to be loaded"]
+      ["file","JsVar","[optional] A string containing the file name for the app to be loaded"]
     ],
     "ifdef" : "BANGLEJS",
     "typescript": [
@@ -5322,7 +5322,7 @@ E.showMenu(menu);
     "generate_js" : "libs/js/banglejs/E_showMessage.min.js",
     "params" : [
       ["message","JsVar","A message to display. Can include newlines"],
-      ["options","JsVar","(optional) a title for the message, or an object of options `{title:string, img:image_string}`"]
+      ["options","JsVar","[optional] a title for the message, or an object of options `{title:string, img:image_string}`"]
     ],
     "ifdef" : "BANGLEJS",
     "typescript" : "showMessage(message: string, title?: string | { title?: string, img?: string }): void;"
@@ -5355,12 +5355,12 @@ E.showMessage("Lots of text will wrap automatically",{
     "generate_js" : "libs/js/banglejs/E_showPrompt.min.js",
     "params" : [
       ["message","JsVar","A message to display. Can include newlines"],
-      ["options","JsVar","(optional) an object of options (see below)"]
+      ["options","JsVar","[optional] an object of options (see below)"]
     ],
     "return" : ["JsVar","A promise that is resolved when 'Ok' is pressed"],
     "ifdef" : "BANGLEJS",
     "typescript" : [
-      "showPrompt<T = boolean>(message: string, options?: { title?: string, buttons?: { [key: string]: T }, remove?: () => void }): Promise<T>;",
+      "showPrompt<T = boolean>(message: string, options?: { title?: string, buttons?: { [key: string]: T }, image?: string, remove?: () => void }): Promise<T>;",
       "showPrompt(): void;"
     ]
 }
@@ -5490,7 +5490,7 @@ To remove the scroller, just call `E.showScroller()`
     "generate_js" : "libs/js/banglejs/E_showAlert.min.js",
     "params" : [
       ["message","JsVar","A message to display. Can include newlines"],
-      ["options","JsVar","(optional) a title for the message or an object containing options"]
+      ["options","JsVar","[optional] a title for the message or an object containing options"]
     ],
     "return" : ["JsVar","A promise that is resolved when 'Ok' is pressed"],
     "ifdef" : "BANGLEJS",

--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -5573,7 +5573,7 @@ displays a circle on the display
       ["callback","JsVar","A function with one argument which is the direction"]
     ],
     "ifdef" : "BANGLEJS",
-    "typescript" : "setUI(type?: \"updown\" | \"leftright\" | \"clock\" | \"clockupdown\" | { mode: \"custom\"; back?: () => void; touch?: TouchCallback; swipe?: SwipeCallback; drag?: DragCallback; btn?: (n: number) => void, clock?: boolean }, callback?: (direction?: -1 | 1) => void): void;"
+    "typescript" : "setUI(type?: \"updown\" | \"leftright\" | \"clock\" | \"clockupdown\" | { mode: \"custom\"; back?: () => void; touch?: TouchCallback; swipe?: SwipeCallback; drag?: DragCallback; btn?: (n: number) => void, remove?: () => void, clock?: boolean }, callback?: (direction?: -1 | 1) => void): void;"
 }
 This puts Bangle.js into the specified UI input mode, and calls the callback
 provided when there is user input.

--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -591,7 +591,7 @@ void jswrap_ble_wake() {
     "name" : "restart",
     "generate" : "jswrap_ble_restart",
     "params" : [
-      ["callback","JsVar","An optional function to be called while the softdevice is uninitialised. Use with caution - accessing console/bluetooth will almost certainly result in a crash."]
+      ["callback","JsVar","[optional] A function to be called while the softdevice is uninitialised. Use with caution - accessing console/bluetooth will almost certainly result in a crash."]
     ]
 }
 Restart the Bluetooth softdevice (if there is currently a BLE connection, it
@@ -991,7 +991,7 @@ JsVar *jswrap_ble_getCurrentAdvertisingData() {
     "generate" : "jswrap_ble_getAdvertisingData",
     "params" : [
       ["data","JsVar","The data to advertise as an object"],
-      ["options","JsVar","An optional object of options"]
+      ["options","JsVar","[optional] An object of options"]
     ],
     "return" : ["JsVar", "An array containing the advertising data" ]
 }
@@ -1743,7 +1743,7 @@ bool jswrap_ble_filter_device(JsVar *filters, JsVar *device) {
     "generate" : "jswrap_ble_setScan",
     "params" : [
       ["callback","JsVar","The callback to call with received advertising packets, or undefined to stop"],
-      ["options","JsVar","An optional object `{filters: ...}` (as would be passed to `NRF.requestDevice`) to filter devices by"]
+      ["options","JsVar","[optional] An object `{filters: ...}` (as would be passed to `NRF.requestDevice`) to filter devices by"]
     ]
 }
 
@@ -3636,7 +3636,7 @@ void jswrap_ble_BluetoothDevice_sendPasskey(JsVar *parent, JsVar *passkeyVar) {
     "#if" : "defined(NRF52_SERIES) || defined(ESP32)",
     "generate" : "jswrap_ble_BluetoothRemoteGATTServer_connect",
     "params" : [
-      ["options","JsVar","(Espruino-specific) An object of connection options (see below)"]
+      ["options","JsVar","[optional] (Espruino-specific) An object of connection options (see below)"]
     ],
     "return" : ["JsVar", "A `Promise` that is resolved (or rejected) when the connection is complete" ],
     "return_object" : "Promise"

--- a/libs/crypto/jswrap_crypto.c
+++ b/libs/crypto/jswrap_crypto.c
@@ -455,7 +455,7 @@ static NO_INLINE JsVar *jswrap_crypto_AEScrypt(JsVar *message, JsVar *key, JsVar
   "params" : [
     ["passphrase","JsVar","Message to encrypt"],
     ["key","JsVar","Key to encrypt message - must be an ArrayBuffer of 128, 192, or 256 BITS"],
-    ["options","JsVar","An optional object, may specify `{ iv : new Uint8Array(16), mode : 'CBC|CFB|CTR|OFB|ECB' }`"]
+    ["options","JsVar","[optional] An object, may specify `{ iv : new Uint8Array(16), mode : 'CBC|CFB|CTR|OFB|ECB' }`"]
   ],
   "return" : ["JsVar","Returns an ArrayBuffer"],
   "return_object" : "ArrayBuffer",
@@ -474,7 +474,7 @@ JsVar *jswrap_crypto_AES_encrypt(JsVar *message, JsVar *key, JsVar *options) {
   "params" : [
     ["passphrase","JsVar","Message to decrypt"],
     ["key","JsVar","Key to encrypt message - must be an ArrayBuffer of 128, 192, or 256 BITS"],
-    ["options","JsVar","An optional object, may specify `{ iv : new Uint8Array(16), mode : 'CBC|CFB|CTR|OFB|ECB' }`"]
+    ["options","JsVar","[optional] An object, may specify `{ iv : new Uint8Array(16), mode : 'CBC|CFB|CTR|OFB|ECB' }`"]
   ],
   "return" : ["JsVar","Returns an ArrayBuffer"],
   "return_object" : "ArrayBuffer",

--- a/libs/filesystem/jswrap_file.c
+++ b/libs/filesystem/jswrap_file.c
@@ -587,7 +587,7 @@ void jswrap_file_skip_or_seek(JsVar* parent, int nBytes, bool is_skip) {
   "generate" : "jswrap_pipe",
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
-    ["options","JsVar",["An optional object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ]
 }
 Pipe this file to a stream (an object with a 'write' method)
@@ -602,9 +602,9 @@ Pipe this file to a stream (an object with a 'write' method)
   "generate" : "jswrap_E_flashFatFS",
   "ifdef" : "USE_FLASHFS",
    "params" : [
-    ["options","JsVar",["An optional object `{ addr : int=0x300000, sectors : int=256, format : bool=false }`","addr : start address in flash","sectors: number of sectors to use","format:  Format the media"]]
+    ["options","JsVar",["[optional] An object `{ addr : int=0x300000, sectors : int=256, format : bool=false }`","addr : start address in flash","sectors: number of sectors to use","format:  Format the media"]]
   ],
-  "return" : ["bool","True on success, or false on failure"]  
+  "return" : ["bool","True on success, or false on failure"]
 }
 Change the parameters used for the flash filesystem. The default address is the
 last 1Mb of 4Mb Flash, 0x300000, with total size of 1Mb.

--- a/libs/graphics/jswrap_font_12x20.c
+++ b/libs/graphics/jswrap_font_12x20.c
@@ -348,7 +348,7 @@ static const unsigned char fontWidths[] = {
   "name" : "setFont12x20",
   "generate" : "jswrap_graphics_setFont12x20",
   "params" : [
-    ["scale","int","(optional) If >1 the font will be scaled up by that amount"]
+    ["scale","int","[optional] If >1 the font will be scaled up by that amount"]
   ],
   "return" : ["JsVar","The instance of Graphics this was called on, to allow call chaining"],
   "return_object" : "Graphics"

--- a/libs/graphics/jswrap_font_6x15.c
+++ b/libs/graphics/jswrap_font_6x15.c
@@ -160,7 +160,7 @@ static const unsigned char fontWidths[] = {
   "name" : "setFont6x15",
   "generate" : "jswrap_graphics_setFont6x15",
   "params" : [
-    ["scale","int","(optional) If >1 the font will be scaled up by that amount"]
+    ["scale","int","[optional] If >1 the font will be scaled up by that amount"]
   ],
   "return" : ["JsVar","The instance of Graphics this was called on, to allow call chaining"],
   "return_object" : "Graphics"

--- a/libs/graphics/jswrap_graphics.c
+++ b/libs/graphics/jswrap_graphics.c
@@ -1434,8 +1434,8 @@ unsigned int jswrap_graphics_blendColor(JsVar *parent, JsVar *ca, JsVar *cb, JsV
   "return" : ["JsVar","The instance of Graphics this was called on, to allow call chaining"],
   "return_object" : "Graphics",
   "typescript" : [
-    "setColor(r: number, g: number, b: number): number;",
-    "setColor(col: ColorResolvable): number;"
+    "setColor(r: number, g: number, b: number): Graphics;",
+    "setColor(col: ColorResolvable): Graphics;"
   ]
 }
 Set the color to use for subsequent drawing operations.
@@ -1469,8 +1469,8 @@ be a floating point value, and `g` and `b` are ignored.
   "return" : ["JsVar","The instance of Graphics this was called on, to allow call chaining"],
   "return_object" : "Graphics",
   "typescript" : [
-    "setBgColor(r: number, g: number, b: number): number;",
-    "setBgColor(col: ColorResolvable): number;"
+    "setBgColor(r: number, g: number, b: number): Graphics;",
+    "setBgColor(col: ColorResolvable): Graphics;"
   ]
 }
 Set the background color to use for subsequent drawing operations.

--- a/libs/misc/jswrap_emulated.c
+++ b/libs/misc/jswrap_emulated.c
@@ -62,7 +62,7 @@
     "generate_full" : "",
     "params" : [
       ["data","JsVar","The data to advertise as an object - see below for more info"],
-      ["options","JsVar","An optional object of options"]
+      ["options","JsVar","[optional] An object of options"]
     ]
 }*/
 /*JSON{

--- a/libs/network/http/jswrap_http.c
+++ b/libs/network/http/jswrap_http.c
@@ -132,7 +132,7 @@ Return a string containing characters that have been received
   "generate" : "jswrap_pipe",
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
-    ["options","JsVar",["An optional object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ]
 }
 Pipe this to a stream (an object with a 'write' method)
@@ -291,7 +291,7 @@ Return a string containing characters that have been received
   "generate" : "jswrap_pipe",
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
-    ["options","JsVar",["An optional object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ]
 }
 Pipe this to a stream (an object with a 'write' method)

--- a/libs/network/jswrap_net.c
+++ b/libs/network/jswrap_net.c
@@ -321,7 +321,7 @@ Return a string containing characters that have been received
   "generate" : "jswrap_pipe",
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
-    ["options","JsVar",["An optional object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ]
 }
 Pipe this to a stream (an object with a 'write' method)

--- a/libs/network/jswrap_wifi.c
+++ b/libs/network/jswrap_wifi.c
@@ -196,7 +196,7 @@ station by the esp8266's access point. The details include:
   "name"     : "disconnect",
   "generate" : "jswrap_wifi_disconnect",
   "params"   : [
-    ["callback", "JsVar", "An optional `callback()` function to be called back on disconnection. The callback function receives no argument."]
+    ["callback", "JsVar", "[optional] An `callback()` function to be called back on disconnection. The callback function receives no argument."]
   ]
 }
 Disconnect the wifi station from an access point and disable the station mode.
@@ -211,7 +211,7 @@ re-enabled by calling `connect` or `scan`.
   "name"     : "stopAP",
   "generate" : "jswrap_wifi_stopAP",
   "params"   : [
-    ["callback", "JsVar", "An optional `callback()` function to be called back on successful stop. The callback function receives no argument."]
+    ["callback", "JsVar", "[optional] An `callback()` function to be called back on successful stop. The callback function receives no argument."]
   ]
 }
 Stop being an access point and disable the AP operation mode. AP mode can be
@@ -226,7 +226,7 @@ re-enabled by calling `startAP`.
   "generate" : "jswrap_wifi_connect",
   "params"   : [
     ["ssid", "JsVar", "The access point network id."],
-    ["options", "JsVar", "Connection options (optional)."],
+    ["options", "JsVar", "[optional] Connection options."],
     ["callback", "JsVar", "A `callback(err)`  function to be called back on completion. `err` is null on success, or contains an error string on failure."]
   ],
   "typescript" : "function connect(ssid: string, options?: { password?: string, dnsServers?: string[], authMode?: string, channel?: number, bssid?: string }, callback?: (err: string | null) => void): void;"
@@ -299,7 +299,7 @@ Notes:
   "generate" : "jswrap_wifi_startAP",
   "params"   : [
     ["ssid", "JsVar", "The network id."],
-    ["options", "JsVar", "Configuration options (optional)."],
+    ["options", "JsVar", "[optional] Configuration options."],
     ["callback", "JsVar", "Optional `callback(err)` function to be called when the AP is successfully started. `err==null` on success, or an error string on failure."]
   ],
   "typescript" : "function startAP(ssid: string, options?: { password?: string, authMode?: \"open\" | \"wpa2\" | \"wpa\" | \"wpa_wpa2\", channel?: number, hidden?: boolean }, callback?: (err: string | null) => void): void;"
@@ -400,7 +400,7 @@ which all set the esp8266 opmode indirectly.
   "#if" : "defined(ESP32) || defined(ESP8266)",
   "return"   : ["JsVar", "An object representing the wifi station details, if available immediately."],
   "params"   : [
-    ["callback", "JsVar", "An optional `callback(details)` function to be called back with the wifi details, i.e. the same object as returned directly."]
+    ["callback", "JsVar", "[optional] An `callback(details)` function to be called back with the wifi details, i.e. the same object as returned directly."]
   ]
 }
 Retrieve the wifi station configuration and status details. The details object
@@ -431,7 +431,7 @@ has the following properties:
   "#if" : "defined(ESP32) || defined(ESP8266)",
   "return"   : ["JsVar", "An object representing the current access point details, if available immediately."],
   "params"   : [
-    ["callback", "JsVar", "An optional `callback(details)` function to be called back with the current access point details, i.e. the same object as returned directly."]
+    ["callback", "JsVar", "[optional] A `callback(details)` function to be called back with the current access point details, i.e. the same object as returned directly."]
   ]
 }
 Retrieve the current access point configuration and status. The details object
@@ -495,7 +495,7 @@ Restores the saved Wifi configuration from flash. See `Wifi.save()`.
   "generate" : "jswrap_wifi_getIP",
   "return"   : ["JsVar", "An object representing the station IP information, if available immediately (**ONLY** on ESP8266/ESP32)."],
   "params"   : [
-    ["callback", "JsVar", "An optional `callback(err, ipinfo)` function to be called back with the IP information."]
+    ["callback", "JsVar", "[optional] A `callback(err, ipinfo)` function to be called back with the IP information."]
   ]
 }
 Return the station IP information in an object as follows:
@@ -515,7 +515,7 @@ Note that the `ip`, `netmask`, and `gw` fields are omitted if no connection is e
   "generate" : "jswrap_wifi_getAPIP",
   "return"   : ["JsVar", "An object representing the esp8266's Access Point IP information, if available immediately (**ONLY** on ESP8266/ESP32)."],
   "params"   : [
-    ["callback", "JsVar", "An optional `callback(err, ipinfo)` function to be called back with the the IP information."]
+    ["callback", "JsVar", "[optional] A `callback(err, ipinfo)` function to be called back with the the IP information."]
   ]
 }
 Return the access point IP information in an object which contains:
@@ -553,7 +553,7 @@ lookups are not supported.
   "#if" : "defined(ESP8266)  || defined(ESP32)",
   "return"   : ["JsVar", "The currently configured hostname, if available immediately."],
   "params"   : [
-    ["callback", "JsVar", "An optional `callback(hostname)` function to be called back with the hostname."]
+    ["callback", "JsVar", "[optional] A `callback(hostname)` function to be called back with the hostname."]
   ]
 }
 Returns the hostname announced to the DHCP server and broadcast via mDNS when
@@ -568,7 +568,7 @@ connecting to an access point.
   "#if" : "defined(ESP8266) || defined(ESPRUINOWIFI) || defined(ESP32)",
   "params"   : [
     ["hostname", "JsVar", "The new hostname."],
-    ["callback", "JsVar", "An optional `callback()` function to be called back when the hostname is set"]
+    ["callback", "JsVar", "[optional] A `callback()` function to be called back when the hostname is set"]
   ]
 }
 Set the hostname. Depending on implementation, the hostname is sent with every

--- a/libs/network/wiznet/jswrap_wiznet.c
+++ b/libs/network/wiznet/jswrap_wiznet.c
@@ -177,7 +177,7 @@ An instantiation of an Ethernet network adaptor
   "name" : "getIP",
   "generate" : "jswrap_ethernet_getIP",
   "params" : [
-    ["options","JsVar","An optional `callback(err, ipinfo)` function to be called back with the IP information."]
+    ["options","JsVar","[optional] An `callback(err, ipinfo)` function to be called back with the IP information."]
   ],
   "return" : ["JsVar",""]
 }
@@ -241,7 +241,7 @@ static void _eth_getIP_set_address(JsVar *options, char *name, unsigned char *pt
   "generate" : "jswrap_ethernet_setIP",
   "params" : [
     ["options","JsVar","Object containing IP address options `{ ip : '1.2.3.4', subnet : '...', gateway: '...', dns:'...', mac:':::::'  }`, or do not supply an object in order to force DHCP."],
-    ["callback","JsVar","An optional `callback(err)` function to invoke when ip is set. `err==null` on success, or a string on failure."]
+    ["callback","JsVar","[optional] An `callback(err)` function to invoke when ip is set. `err==null` on success, or a string on failure."]
   ],
   "return" : ["bool","True on success"]
 }
@@ -330,7 +330,7 @@ bool jswrap_ethernet_setIP(JsVar *wlanObj, JsVar *options, JsVar *callback) {
   "generate" : "jswrap_ethernet_setHostname",
   "params" : [
     ["hostname","JsVar","hostname as string"],
-    ["callback","JsVar","An optional `callback(err)` function to be called back with null or error text."]
+    ["callback","JsVar","[optional] An `callback(err)` function to be called back with null or error text."]
   ],
   "return" : ["bool","True on success"]
 }
@@ -369,7 +369,7 @@ bool jswrap_ethernet_setHostname(JsVar *wlanObj, JsVar *jsHostname, JsVar *callb
   "name" : "getHostname",
   "generate" : "jswrap_ethernet_getHostname",
   "params" : [
-    ["callback","JsVar","An optional `callback(err,hostname)` function to be called back with the status information."]
+    ["callback","JsVar","[optional] An `callback(err,hostname)` function to be called back with the status information."]
   ],
   "return" : ["JsVar" ]
 }
@@ -398,7 +398,7 @@ JsVar * jswrap_ethernet_getHostname(JsVar *wlanObj, JsVar *callback) {
   "name" : "getStatus",
   "generate" : "jswrap_ethernet_getStatus",
   "params" : [
-    ["options","JsVar","An optional `callback(err, status)` function to be called back with the status information."]
+    ["options","JsVar","[optional] An `callback(err, status)` function to be called back with the status information."]
   ],
   "return" : ["JsVar" ]
 }

--- a/libs/pixljs/jswrap_pixljs.c
+++ b/libs/pixljs/jswrap_pixljs.c
@@ -533,6 +533,7 @@ type MenuOptions = {
   back?: () => void;
   selected?: number;
   fontHeight?: number;
+  scroll?: number;
   x?: number;
   y?: number;
   x2?: number;
@@ -633,7 +634,7 @@ See http://www.espruino.com/graphical_menu for more detailed information.
     "generate_js" : "libs/js/pixljs/E_showMessage.min.js",
     "params" : [
       ["message","JsVar","A message to display. Can include newlines"],
-      ["title","JsVar","(optional) a title for the message"]
+      ["title","JsVar","[optional] a title for the message"]
     ],
     "ifdef" : "PIXLJS",
     "typescript" : "showMessage(message: string, title?: string): void;"
@@ -655,7 +656,7 @@ E.showMessage("These are\nLots of\nLines","My Title")
     "generate_js" : "libs/js/pixljs/E_showPrompt.min.js",
     "params" : [
       ["message","JsVar","A message to display. Can include newlines"],
-      ["options","JsVar","(optional) an object of options (see below)"]
+      ["options","JsVar","[optional] an object of options (see below)"]
     ],
     "return" : ["JsVar","A promise that is resolved when 'Ok' is pressed"],
     "ifdef" : "PIXLJS",
@@ -704,7 +705,7 @@ The second `options` argument can contain:
     "generate_js" : "libs/js/pixljs/E_showAlert.min.js",
     "params" : [
       ["message","JsVar","A message to display. Can include newlines"],
-      ["options","JsVar","(optional) a title for the message"]
+      ["options","JsVar","[optional] a title for the message"]
     ],
     "return" : ["JsVar","A promise that is resolved when 'Ok' is pressed"],
     "ifdef" : "PIXLJS",

--- a/libs/puckjs/jswrap_puck.c
+++ b/libs/puckjs/jswrap_puck.c
@@ -1124,8 +1124,8 @@ int jswrap_puck_accelRd(JsVarInt reg) {
   "generate" : "jswrap_puck_IR",
   "params" : [
       ["data","JsVar","An array of pulse lengths, in milliseconds"],
-      ["cathode","pin","(optional) pin to use for IR LED cathode - if not defined, the built-in IR LED is used"],
-      ["anode","pin","(optional) pin to use for IR LED anode - if not defined, the built-in IR LED is used"]
+      ["cathode","pin","[optional] pin to use for IR LED cathode - if not defined, the built-in IR LED is used"],
+      ["anode","pin","[optional] pin to use for IR LED anode - if not defined, the built-in IR LED is used"]
   ]
 }
 Transmit the given set of IR pulses - data should be an array of pulse times in

--- a/src/jswrap_array.c
+++ b/src/jswrap_array.c
@@ -111,7 +111,7 @@ Find the length of the array
   "generate" : "jswrap_array_indexOf",
   "params" : [
     ["value","JsVar","The value to check for"],
-    ["startIndex","int","(optional) the index to search from, or 0 if not specified"]
+    ["startIndex","int","[optional] the index to search from, or 0 if not specified"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "typescript" : "indexOf(value: T, startIndex?: number): number;"
@@ -133,7 +133,7 @@ JsVar *jswrap_array_indexOf(JsVar *parent, JsVar *value, JsVarInt startIdx) {
   "generate" : "jswrap_array_includes",
   "params" : [
     ["value","JsVar","The value to check for"],
-    ["startIndex","int","(optional) the index to search from, or 0 if not specified"]
+    ["startIndex","int","[optional] the index to search from, or 0 if not specified"]
   ],
   "return" : ["bool","`true` if the array includes the value, `false` otherwise"],
   "typescript" : "includes(value: T, startIndex?: number): boolean;"
@@ -345,7 +345,7 @@ static JsVar *_jswrap_array_iterate_with_callback(
   "generate" : "jswrap_array_map",
   "params" : [
     ["function","JsVar","Function used to map one item to another"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "return" : ["JsVar","An array containing the results"],
   "typescript" : "map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];"
@@ -364,7 +364,7 @@ JsVar *jswrap_array_map(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   "generate" : "jswrap_array_forEach",
   "params" : [
     ["function","JsVar","Function to be executed"],
-    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "typescript" : "forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;"
 }
@@ -381,7 +381,7 @@ void jswrap_array_forEach(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   "generate" : "jswrap_array_filter",
   "params" : [
     ["function","JsVar","Function to be executed"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "return" : ["JsVar","An array containing the results"],
   "typescript" : [
@@ -456,7 +456,7 @@ JsVar *jswrap_array_findIndex(JsVar *parent, JsVar *funcVar) {
   "generate" : "jswrap_array_some",
   "params" : [
     ["function","JsVar","Function to be executed"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "return" : ["JsVar","A boolean containing the result"],
   "typescript" : "some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;"
@@ -475,7 +475,7 @@ JsVar *jswrap_array_some(JsVar *parent, JsVar *funcVar, JsVar *thisVar) {
   "generate" : "jswrap_array_every",
   "params" : [
     ["function","JsVar","Function to be executed"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "return" : ["JsVar","A boolean containing the result"],
   "typescript" : "every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;"
@@ -704,7 +704,7 @@ JsVarInt jswrap_array_unshift(JsVar *parent, JsVar *elements) {
   "generate" : "jswrap_array_slice",
   "params" : [
     ["start","int","Start index"],
-    ["end","JsVar","End index (optional)"]
+    ["end","JsVar","[optional] End index"]
   ],
   "return" : ["JsVar","A new array"],
   "typescript" : "slice(start?: number, end?: number): T[];"

--- a/src/jswrap_arraybuffer.c
+++ b/src/jswrap_arraybuffer.c
@@ -608,7 +608,7 @@ The offset, in bytes, to the first byte of the view within the backing
   "generate" : "jswrap_arraybufferview_set",
   "params" : [
     ["arr","JsVar","Floating point index to access"],
-    ["offset","int32","The offset in this array at which to write the values (optional)"]
+    ["offset","int32","[optional] The offset in this array at which to write the values"]
   ],
   "typescript" : "set(arr: ArrayLike<number>, offset: number): void"
 }
@@ -670,7 +670,7 @@ void jswrap_arraybufferview_set(JsVar *parent, JsVar *arr, int offset) {
   "generate" : "jswrap_arraybufferview_map",
   "params" : [
     ["function","JsVar","Function used to map one item to another"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "return" : ["JsVar","An array containing the results"],
   "return_object" : "ArrayBufferView",
@@ -793,7 +793,7 @@ JsVar *jswrap_arraybufferview_subarray(JsVar *parent, JsVarInt begin, JsVar *end
   "generate" : "jswrap_array_indexOf",
   "params" : [
     ["value","JsVar","The value to check for"],
-    ["startIndex","int","(optional) the index to search from, or 0 if not specified"]
+    ["startIndex","int","[optional] the index to search from, or 0 if not specified"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "typescript" : "indexOf(value: number, startIndex?: number): number;"
@@ -808,7 +808,7 @@ Return the index of the value in the array, or `-1`
   "generate" : "jswrap_array_includes",
   "params" : [
     ["value","JsVar","The value to check for"],
-    ["startIndex","int","(optional) the index to search from, or 0 if not specified"]
+    ["startIndex","int","[optional] the index to search from, or 0 if not specified"]
   ],
   "return" : ["bool","`true` if the array includes the value, `false` otherwise"],
   "typescript" : "includes(value: number, startIndex?: number): boolean;"
@@ -875,7 +875,7 @@ JsVar *jswrap_arraybufferview_sort(JsVar *array, JsVar *compareFn) {
   "generate" : "jswrap_array_forEach",
   "params" : [
     ["function","JsVar","Function to be executed"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "typescript" : "forEach(callbackfn: (value: number, index: number, array: T) => void, thisArg?: any): void;"
 }
@@ -923,7 +923,7 @@ Fill this array with the given value, for every index `>= start` and `< end`
   "generate" : "jswrap_array_filter",
   "params" : [
     ["function","JsVar","Function to be executed"],
-    ["thisArg","JsVar","if specified, the function is called with 'this' set to thisArg (optional)"]
+    ["thisArg","JsVar","[optional] If specified, the function is called with 'this' set to thisArg"]
   ],
   "return" : ["JsVar","An array containing the results"],
   "typescript" : "filter(predicate: (value: number, index: number, array: T) => any, thisArg?: any): T;"
@@ -981,7 +981,7 @@ Reverse the contents of this `ArrayBufferView` in-place
   "generate" : "jswrap_array_slice",
   "params" : [
     ["start","int","Start index"],
-    ["end","JsVar","End index (optional)"]
+    ["end","JsVar","[optional] End index"]
   ],
   "return" : ["JsVar","A new array"],
   "return_object" : "Array",

--- a/src/jswrap_dataview.c
+++ b/src/jswrap_dataview.c
@@ -34,8 +34,8 @@ This class helps
   "generate" : "jswrap_dataview_constructor",
   "params" : [
     ["buffer","JsVar","The `ArrayBuffer` to base this on"],
-    ["byteOffset","int","(optional) The offset of this view in bytes"],
-    ["byteLength","int","(optional) The length in bytes"]
+    ["byteOffset","int","[optional] The offset of this view in bytes"],
+    ["byteLength","int","[optional] The length in bytes"]
   ],
   "return" : ["JsVar","A `DataView` object"],
   "return_object" : "DataView",
@@ -121,7 +121,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_FLOAT32, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -135,7 +135,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_FLOAT64, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -149,7 +149,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_INT8, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -163,7 +163,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_INT16, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -177,7 +177,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_INT32, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -191,7 +191,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_UINT8, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -205,7 +205,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_UINT16, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -219,7 +219,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "generate_full" : "jswrap_dataview_get(parent, ARRAYBUFFERVIEW_UINT32, byteOffset, littleEndian)",
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "return" : ["JsVar","the index of the value in the array, or -1"],
   "ifndef" : "SAVE_ON_FLASH",
@@ -237,7 +237,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setFloat32(byteOffset: number, value: number, littleEndian?: boolean): void;"
@@ -251,7 +251,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setFloat64(byteOffset: number, value: number, littleEndian?: boolean): void;"
@@ -265,7 +265,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setInt8(byteOffset: number, value: number, littleEndian?: boolean): void;"
@@ -279,7 +279,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setInt16(byteOffset: number, value: number, littleEndian?: boolean): void;"
@@ -293,7 +293,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setInt32(byteOffset: number, value: number, littleEndian?: boolean): void;"
@@ -307,7 +307,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setUint8(byteOffset: number, value: number, littleEndian?: boolean): void;"
@@ -321,7 +321,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setUint16(byteOffset: number, value: number, littleEndian?: boolean): void;"
@@ -335,7 +335,7 @@ void jswrap_dataview_set(JsVar *dataview, JsVarDataArrayBufferViewType type, int
   "params" : [
     ["byteOffset","int","The offset in bytes to read from"],
     ["value","JsVar","The value to write"],
-    ["littleEndian","bool","(optional) Whether to read in little endian - if false or undefined data is read as big endian"]
+    ["littleEndian","bool","[optional] Whether to read in little endian - if false or undefined data is read as big endian"]
   ],
   "ifndef" : "SAVE_ON_FLASH",
   "typescript" : "setUint32(byteOffset: number, value: number, littleEndian?: boolean): void;"

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -495,8 +495,8 @@ int jswrap_date_getFullYear(JsVar *parent) {
   "params" : [
     ["hoursValue","int","number of hours, 0..23"],
     ["minutesValue","JsVar","number of minutes, 0..59"],
-    ["secondsValue","JsVar","optional - number of seconds, 0..59"],
-    ["millisecondsValue","JsVar","optional - number of milliseconds, 0..999"]
+    ["secondsValue","JsVar","[optional] number of seconds, 0..59"],
+    ["millisecondsValue","JsVar","[optional] number of milliseconds, 0..999"]
   ],
   "return" : ["float","The number of milliseconds since 1970"],
   "typescript" : "setHours(hoursValue: number, minutesValue?: number, secondsValue?: number, millisecondsValue?: number): number;"
@@ -524,8 +524,8 @@ JsVarFloat jswrap_date_setHours(JsVar *parent, int hoursValue, JsVar *minutesVal
   "generate" : "jswrap_date_setMinutes",
   "params" : [
     ["minutesValue","int","number of minutes, 0..59"],
-    ["secondsValue","JsVar","optional - number of seconds, 0..59"],
-    ["millisecondsValue","JsVar","optional - number of milliseconds, 0..999"]
+    ["secondsValue","JsVar","[optional] number of seconds, 0..59"],
+    ["millisecondsValue","JsVar","[optional] number of milliseconds, 0..999"]
   ],
   "return" : ["float","The number of milliseconds since 1970"],
   "typescript" : "setMinutes(minutesValue: number, secondsValue?: number, millisecondsValue?: number): number;"
@@ -551,7 +551,7 @@ JsVarFloat jswrap_date_setMinutes(JsVar *parent, int minutesValue, JsVar *second
   "generate" : "jswrap_date_setSeconds",
   "params" : [
     ["secondsValue","int","number of seconds, 0..59"],
-    ["millisecondsValue","JsVar","optional - number of milliseconds, 0..999"]
+    ["millisecondsValue","JsVar","[optional] number of milliseconds, 0..999"]
   ],
   "return" : ["float","The number of milliseconds since 1970"],
   "typescript" : "setSeconds(secondsValue: number, millisecondsValue?: number): number;"
@@ -617,7 +617,7 @@ JsVarFloat jswrap_date_setDate(JsVar *parent, int dayValue) {
   "generate" : "jswrap_date_setMonth",
   "params" : [
     ["yearValue","int","The month, between 0 and 11"],
-    ["dayValue","JsVar","optional - the day, between 0 and 31"]
+    ["dayValue","JsVar","[optional] the day, between 0 and 31"]
   ],
   "return" : ["float","The number of milliseconds since 1970"],
   "typescript" : "setMonth(yearValue: number, dayValue?: number): number;"
@@ -643,8 +643,8 @@ JsVarFloat jswrap_date_setMonth(JsVar *parent, int monthValue, JsVar *dayValue) 
   "generate" : "jswrap_date_setFullYear",
   "params" : [
     ["yearValue","int","The full year - eg. 1989"],
-    ["monthValue","JsVar","optional - the month, between 0 and 11"],
-    ["dayValue","JsVar","optional - the day, between 0 and 31"]
+    ["monthValue","JsVar","[optional] the month, between 0 and 11"],
+    ["dayValue","JsVar","[optional] the day, between 0 and 31"]
   ],
   "return" : ["float","The number of milliseconds since 1970"],
   "typescript" : "setFullYear(yearValue: number, monthValue?: number, dayValue?: number): number;"

--- a/src/jswrap_error.c
+++ b/src/jswrap_error.c
@@ -67,7 +67,7 @@ JsVar *_jswrap_error_constructor(JsVar *msg, char *type) {
   "name" : "Error",
   "generate" : "jswrap_error_constructor",
   "params" : [
-    ["message","JsVar","An optional message string"]
+    ["message","JsVar","[optional] An message string"]
   ],
   "return" : ["JsVar","An Error object"],
   "typescript" : "new(message?: string): Error;"
@@ -83,7 +83,7 @@ JsVar *jswrap_error_constructor(JsVar *msg) {
   "name" : "SyntaxError",
   "generate" : "jswrap_syntaxerror_constructor",
   "params" : [
-    ["message","JsVar","An optional message string"]
+    ["message","JsVar","[optional] An message string"]
   ],
   "return" : ["JsVar","A SyntaxError object"],
   "typescript" : "new(message?: string): SyntaxError;"
@@ -99,7 +99,7 @@ JsVar *jswrap_syntaxerror_constructor(JsVar *msg) {
   "name" : "TypeError",
   "generate" : "jswrap_typeerror_constructor",
   "params" : [
-    ["message","JsVar","An optional message string"]
+    ["message","JsVar","[optional] An message string"]
   ],
   "return" : ["JsVar","A TypeError object"],
   "typescript" : "new(message?: string): TypeError;"
@@ -115,7 +115,7 @@ JsVar *jswrap_typeerror_constructor(JsVar *msg) {
   "name" : "InternalError",
   "generate" : "jswrap_internalerror_constructor",
   "params" : [
-    ["message","JsVar","An optional message string"]
+    ["message","JsVar","[optional] An message string"]
   ],
   "return" : ["JsVar","An InternalError object"],
   "typescript" : "new(message?: string): InternalError;"
@@ -132,7 +132,7 @@ JsVar *jswrap_internalerror_constructor(JsVar *msg) {
   "name" : "ReferenceError",
   "generate" : "jswrap_referenceerror_constructor",
   "params" : [
-    ["message","JsVar","An optional message string"]
+    ["message","JsVar","[optional] An message string"]
   ],
   "return" : ["JsVar","A ReferenceError object"],
   "typescript" : "new(message?: string): ReferenceError;"

--- a/src/jswrap_espruino.c
+++ b/src/jswrap_espruino.c
@@ -778,7 +778,7 @@ their values.
   "params" : [
     ["source","JsVar","The source file/stream that will send content."],
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
-    ["options","JsVar",["An optional object `{ chunkSize : int=64, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=64, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ],
   "typescript" : "pipe(source: any, destination: any, options?: { chunkSize?: number, end?: boolean, complete?: () => void }): void"
 }*/
@@ -1096,7 +1096,7 @@ int jswrap_espruino_setClock(JsVar *options) {
   "generate" : "jswrap_espruino_setConsole",
   "params" : [
     ["device","JsVar",""],
-    ["options","JsVar","(optional) object of options, see below"]
+    ["options","JsVar","[optional] object of options, see below"]
   ],
   "typescript" : "setConsole(device: \"Serial1\" | \"USB\" | \"Bluetooth\" | \"Telnet\" | \"Terminal\" | Serial | null, options?: { force?: boolean }): void;"
 }

--- a/src/jswrap_functions.c
+++ b/src/jswrap_functions.c
@@ -143,7 +143,7 @@ JsVar *jswrap_eval(JsVar *v) {
   "generate" : "jswrap_parseInt",
   "params" : [
     ["string","JsVar",""],
-    ["radix","JsVar","The Radix of the string (optional)"]
+    ["radix","JsVar","[optional] The Radix of the string"]
   ],
   "return" : ["JsVar","The integer value of the string (or NaN)"]
 }

--- a/src/jswrap_interactive.c
+++ b/src/jswrap_interactive.c
@@ -131,7 +131,7 @@ need to recreate these in the `onInit` function.
   "name" : "load",
   "generate" : "jswrap_interface_load",
   "params" : [
-    ["filename","JsVar","optional: The name of a text JS file to load from Storage after reset"]
+    ["filename","JsVar","[optional] The name of a text JS file to load from Storage after reset"]
   ]
 }
 Restart and load the program out of flash - this has an effect similar to

--- a/src/jswrap_io.c
+++ b/src/jswrap_io.c
@@ -30,7 +30,7 @@
   "generate_full" : "jswrap_io_peek(addr,count,1)",
   "params"        : [
     ["addr", "int", "The address in memory to read"],
-    ["count", "int", "(optional) the number of items to read. If >1 a Uint8Array will be returned."]
+    ["count", "int", "[optional] the number of items to read. If >1 a Uint8Array will be returned."]
   ],
   "return"        : ["JsVar","The value of memory at the given location"],
   "typescript"    : [
@@ -58,7 +58,7 @@ Write 8 bits of memory at the given location - VERY DANGEROUS!
   "generate_full" : "jswrap_io_peek(addr,count,2)",
   "params" : [
     ["addr","int","The address in memory to read"],
-    ["count","int","(optional) the number of items to read. If >1 a Uint16Array will be returned."]
+    ["count","int","[optional] the number of items to read. If >1 a Uint16Array will be returned."]
   ],
   "return" : ["JsVar","The value of memory at the given location"],
   "typescript" : [
@@ -86,7 +86,7 @@ Write 16 bits of memory at the given location - VERY DANGEROUS!
   "generate_full" : "jswrap_io_peek(addr,count,4)",
   "params" : [
     ["addr","int","The address in memory to read"],
-    ["count","int","(optional) the number of items to read. If >1 a Uint32Array will be returned."]
+    ["count","int","[optional] the number of items to read. If >1 a Uint32Array will be returned."]
   ],
   "return" : ["JsVar","The value of memory at the given location"],
   "typescript" : [

--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -113,7 +113,8 @@ JsVar *jswrap_object_valueOf(JsVar *parent) {
   "params" : [
     ["radix","JsVar","If the object is an integer, the radix (between 2 and 36) to use. NOTE: Setting a radix does not work on floating point numbers."]
   ],
-  "return" : ["JsVar","A String representing the object"]
+  "return" : ["JsVar","A String representing the object"],
+  "return_object" : "string"
 }
 Convert the Object to a string
  */
@@ -154,7 +155,8 @@ JsVar *jswrap_object_clone(JsVar *parent) {
   "params" : [
     ["object","JsVar","The object to return keys for"]
   ],
-  "return" : ["JsVar","An array of strings - one for each key on the given object"]
+  "return" : ["JsVar","An array of strings - one for each key on the given object"],
+  "return_object" : "Array<any>"
 }
 Return all enumerable keys of the given object
  */
@@ -166,7 +168,8 @@ Return all enumerable keys of the given object
   "params" : [
     ["object","JsVar","The Object to return a list of property names for"]
   ],
-  "return" : ["JsVar","An array of the Object's own properties"]
+  "return" : ["JsVar","An array of the Object's own properties"],
+  "return_object" : "Array<any>"
 }
 Returns an array of all properties (enumerable or not) found directly on a given
 object.
@@ -309,7 +312,8 @@ JsVar *jswrap_object_keys_or_property_names(
   "params" : [
     ["object","JsVar","The object to return values for"]
   ],
-  "return" : ["JsVar","An array of values - one for each key on the given object"]
+  "return" : ["JsVar","An array of values - one for each key on the given object"],
+  "return_object" : "Array<any>"
 }
 Return all enumerable values of the given object
  */
@@ -322,7 +326,8 @@ Return all enumerable values of the given object
   "params" : [
     ["object","JsVar","The object to return values for"]
   ],
-  "return" : ["JsVar","An array of `[key,value]` pairs - one for each key on the given object"]
+  "return" : ["JsVar","An array of `[key,value]` pairs - one for each key on the given object"],
+  "return_object" : "Array<[string, any]>"
 }
 Return all enumerable keys and values of the given object
  */

--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -111,7 +111,7 @@ JsVar *jswrap_object_valueOf(JsVar *parent) {
   "name" : "toString",
   "generate" : "jswrap_object_toString",
   "params" : [
-    ["radix","JsVar","If the object is an integer, the radix (between 2 and 36) to use. NOTE: Setting a radix does not work on floating point numbers."]
+    ["radix","JsVar","[optional] If the object is an integer, the radix (between 2 and 36) to use. NOTE: Setting a radix does not work on floating point numbers."]
   ],
   "return" : ["JsVar","A String representing the object"],
   "return_object" : "string"

--- a/src/jswrap_onewire.c
+++ b/src/jswrap_onewire.c
@@ -220,7 +220,7 @@ void jswrap_onewire_write(JsVar *parent, JsVar *data, bool leavePowerOn) {
   "class" : "OneWire",
   "name" : "read",
   "generate" : "jswrap_onewire_read",
-  "params" : [["count","JsVar","(optional) The amount of bytes to read"]],
+  "params" : [["count","JsVar","[optional] The amount of bytes to read"]],
   "return" : ["JsVar","The byte that was read, or a Uint8Array if count was specified and >=0"]
 }
 Read a byte

--- a/src/jswrap_pipe.c
+++ b/src/jswrap_pipe.c
@@ -245,7 +245,7 @@ static void jswrap_pipe_dst_close_listener(JsVar *destination) {
   "params" : [
     ["source","JsVar","The source file/stream that will send content."],
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
-    ["options","JsVar",["An optional object `{ chunkSize : int=64, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=64, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ]
 }*/
 void jswrap_pipe(JsVar* source, JsVar* dest, JsVar* options) {

--- a/src/jswrap_process.c
+++ b/src/jswrap_process.c
@@ -171,7 +171,7 @@ JsVar *jswrap_process_env() {
   "name" : "memory",
   "generate" : "jswrap_process_memory",
   "params" : [
-    ["gc","JsVar","An optional boolean. If `undefined` or `true` Garbage collection is performed, if `false` it is not"]
+    ["gc","JsVar","[optional] A boolean. If `undefined` or `true` Garbage collection is performed, if `false` it is not"]
   ],
   "return" : ["JsVar","Information about memory usage"]
 }

--- a/src/jswrap_serial.c
+++ b/src/jswrap_serial.c
@@ -228,7 +228,7 @@ void jswrap_serial_setConsole(JsVar *parent, bool force) {
   "generate" : "jswrap_serial_setup",
   "params" : [
     ["baudrate","JsVar","The baud rate - the default is 9600"],
-    ["options","JsVar","An optional structure containing extra information on initialising the serial port - see below."]
+    ["options","JsVar","[optional] A structure containing extra information on initialising the serial port - see below."]
   ]
 }
 Setup this Serial port with the given baud rate and options.
@@ -533,7 +533,7 @@ Return a string containing characters that have been received
   "generate" : "jswrap_pipe",
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
-    ["options","JsVar",["An optional object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ]
 }
 Pipe this USART to a stream (an object with a 'write' method)

--- a/src/jswrap_spi_i2c.c
+++ b/src/jswrap_spi_i2c.c
@@ -579,7 +579,7 @@ The third I2C port
   "name" : "setup",
   "generate" : "jswrap_i2c_setup",
   "params" : [
-    ["options","JsVar",["An optional structure containing extra information on initialising the I2C port","```{scl:pin, sda:pin, bitrate:100000}```","You can find out which pins to use by looking at [your board's reference page](#boards) and searching for pins with the `I2C` marker. Note that 400kHz is the maximum bitrate for most parts."]]
+    ["options","JsVar",["[optional] A structure containing extra information on initialising the I2C port","```{scl:pin, sda:pin, bitrate:100000}```","You can find out which pins to use by looking at [your board's reference page](#boards) and searching for pins with the `I2C` marker. Note that 400kHz is the maximum bitrate for most parts."]]
   ]
 }
 Set up this I2C port

--- a/src/jswrap_storage.c
+++ b/src/jswrap_storage.c
@@ -106,8 +106,8 @@ void jswrap_storage_erase(JsVar *name) {
   "generate" : "jswrap_storage_read",
   "params" : [
     ["name","JsVar","The filename - max 28 characters (case sensitive)"],
-    ["offset","int","(optional) The offset in bytes to start from"],
-    ["length","int","(optional) The length to read in bytes (if <=0, the entire file is read)"]
+    ["offset","int","[optional] The offset in bytes to start from"],
+    ["length","int","[optional] The length to read in bytes (if <=0, the entire file is read)"]
   ],
   "return" : ["JsVar","A string of data, or `undefined` if the file is not found"],
   "typescript" : "read(name: string, offset?: number, length?: number): string | undefined;"
@@ -299,8 +299,8 @@ bool jswrap_storage_writeJSON(JsVar *name, JsVar *data) {
   "name" : "list",
   "generate" : "jswrap_storage_list",
   "params" : [
-    ["regex","JsVar","(optional) If supplied, filenames are checked against this regular expression (with `String.match(regexp)`) to see if they match before being returned"],
-    ["filter","JsVar","(optional) If supplied, File Types are filtered based on this: `{sf:true}` or `{sf:false}` for whether to show StorageFile"]
+    ["regex","JsVar","[optional] If supplied, filenames are checked against this regular expression (with `String.match(regexp)`) to see if they match before being returned"],
+    ["filter","JsVar","[optional] If supplied, File Types are filtered based on this: `{sf:true}` or `{sf:false}` for whether to show StorageFile"]
   ],
   "return" : ["JsVar","An array of filenames"],
   "typescript" : "list(regex?: RegExp, filter?: { sf: boolean }): string[];"
@@ -346,7 +346,7 @@ JsVar *jswrap_storage_list(JsVar *regex, JsVar *filter) {
   "name" : "hash",
   "generate" : "jswrap_storage_hash",
   "params" : [
-    ["regex","JsVar","(optional) If supplied, filenames are checked against this regular expression (with `String.match(regexp)`) to see if they match before being hashed"]
+    ["regex","JsVar","[optional] If supplied, filenames are checked against this regular expression (with `String.match(regexp)`) to see if they match before being hashed"]
   ],
   "return" : ["int","A hash of the files matching"],
   "typescript" : "hash(regex: RegExp): number;"


### PR DESCRIPTION
This updates a few methods on `Bangle`, `Object` and `Graphics`, along with changing documented optional properties/arguments to match the `"[optional]"` format used in [build_types.js](https://github.com/espruino/Espruino/blob/149a7f6bace3a56c1892de47bd8baacfb3f496a5/scripts/build_types.js#L132-L132)