### PR TITLE
Guard against Bangle.setUI({ <no mode> })

### DIFF
--- a/libs/js/banglejs/Bangle_setUI_F18.js
+++ b/libs/js/banglejs/Bangle_setUI_F18.js
@@ -3,6 +3,7 @@
   if ("object"==typeof mode) {
     options = mode;
     mode = options.mode;
+    if (!mode) throw new Error("Missing mode in setUI({...})");
   }
   var redraw = true;
   if (global.WIDGETS && WIDGETS.back) {

--- a/libs/js/banglejs/Bangle_setUI_Q3.js
+++ b/libs/js/banglejs/Bangle_setUI_Q3.js
@@ -3,6 +3,7 @@
   if ("object"==typeof mode) {
     options = mode;
     mode = options.mode;
+    if (!mode) throw new Error("Missing mode in setUI({...})");
   }
   var redraw = true;
   if (global.WIDGETS && WIDGETS.back) {


### PR DESCRIPTION
Following on from #2389, this makes it clear that while `setUI()` can be used to reset the UI, `setUI({})` cannot, and must always specify `mode` (amongst other options).