### PR TITLE
Adjust name string

### DIFF
--- a/tests/test_long_string_to_name.js
+++ b/tests/test_long_string_to_name.js
@@ -1,0 +1,26 @@
+o = {};
+n = 'a';
+i = 1;
+while (true) {
+  o[n] = i++;
+  n += (i % 10) || (i / 10);
+  if (E.getSizeOf(n) == 3) break;
+}
+/* o.a == 1
+ * o.a2 == 2
+ * ..
+ * o.a234567891 == 10
+ * o.a2345678911 == 11
+ * ..
+ */
+while (true) {
+  n = n.substring(0, n.length - 1);
+  if (!n.length) {
+    result = true;
+    break;
+  }
+  if (o[n] != n.length) {
+    result = false;
+    break;
+  }
+}


### PR DESCRIPTION
Currently, when converting strings to names, existing StringExt are replaced by new ones. This introduces gaps, e.g.

1: String
2: StringExt
3: first empty
4: second empty

may become either 1 -> 3 (new StringExt) and 2 (first empty) -> 4, or 1 -> 3 -> 4 and 2 -> 5.

This PR changes the algorithm to reuse the existing StringExt by increasing the length of the string and shifting the characters. On my Bangle ~50% of the strings enter this part, each adding ~0.15 gaps on average (~4000 in ~30min).

I don't expect this to hit master anytime soon because it doesn't solve an actual issue and its value is debatable. The only real gain is potentially more space for flat strings and less GC.