### PR TITLE
Add function deepSleepExt0

### DIFF
--- a/targets/esp32/jswrap_esp32.c
+++ b/targets/esp32/jswrap_esp32.c
@@ -88,6 +88,24 @@ void jswrap_ESP32_deepSleep(int us) {
   esp_deep_sleep_start(); // This function does not return.
 } // End of jswrap_ESP32_deepSleep
 
+/*JSON{
+  "type"     : "staticmethod",
+  "class"    : "ESP32",
+  "ifdef" : "ESP32",
+  "name"     : "deepSleepExt0",
+  "generate" : "jswrap_ESP32_deepSleep_ext0",
+  "params"   : [
+    ["pin", "pin", "Pin to trigger wakeup"],
+    ["level", "int", "Logic level to trigger"]
+  ]
+}
+Put device in deepsleep state until interrupted by pin "pin".
+*/
+void jswrap_ESP32_deepSleep_ext0(Pin pin, int level) {
+  esp_sleep_enable_ext0_wakeup(pin, level);
+  esp_deep_sleep_start(); // This function does not return.
+} // End of jswrap_ESP32_deepSleep_ext0
+
 
 /*JSON{
   "type"     : "staticmethod",

--- a/targets/esp32/jswrap_esp32.h
+++ b/targets/esp32/jswrap_esp32.h
@@ -23,6 +23,7 @@ JsVar *jswrap_ESP32_getState();
 JsVar *jswrap_ESP32_setBoot(JsVar *jsPartitionName);
 void   jswrap_ESP32_reboot();
 void   jswrap_ESP32_deepSleep(int us);
+void   jswrap_ESP32_deepSleep_ext0(Pin pin,int level);
 void   jswrap_ESP32_setAtten(Pin pin,int atten);
 
 #ifdef BLUETOOTH


### PR DESCRIPTION
This PR adds ability for ESP32 boards to wake from deep sleep by trigger from external interrupt (setting a GPIO pin). It may be confirmed with this example code:
```
const buttonPin = D4;
pinMode(buttonPin, 'input');

// Flash LED1 (while awake)
var on = false;
setInterval(function() {
  on = !on;
  LED1.write(on);
}, 500);

// Every 10secs, sleep until buttonPin is pressed
setInterval(function() {
  console.log("Time to sleep");
  ESP32.deepSleepExt0(buttonPin, 1);
}, 10000);
```