### PR TITLE
Add function getWakeupCause for ESP32

### DIFF
--- a/targets/esp32/jswrap_esp32.c
+++ b/targets/esp32/jswrap_esp32.c
@@ -106,6 +106,29 @@ void jswrap_ESP32_deepSleep_ext0(Pin pin, int level) {
   esp_deep_sleep_start(); // This function does not return.
 } // End of jswrap_ESP32_deepSleep_ext0
 
+/*JSON{
+  "type"     : "staticmethod",
+  "class"    : "ESP32",
+  "ifdef" : "ESP32",
+  "name"     : "getWakeupCause",
+  "generate" : "jswrap_ESP32_getWakeupCause",
+  "return"   : ["int", "The cause of the ESP32's wakeup from sleep"]
+}
+Returns a variable identifying the cause of wakeup from deep sleep.
+Possible causes include:
+
+* `0: ESP_SLEEP_WAKEUP_UNDEFINED` - reset was not caused by exit from deep sleep
+* `2: ESP_SLEEP_WAKEUP_EXT0` - Wakeup caused by external signal using RTC_IO
+* `3: ESP_SLEEP_WAKEUP_EXT1` - Wakeup caused by external signal using RTC_CNTL
+* `4: ESP_SLEEP_WAKEUP_TIMER` - Wakeup caused by timer
+* `5: ESP_SLEEP_WAKEUP_TOUCHPAD` - Wakeup caused by touchpad
+* `6: ESP_SLEEP_WAKEUP_ULP` - Wakeup caused by ULP program
+
+*/
+int jswrap_ESP32_getWakeupCause() {
+  return esp_sleep_get_wakeup_cause();
+} // End of jswrap_ESP32_getWakeupCause
+
 
 /*JSON{
   "type"     : "staticmethod",

--- a/targets/esp32/jswrap_esp32.h
+++ b/targets/esp32/jswrap_esp32.h
@@ -24,6 +24,7 @@ JsVar *jswrap_ESP32_setBoot(JsVar *jsPartitionName);
 void   jswrap_ESP32_reboot();
 void   jswrap_ESP32_deepSleep(int us);
 void   jswrap_ESP32_deepSleep_ext0(Pin pin,int level);
+int    jswrap_ESP32_getWakeupCause();
 void   jswrap_ESP32_setAtten(Pin pin,int atten);
 
 #ifdef BLUETOOTH


### PR DESCRIPTION
This function returns a number representing the reason that a device has woken from deep sleep. Example code:
```
var wakeupCause = ESP32.getWakeupCause();
if (wakeupCause == 0) {
  // Assume a reboot i.e.completely new start
  OnInit(); 
} else {
  // Wakeup from deep sleep.
  // Could check values 2-6 for explicit wakeup source
  OnWakeup();
}
```