### PR TITLE
Update this reference in call/apply/bind types

### DIFF
--- a/scripts/build_types.js
+++ b/scripts/build_types.js
@@ -63,6 +63,7 @@ function getDocumentation(object) {
           ? [""].concat(
               object.params
                 .map(([name, type, description]) => {
+                  if (name === "this") name = "thisArg";
                   const desc = getParameterDescription(description);
                   return (
                     "@param {" +
@@ -128,6 +129,7 @@ function getArguments(method) {
       if (param[0] == "pin" && param[1] == "JsLet") param[1] = "Pin";
       if (param[0] === "function") param[0] = "func";
       if (param[0] === "var") param[0] = "variable";
+      if (param[0] === "this") param[0] = "thisArg";
       let doc = typeof param[2] === "string" ? param[2] : param[2].join("\n");
       let optional = doc && doc.startsWith("[optional]");
       let rest = param[1] === "JsVarArray";

--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -1141,7 +1141,7 @@ void jswrap_function_replaceWith(JsVar *oldFunc, JsVar *newFunc) {
   "name" : "call",
   "generate" : "jswrap_function_apply_or_call",
   "params" : [
-    ["this","JsVar","The value to use as the 'this' argument when executing the function"],
+    ["thisArg","JsVar","The value to use as the 'this' argument when executing the function"],
     ["params","JsVarArray","Optional Parameters"]
   ],
   "return" : ["JsVar","The return value of executing this function"]
@@ -1157,10 +1157,13 @@ This executes the function with the supplied 'this' argument and parameters
   "name" : "apply",
   "generate" : "jswrap_function_apply_or_call",
   "params" : [
-    ["this","JsVar","The value to use as the 'this' argument when executing the function"],
-    ["args","JsVar","Optional Array of Arguments"]
+    ["thisArg","JsVar","The value to use as the 'this' argument when executing the function"],
+    ["args","JsVarArray","Optional Array of Arguments"]
   ],
-  "return" : ["JsVar","The return value of executing this function"]
+  "return" : ["JsVar","The return value of executing this function"],
+  "typescript" : [
+    "apply(thisArg: any, args: ArrayLike<any>): any;"
+  ]
 }
 This executes the function with the supplied 'this' argument and parameters
  */
@@ -1209,7 +1212,7 @@ JsVar *jswrap_function_apply_or_call(JsVar *parent, JsVar *thisArg, JsVar *argsA
   "name" : "bind",
   "generate" : "jswrap_function_bind",
   "params" : [
-    ["this","JsVar","The value to use as the 'this' argument when executing the function"],
+    ["thisArg","JsVar","The value to use as the 'this' argument when executing the function"],
     ["params","JsVarArray","Optional Default parameters that are prepended to the call"]
   ],
   "return" : ["JsVar","The 'bound' function"]

--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -1141,7 +1141,7 @@ void jswrap_function_replaceWith(JsVar *oldFunc, JsVar *newFunc) {
   "name" : "call",
   "generate" : "jswrap_function_apply_or_call",
   "params" : [
-    ["thisArg","JsVar","The value to use as the 'this' argument when executing the function"],
+    ["this","JsVar","The value to use as the 'this' argument when executing the function"],
     ["params","JsVarArray","Optional Parameters"]
   ],
   "return" : ["JsVar","The return value of executing this function"]
@@ -1157,8 +1157,8 @@ This executes the function with the supplied 'this' argument and parameters
   "name" : "apply",
   "generate" : "jswrap_function_apply_or_call",
   "params" : [
-    ["thisArg","JsVar","The value to use as the 'this' argument when executing the function"],
-    ["args","JsVarArray","Optional Array of Arguments"]
+    ["this","JsVar","The value to use as the 'this' argument when executing the function"],
+    ["args","JsVar","Optional Array of Arguments"]
   ],
   "return" : ["JsVar","The return value of executing this function"],
   "typescript" : [
@@ -1212,7 +1212,7 @@ JsVar *jswrap_function_apply_or_call(JsVar *parent, JsVar *thisArg, JsVar *argsA
   "name" : "bind",
   "generate" : "jswrap_function_bind",
   "params" : [
-    ["thisArg","JsVar","The value to use as the 'this' argument when executing the function"],
+    ["this","JsVar","The value to use as the 'this' argument when executing the function"],
     ["params","JsVarArray","Optional Default parameters that are prepended to the call"]
   ],
   "return" : ["JsVar","The 'bound' function"]


### PR DESCRIPTION
`this` as the first argument means the function is callable as in `obj.func()`, and that we've specified the type of `obj`, rather than the type of the first argument.

We can rename `this` to `thisArg` to avoid this behaviour, meaning we now have a "real" first argument, that will be the `this` passed to the function we've specified.

This change also restricts `apply`'s second argument to be an array-like object.