### PR TITLE
Add `PipeOptions` to `pipe()` typescript definitions

### DIFF
--- a/libs/filesystem/jswrap_file.c
+++ b/libs/filesystem/jswrap_file.c
@@ -588,7 +588,8 @@ void jswrap_file_skip_or_seek(JsVar* parent, int nBytes, bool is_skip) {
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
-  ]
+  ],
+  "typescript": "pipe(destination: any, options?: PipeOptions): void"
 }
 Pipe this file to a stream (an object with a 'write' method)
 */

--- a/libs/network/http/jswrap_http.c
+++ b/libs/network/http/jswrap_http.c
@@ -133,7 +133,8 @@ Return a string containing characters that have been received
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
-  ]
+  ],
+  "typescript": "pipe(dest: any, options?: PipeOptions): void"
 }
 Pipe this to a stream (an object with a 'write' method)
 */
@@ -292,7 +293,8 @@ Return a string containing characters that have been received
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
-  ]
+  ],
+  "typescript": "pipe(destination: any, options?: PipeOptions): void"
 }
 Pipe this to a stream (an object with a 'write' method)
 */

--- a/libs/network/jswrap_net.c
+++ b/libs/network/jswrap_net.c
@@ -322,7 +322,8 @@ Return a string containing characters that have been received
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
-  ]
+  ],
+  "typescript": "pipe(destination: any, options?: PipeOptions): void"
 }
 Pipe this to a stream (an object with a 'write' method)
 */

--- a/src/jswrap_espruino.c
+++ b/src/jswrap_espruino.c
@@ -780,7 +780,7 @@ their values.
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=64, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
   ],
-  "typescript" : "pipe(source: any, destination: any, options?: { chunkSize?: number, end?: boolean, complete?: () => void }): void"
+  "typescript" : "pipe(source: any, destination: any, options?: PipeOptions): void"
 }*/
 
 /*JSON{

--- a/src/jswrap_pipe.c
+++ b/src/jswrap_pipe.c
@@ -236,6 +236,14 @@ static void jswrap_pipe_dst_close_listener(JsVar *destination) {
   jswrap_pipe_close_listener(destination, "destination");
 }
 
+/*TYPESCRIPT
+type PipeOptions = {
+  chunkSize?: number,
+  end?: boolean,
+  complete?: () => void,
+};
+*/
+
 /*JSON{
   "type" : "staticmethod",
   "class" : "fs",
@@ -246,7 +254,8 @@ static void jswrap_pipe_dst_close_listener(JsVar *destination) {
     ["source","JsVar","The source file/stream that will send content."],
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=64, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
-  ]
+  ],
+  "typescript": "pipe(destination: any, options?: PipeOptions): void"
 }*/
 void jswrap_pipe(JsVar* source, JsVar* dest, JsVar* options) {
   if (!source || !dest) return;

--- a/src/jswrap_serial.c
+++ b/src/jswrap_serial.c
@@ -534,7 +534,8 @@ Return a string containing characters that have been received
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
-  ]
+  ],
+  "typescript": "pipe(destination: any, options?: PipeOptions): void"
 }
 Pipe this USART to a stream (an object with a 'write' method)
  */

--- a/src/jswrap_storage.c
+++ b/src/jswrap_storage.c
@@ -957,7 +957,8 @@ void jswrap_storagefile_erase(JsVar *f) {
   "params" : [
     ["destination","JsVar","The destination file/stream that will receive content from the source."],
     ["options","JsVar",["[optional] An object `{ chunkSize : int=32, end : bool=true, complete : function }`","chunkSize : The amount of data to pipe from source to destination at a time","complete : a function to call when the pipe activity is complete","end : call the 'end' function on the destination when the source is finished"]]
-  ]
+  ],
+  "typescript": "pipe(destination: any, options?: PipeOptions): void"
 }
 Pipe this file to a stream (an object with a 'write' method)
 */


### PR DESCRIPTION
As discussed in #2350, we can apply the [existing](https://github.com/espruino/Espruino/blob/b990a79d3fe0b9a3d50dfb74cb5a07827a44c107/src/jswrap_espruino.c#L783) pipe options to our other `pipe` declarations.