### PR TITLE
Add `getSecurityStatus().advertising` property

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -3454,13 +3454,27 @@ void jswrap_ble_setSecurity(JsVar *options) {
   }
 }
 
+/*TYPESCRIPT
+type NRFSecurityStatus = {
+  connected: false
+} | {
+  connected: boolean,
+  encrypted: boolean,
+  mitm_protected: boolean,
+  bonded: boolean,
+  advertising: boolean,
+  connected_addr?: string,
+};
+*/
+
 /*JSON{
     "type" : "staticmethod",
     "class" : "NRF",
     "name" : "getSecurityStatus",
     "ifdef" : "NRF52_SERIES",
     "generate" : "jswrap_ble_getSecurityStatus",
-    "return" : ["JsVar", "An object" ]
+    "return" : ["JsVar", "An object" ],
+    "return_object" : "NRFSecurityStatus"
 }
 Return an object with information about the security state of the current
 peripheral connection:
@@ -3859,7 +3873,8 @@ JsVar *jswrap_ble_BluetoothRemoteGATTServer_startBonding(JsVar *parent, bool for
     "name" : "getSecurityStatus",
     "ifdef" : "NRF52_SERIES",
     "generate" : "jswrap_ble_BluetoothRemoteGATTServer_getSecurityStatus",
-    "return" : ["JsVar", "An object" ]
+    "return" : ["JsVar", "An object" ],
+    "return_object" : "NRFSecurityStatus"
 }
 Return an object with information about the security state of the current
 connection:

--- a/libs/misc/jswrap_emulated.c
+++ b/libs/misc/jswrap_emulated.c
@@ -34,7 +34,8 @@
     "class" : "NRF",
     "name" : "getSecurityStatus",
     "generate_full" : "jsvNewObject()",
-    "return" : ["JsVar", "An object" ]
+    "return" : ["JsVar", "An object" ],
+    "return_object" : "NRFSecurityStatus"
 }
 */
 /*JSON{

--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -3100,6 +3100,8 @@ JsVar *jsble_get_security_status(uint16_t conn_handle) {
     jsvObjectSetChildAndUnLock(result, "encrypted", jsvNewFromBool(status.encrypted));
     jsvObjectSetChildAndUnLock(result, "mitm_protected", jsvNewFromBool(status.mitm_protected));
     jsvObjectSetChildAndUnLock(result, "bonded", jsvNewFromBool(status.bonded));
+    bool isAdvertising = bleStatus & BLE_IS_ADVERTISING;
+    jsvObjectSetChildAndUnLock(result, "advertising", jsvNewFromBool(isAdvertising));
 #ifndef SAVE_ON_FLASH
     if (status.connected && conn_handle==m_peripheral_conn_handle)
       jsvObjectSetChildAndUnLock(result, "connected_addr", bleAddrToStr(m_peripheral_addr));


### PR DESCRIPTION
As mentioned in espruino/BangleApps#2608, this adds a `advertising` property to the object returned by `NRF.getSecurityStatus()`, allowing us to determine whether the chip is idle, advertising or connected.