### PR TITLE
add pipe method to StorageFile

### DIFF
--- a/src/jswrap_storage.c
+++ b/src/jswrap_storage.c
@@ -927,3 +927,18 @@ void jswrap_storagefile_erase(JsVar *f) {
   jsvObjectSetChildAndUnLock(f,"addr",jsvNewFromInteger(0));
   jsvObjectSetChildAndUnLock(f,"mode",jsvNewFromInteger(0));
 }
+
+
+/*JSON{
+  "type" : "method",
+  "class" : "StorageFile",
+  "name" : "pipe",
+  "ifndef" : "SAVE_ON_FLASH",
+  "generate" : "jswrap_pipe",
+  "params" : [
+    ["destination","JsVar","The destination file/stream that will receive content from the source."],
+    ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
+  ]
+}
+Pipe this file to a stream (an object with a 'write' method)
+*/


### PR DESCRIPTION
This adds the pipe method to storage files, so they can be piped to for example an http request or response. 

I have tested and this seems to work:
```js
const logFile = Storage.open("log", "r");

// without this change
E.pipe(logFile, req);

// with this change:
logFile.pipe(req)
```