### PR TITLE
Add non-new constructors for Number, String, Date, Boolean & RegExp

### DIFF
--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -269,7 +269,8 @@ JsVar *jswrap_date_from_milliseconds(JsVarFloat time) {
   "typescript" : [
     "new(): Date;",
     "new(value: number | string): Date;",
-    "new(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date;"
+    "new(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date;",
+    "(arg?: any): string;"
   ]
 }
 Creates a date object

--- a/src/jswrap_number.c
+++ b/src/jswrap_number.c
@@ -31,7 +31,11 @@ This is the built-in JavaScript class for numbers.
   "params" : [
     ["value","JsVarArray","A single value to be converted to a number"]
   ],
-  "return" : ["JsVar","A Number object"]
+  "return" : ["JsVar","A Number object"],
+  "typescript" : [
+    "new(...value: any[]): Number;",
+    "(value: any): number;"
+  ]
 }
 Creates a number
  */

--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -768,7 +768,11 @@ JsVar *jswrap_object_assign(JsVar *args) {
   "params" : [
     ["value","JsVar","A single value to be converted to a number"]
   ],
-  "return" : ["bool","A Boolean object"]
+  "return" : ["bool","A Boolean object"],
+  "typescript" : [
+    "new(...value: any[]): Number;",
+    "(value: any): boolean;"
+  ]
 }
 Creates a boolean
  */

--- a/src/jswrap_regexp.c
+++ b/src/jswrap_regexp.c
@@ -290,7 +290,11 @@ basics.
     ["flags","JsVar","Flags for the regular expression as a string"]
   ],
   "return" : ["JsVar","A RegExp object"],
-  "return_object" : "RegExp"
+  "return_object" : "RegExp",
+  "typescript" : [
+    "new(...value: any[]): RegExp;",
+    "(value: any): RegExp;"
+  ]
 }
 Creates a RegExp object, for handling Regular Expressions
  */

--- a/src/jswrap_string.c
+++ b/src/jswrap_string.c
@@ -39,7 +39,11 @@ them.
   "params" : [
     ["str","JsVarArray","A value to turn into a string. If undefined or not supplied, an empty String is created."]
   ],
-  "return" : ["JsVar","A String"]
+  "return" : ["JsVar","A String"],
+  "typescript" : [
+    "new(...str: any[]): any;",
+    "(arg?: any): string;"
+  ]
 }
 Create a new String
  */


### PR DESCRIPTION
This allows typescript code such as:

```typescript
var n = Number("123.45");
```

and similarly for `String(...)`, `Date(...)`, etc