### PR TITLE
Update `NRFSecurityStatus` type

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -3456,15 +3456,21 @@ void jswrap_ble_setSecurity(JsVar *options) {
 
 /*TYPESCRIPT
 type NRFSecurityStatus = {
-  connected: false
-} | {
-  connected: boolean,
-  encrypted: boolean,
-  mitm_protected: boolean,
-  bonded: boolean,
   advertising: boolean,
-  connected_addr?: string,
-};
+} & (
+  {
+    connected: true,
+    encrypted: boolean,
+    mitm_protected: boolean,
+    bonded: boolean,
+    connected_addr?: string,
+  } | {
+    connected: false,
+    encrypted: false,
+    mitm_protected: false,
+    bonded: false,
+  }
+);
 */
 
 /*JSON{


### PR DESCRIPTION
This updates the `NRFSecurityStatus` type from a prior commit (#2337), always exposing `advertising` and clarifying other properties depending on `connected`'s value - sorry about the double PR!