### PR TITLE
typescript: `Storage` and HID tweaks

### DIFF
--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -2703,7 +2703,8 @@ void jswrap_nfc_send(JsVar *payload) {
     "params" : [
       ["data","JsVar","Input report data as an array"],
       ["callback","JsVar","A callback function to be called when the data is sent"]
-    ]
+    ],
+    "typescript" : "sendHIDReport(data: number[], callback?: () => void): void"
 }
 Send a USB HID report. HID must first be enabled with `NRF.setServices({}, {hid:
 hid_report})`

--- a/src/jswrap_storage.c
+++ b/src/jswrap_storage.c
@@ -142,7 +142,7 @@ JsVar *jswrap_storage_read(JsVar *name, int offset, int length) {
     ["noExceptions","bool","If true and the JSON is not valid, just return `undefined` - otherwise an `Exception` is thrown"]
   ],
   "return" : ["JsVar","An object containing parsed JSON from the file, or undefined"],
-  "typescript" : "readJSON(name: string, noExceptions: boolean): any;"
+  "typescript" : "readJSON(name: string, noExceptions: ShortBoolean): any;"
 }
 Read a file from the flash storage area that has been written with
 `require("Storage").write(...)`, and parse JSON in it into a JavaScript object.


### PR DESCRIPTION
- A small tweak to `Storage.readJSON` typescript - permit 1 instead of true/false to "bless" popular usage
- Clarify the types of `sendHIDReport`, and make callback optional