### PR TITLE
readJSON typescript: prevent `any` propagation

### DIFF
--- a/src/jswrap_storage.c
+++ b/src/jswrap_storage.c
@@ -142,7 +142,10 @@ JsVar *jswrap_storage_read(JsVar *name, int offset, int length) {
     ["noExceptions","bool","If true and the JSON is not valid, just return `undefined` - otherwise an `Exception` is thrown"]
   ],
   "return" : ["JsVar","An object containing parsed JSON from the file, or undefined"],
-  "typescript" : "readJSON(name: string, noExceptions: ShortBoolean): any;"
+  "typescript" : [
+    "function readJSON(name: string, noExceptions?: false | 0): unknown;",
+    "function readJSON(name: string, noExceptions?: ShortBoolean): unknown | undefined;"
+  ]
 }
 Read a file from the flash storage area that has been written with
 `require("Storage").write(...)`, and parse JSON in it into a JavaScript object.


### PR DESCRIPTION
This tweaks the `readJSON` type to indicate that (when we're in the object-or-exception case), we get back `unknown`, prompting the developer to cast the json to the appropriate type, rather than `any` making its way through their code.

In the non-exception case of `readJSON(..., 1)`, we also have `undefined` as a possible return value.