### PR TITLE
Free in reverse order

### DIFF
--- a/src/jsvar.c
+++ b/src/jsvar.c
@@ -724,7 +724,7 @@ ALWAYS_INLINE void jsvFreePtr(JsVar *var) {
     can be ints or strings */
 
   if (jsvHasChildren(var)) {
-    JsVarRef childref = jsvGetFirstChild(var);
+    JsVarRef childref = jsvGetLastChild(var);
 #ifdef CLEAR_MEMORY_ON_FREE
     jsvSetFirstChild(var, 0);
     jsvSetLastChild(var, 0);
@@ -732,7 +732,7 @@ ALWAYS_INLINE void jsvFreePtr(JsVar *var) {
     while (childref) {
       JsVar *child = jsvLock(childref);
       assert(jsvIsName(child));
-      childref = jsvGetNextSibling(child);
+      childref = jsvGetPrevSibling(child);
       jsvSetPrevSibling(child, 0);
       jsvSetNextSibling(child, 0);
       jsvUnRef(child);


### PR DESCRIPTION
Currently, StringExt blocks as well as children are freed in order. This leads to backward links, e.g.

1: String
2: StringExt
3: StringExt

creates 1 -> 3 -> 2 and

1: Object
2: first name or index
3: first value
4: second name or index
5: second value

creates 1 -> 4 -> 5 -> 2 -> 3

This PR reverses the order. It shouldn't have a significant performance impact but lead to less fragmentation and less frequent GC