### PR TITLE
Update Widget type

### DIFF
--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -87,7 +87,10 @@ type WidgetArea = "tl" | "tr" | "bl" | "br";
 type Widget = {
   area: WidgetArea;
   width: number;
-  draw: (this: { x: number; y: number }) => void;
+  sortorder?: number;
+  draw: (this: Widget, w: Widget) => void;
+  x?: number;
+  y?: number;
 };
 declare const WIDGETS: { [key: string]: Widget };
 */


### PR DESCRIPTION
This includes the `x` & `y` present when a widget's been drawn, along with the optional `sortorder`.

The `draw` function takes `this` as the widget, but also an argument of `Widget` too, as we setup the call to [pass the widget in both cases](https://github.com/bobrippling/Espruino/blob/1876343c8bf61aeac907fdff2e1c0d1d91323a92/libs/js/banglejs/Bangle_drawWidgets.js#L20-L20)