### PR TITLE
Implement `Object.fromEntries`

### DIFF
--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -356,6 +356,38 @@ JsVar *jswrap_object_values_or_entries(JsVar *object, bool returnEntries) {
   return cbData[0];
 }
 
+/*JSON{
+  "type" : "staticmethod",
+  "class" : "Object",
+  "name" : "fromEntries",
+  "ifndef" : "SAVE_ON_FLASH",
+  "generate_full" : "jswrap_object_fromentries(entries);",
+  "params" : [
+    ["entries","JsVar","An array of `[key,value]` pairs to be used to create an object"]
+  ],
+  "return" : ["JsVar","An object containing all the specified pairs"],
+  "return_object" : "any"
+}
+Return all enumerable keys and values of the given object
+ */
+JsVar *jswrap_object_fromentries(JsVar *entries) {
+  JsVar *obj = jsvNewObject();
+  if (!obj) return 0;
+  JsvObjectIterator it;
+  jsvObjectIteratorNew(&it, entries);
+  while (jsvObjectIteratorHasValue(&it)) {
+    JsVar *key = jsvObjectIteratorGetKey(&it);
+    JsVar *value = jsvObjectIteratorGetValue(&it);
+    if (jsvIsString(key)) {
+      jsvObjectSetChildAndUnLock(obj, key, value);
+    } else {
+      jsvUnLock(key);
+      jsvUnLock(value);
+    }
+    jsvObjectIteratorNext(&it);
+  }
+  return obj;
+}
 
 /*JSON{
   "type" : "staticmethod",

--- a/src/jswrap_object.h
+++ b/src/jswrap_object.h
@@ -41,6 +41,7 @@ JsVar *jswrap_object_keys_or_property_names(
     JsVar *obj,
     JswObjectKeysOrPropertiesFlags flags);
 JsVar *jswrap_object_values_or_entries(JsVar *object, bool returnEntries);
+JsVar *jswrap_object_fromentries(JsVar *entries);
 JsVar *jswrap_object_create(JsVar *proto, JsVar *propertiesObject);
 JsVar *jswrap_object_getOwnPropertyDescriptor(JsVar *parent, JsVar *name);
 bool jswrap_object_hasOwnProperty(JsVar *parent, JsVar *name);

--- a/tests/test_object_fromEntries.js
+++ b/tests/test_object_fromEntries.js
@@ -1,0 +1,14 @@
+var tests=0,testpass=0;
+
+function test(a,b) {
+  tests++;
+  if (JSON.stringify(a)==JSON.stringify(b))
+    testpass++;
+  else
+    console.log("Got",a,"expected", b);
+}
+
+test(Object.fromEntries([['a',1],['b','c'],['d',true]]),{ a:1, b:'c', d:true });
+test(Object.fromEntries([]),{});
+
+result = tests==testpass;


### PR DESCRIPTION
This PR adds support for [`Object.fromEntries`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries) from ES2019.

Opening as a draft because I still have to figure out how to properly run tests.
