### PR TITLE
Add function deepSleepExt1 for EXP32

### DIFF
--- a/targets/esp32/jswrap_esp32.c
+++ b/targets/esp32/jswrap_esp32.c
@@ -141,12 +141,12 @@ void jswrap_ESP32_deepSleep_ext1(JsVar *pinVar, JsVarInt mode) {
     JsvIterator it;
     jsvIteratorNew(&it, pinVar, JSIF_DEFINED_ARRAY_ElEMENTS);
     while (jsvIteratorHasElement(&it)) {
-      Pin pin = jshGetPinFromVar(jsvIteratorGetValue(&it));
+      Pin pin = jshGetPinFromVarAndUnLock(jsvIteratorGetValue(&it));
       if (!rtc_gpio_is_valid_gpio(pin)) {
         jsExceptionHere(JSET_ERROR, "Invalid pin (%d)!", pin);
         return;
       }
-      pinSum += (uint64_t)pow(2, pin);
+      pinSum += 1<<pin;
 
       jsvIteratorNext(&it);
     }
@@ -159,7 +159,7 @@ void jswrap_ESP32_deepSleep_ext1(JsVar *pinVar, JsVarInt mode) {
       jsExceptionHere(JSET_ERROR, "Invalid pin (%d)!", pin);
       return;
     }
-    pinSum = (uint64_t)pow(2, pin);
+    pinSum = 1<<pin;
   }
 
   if ((mode < 0) || (mode > 1)) {

--- a/targets/esp32/jswrap_esp32.h
+++ b/targets/esp32/jswrap_esp32.h
@@ -24,6 +24,7 @@ JsVar *jswrap_ESP32_setBoot(JsVar *jsPartitionName);
 void   jswrap_ESP32_reboot();
 void   jswrap_ESP32_deepSleep(int us);
 void   jswrap_ESP32_deepSleep_ext0(Pin pin,int level);
+void   jswrap_ESP32_deepSleep_ext1(JsVar *pinVar, JsVarInt mode);
 int    jswrap_ESP32_getWakeupCause();
 void   jswrap_ESP32_setAtten(Pin pin,int atten);
 


### PR DESCRIPTION
An array of RTC enabled GPIOs can be used to wake from deep sleep. Example code:

// Flash LED1 (while awake)
var on = false;
setInterval(function() {
  on = !on;
  LED1.write(on);
}, 500);

// Every 10secs, sleep until any of pinArray is pressed
setInterval(function() {
  var pinArray = [D4,D15];

  ESP32.deepSleepExt1(pinArray, 1);
}, 10000);
