### PR TITLE
Test validity of wakeup pin for ESP32 deep sleep

### DIFF
--- a/targets/esp32/jswrap_esp32.c
+++ b/targets/esp32/jswrap_esp32.c
@@ -25,6 +25,8 @@
 #include "esp_heap_caps.h"
 #include "esp_ota_ops.h"
 
+#include "driver/rtc_io.h"
+
 #ifdef BLUETOOTH
 #include "BLE/esp32_bluetooth_utils.h"
 #endif
@@ -100,8 +102,14 @@ void jswrap_ESP32_deepSleep(int us) {
   ]
 }
 Put device in deepsleep state until interrupted by pin "pin".
+Eligible pin numbers are restricted to those [GPIOs designated
+as RTC GPIOs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary).
 */
 void jswrap_ESP32_deepSleep_ext0(Pin pin, int level) {
+  if (!rtc_gpio_is_valid_gpio(pin)) {
+    jsExceptionHere(JSET_ERROR, "Invalid pin!");
+    return;
+  }
   esp_sleep_enable_ext0_wakeup(pin, level);
   esp_deep_sleep_start(); // This function does not return.
 } // End of jswrap_ESP32_deepSleep_ext0


### PR DESCRIPTION
PR #2358 added wakeup from deep sleep by setting a GPIO pin. However not all GPIOs are valid wakeup pins and could result in a deep sleep without any way to wake up. This PR attempts to ensure that only a valid RTC GPIO is selected before sending the device into deep sleep.