### PR TITLE
ble: if mitm is set, reject unauthenticated security procedures

### DIFF
--- a/libs/bluetooth/bluetooth.h
+++ b/libs/bluetooth/bluetooth.h
@@ -119,20 +119,22 @@ typedef enum  {
   BLE_PM_INITIALISED = 1<<10,  //< Set when the Peer Manager has been initialised (only needs doing once, even after SD restart)
   BLE_IS_NOT_CONNECTABLE = 1<<11, //< Is the device connectable?
   BLE_IS_NOT_SCANNABLE = 1<<12, //< Is the device scannable? eg, scan response
-  BLE_WHITELIST_ON_BOND = 1<<13,  //< Should we write to the whitelist whenever we bond to a device?
-  BLE_DISABLE_DYNAMIC_INTERVAL = 1<<14, //< Disable automatically changing interval based on BLE peripheral activity
-  BLE_ENCRYPT_UART = 1<<15,  //< Has security with encryption been requested (if so UART must require it)
+  BLE_IS_NOT_PAIRABLE = 1<<13, //< Is the device pairable?
+  BLE_WHITELIST_ON_BOND = 1<<14,  //< Should we write to the whitelist whenever we bond to a device?
+  BLE_DISABLE_DYNAMIC_INTERVAL = 1<<15, //< Disable automatically changing interval based on BLE peripheral activity
+  BLE_ENCRYPT_UART = 1<<16,  //< Has security with encryption been requested (if so UART must require it)
+  BLE_SECURITY_MITM = 1 << 17, //< Has security with mitm protection been requested (if so UART must require it)
 #ifdef ESPR_BLUETOOTH_ANCS
-  BLE_ANCS_INITED = 1<<16,   //< Apple Notification Centre enabled
-  BLE_AMS_INITED = 1<<17,   //< Apple Media Service enabled
-  BLE_CTS_INITED = 1<<18,   //< Apple Notification Centre enabled
+  BLE_ANCS_INITED = 1<<18,   //< Apple Notification Centre enabled
+  BLE_AMS_INITED = 1<<19,   //< Apple Media Service enabled
+  BLE_CTS_INITED = 1<<20,   //< Apple Notification Centre enabled
   BLE_ANCS_AMS_OR_CTS_INITED = BLE_ANCS_INITED|BLE_AMS_INITED|BLE_CTS_INITED, //< Apple Notifications or Media Service enabled
 #endif
 #ifndef SAVE_ON_FLASH
-  BLE_ADVERTISE_WHEN_CONNECTED = 1<<19, // Do we keep advertising when we're connected?
+  BLE_ADVERTISE_WHEN_CONNECTED = 1<<21, // Do we keep advertising when we're connected?
 #endif
-  BLE_IS_ADVERTISING_MULTIPLE = 1<<20, // We have multiple different advertising packets
-  BLE_ADVERTISING_MULTIPLE_SHIFT = 21,//GET_BIT_NUMBER(BLE_ADVERTISING_MULTIPLE_ONE),
+  BLE_IS_ADVERTISING_MULTIPLE = 1<<22, // We have multiple different advertising packets
+  BLE_ADVERTISING_MULTIPLE_SHIFT = 23,//GET_BIT_NUMBER(BLE_ADVERTISING_MULTIPLE_ONE),
   BLE_ADVERTISING_MULTIPLE_ONE = 1 << BLE_ADVERTISING_MULTIPLE_SHIFT,
   BLE_ADVERTISING_MULTIPLE_MASK = 255 << BLE_ADVERTISING_MULTIPLE_SHIFT,
 

--- a/targetlibs/nrf5x_12/components/ble/ble_services/ble_nus/ble_nus.c
+++ b/targetlibs/nrf5x_12/components/ble/ble_services/ble_nus/ble_nus.c
@@ -131,7 +131,19 @@ static uint32_t rx_char_add(ble_nus_t * p_nus, const ble_nus_init_t * p_nus_init
     memset(&cccd_md, 0, sizeof(cccd_md));
 
     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.read_perm);
+#if PEER_MANAGER_ENABLED
+    if (p_nus_init->encrypt) {
+        if (p_nus_init->mitmProtect) {
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&cccd_md.write_perm);
+        } else {
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&cccd_md.write_perm);
+        }
+    } else {
+        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
+    }
+#else
     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
+#endif
 
     cccd_md.vloc = BLE_GATTS_VLOC_STACK;
 
@@ -149,13 +161,23 @@ static uint32_t rx_char_add(ble_nus_t * p_nus, const ble_nus_init_t * p_nus_init
 
     memset(&attr_md, 0, sizeof(attr_md));
 
+#if PEER_MANAGER_ENABLED
     if (p_nus_init->encrypt) {
-      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
-      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
+        if (p_nus_init->mitmProtect) {
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.read_perm);
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.write_perm);
+        } else {
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
+        }
     } else {
-      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
-      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
     }
+#else
+    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+#endif
 
     attr_md.vloc    = BLE_GATTS_VLOC_STACK;
     attr_md.rd_auth = 0;
@@ -207,13 +229,23 @@ static uint32_t tx_char_add(ble_nus_t * p_nus, const ble_nus_init_t * p_nus_init
 
     memset(&attr_md, 0, sizeof(attr_md));
 
+#if PEER_MANAGER_ENABLED
     if (p_nus_init->encrypt) {
-      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
-      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
+        if (p_nus_init->mitmProtect) {
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.read_perm);
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.write_perm);
+        } else {
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
+            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
+        }
     } else {
-      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
-      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
     }
+#else
+    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+#endif
 
     attr_md.vloc    = BLE_GATTS_VLOC_STACK;
     attr_md.rd_auth = 0;

--- a/targetlibs/nrf5x_12/components/ble/ble_services/ble_nus/ble_nus.h
+++ b/targetlibs/nrf5x_12/components/ble/ble_services/ble_nus/ble_nus.h
@@ -91,7 +91,10 @@ typedef void (*ble_nus_data_handler_t) (ble_nus_t * p_nus, uint8_t * p_data, uin
 typedef struct
 {
     ble_nus_data_handler_t data_handler; /**< Event handler to be called for handling received data. */
+#if PEER_MANAGER_ENABLED
     bool encrypt; //< GW added - require encryption
+    bool mitmProtect; //< require mitm protection
+#endif
 } ble_nus_init_t;
 
 /**@brief Nordic UART Service structure.

--- a/targetlibs/nrf5x_15/patches/0010-BLE-encrypt-NUS.patch
+++ b/targetlibs/nrf5x_15/patches/0010-BLE-encrypt-NUS.patch
@@ -1,57 +1,88 @@
 --- a/targetlibs/nrf5x_15/components/ble/ble_services/ble_nus/ble_nus.c	2021-10-18 20:54:51.484970647 +0100
-+++ b/targetlibs/nrf5x_15/components/ble/ble_services/ble_nus/ble_nus.c	2021-10-18 20:55:28.765614856 +0100
-@@ -234,7 +234,11 @@
++++ b/targetlibs/nrf5x_15/components/ble/ble_services/ble_nus/ble_nus.c	2023-08-14 10:36:45.381885738 +0200
+@@ -234,7 +234,19 @@
      memset(&cccd_md, 0, sizeof(cccd_md));
- 
+
      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.read_perm);
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
++#if PEER_MANAGER_ENABLED
 +    if (p_nus_init->encrypt) {
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&cccd_md.write_perm);
++        if (p_nus_init->mitmProtect) {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&cccd_md.write_perm);
++        } else {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&cccd_md.write_perm);
++        }
 +    } else {
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
 +    }
- 
++#else
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
++#endif
+
      cccd_md.vloc = BLE_GATTS_VLOC_STACK;
- 
-@@ -252,8 +256,13 @@
- 
+
+@@ -252,8 +264,23 @@
+
      memset(&attr_md, 0, sizeof(attr_md));
- 
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+
++#if PEER_MANAGER_ENABLED
 +    if (p_nus_init->encrypt) {
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        if (p_nus_init->mitmProtect) {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.write_perm);
++        } else {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        }
 +    } else {
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
 +    }
- 
++#else
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++#endif
+
      attr_md.vloc    = BLE_GATTS_VLOC_STACK;
      attr_md.rd_auth = 0;
-@@ -305,8 +314,13 @@
- 
+@@ -305,8 +332,23 @@
+
      memset(&attr_md, 0, sizeof(attr_md));
- 
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+
++#if PEER_MANAGER_ENABLED
 +    if (p_nus_init->encrypt) {
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        if (p_nus_init->mitmProtect) {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.write_perm);
++        } else {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        }
 +    } else {
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
 +    }
- 
++#else
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++#endif
+
      attr_md.vloc    = BLE_GATTS_VLOC_STACK;
      attr_md.rd_auth = 0;
+@@ -438,3 +480,4 @@
+
+
+ #endif // NRF_MODULE_ENABLED(BLE_NUS)
++
 --- a/targetlibs/nrf5x_15/components/ble/ble_services/ble_nus/ble_nus.h	2018-03-22 15:25:08.000000000 +0000
-+++ b/targetlibs/nrf5x_15/components/ble/ble_services/ble_nus/ble_nus.h	2020-05-13 10:26:53.632988548 +0100
-@@ -173,6 +173,7 @@
++++ b/targetlibs/nrf5x_15/components/ble/ble_services/ble_nus/ble_nus.h 2023-08-14 10:36:56.914007933 +0200
+@@ -173,6 +173,10 @@
  typedef struct
  {
      ble_nus_data_handler_t data_handler; /**< Event handler to be called for handling received data. */
++#if PEER_MANAGER_ENABLED
 +    bool encrypt; //< GW added - require encryption
++    bool mitmProtect; //< require mitm protection
++#endif
  } ble_nus_init_t;
 
 

--- a/targetlibs/nrf5x_15_3/patches/0010-BLE-encrypt-NUS.patch
+++ b/targetlibs/nrf5x_15_3/patches/0010-BLE-encrypt-NUS.patch
@@ -1,57 +1,88 @@
 --- a/targetlibs/nrf5x_15_3/components/ble/ble_services/ble_nus/ble_nus.c	2021-10-18 20:54:51.484970647 +0100
-+++ b/targetlibs/nrf5x_15_3/components/ble/ble_services/ble_nus/ble_nus.c	2021-10-18 20:55:28.765614856 +0100
-@@ -234,7 +234,11 @@
++++ b/targetlibs/nrf5x_15_3/components/ble/ble_services/ble_nus/ble_nus.c	2023-08-14 10:36:45.381885738 +0200
+@@ -234,7 +234,19 @@
      memset(&cccd_md, 0, sizeof(cccd_md));
- 
+
      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.read_perm);
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
++#if PEER_MANAGER_ENABLED
 +    if (p_nus_init->encrypt) {
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&cccd_md.write_perm);
++        if (p_nus_init->mitmProtect) {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&cccd_md.write_perm);
++        } else {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&cccd_md.write_perm);
++        }
 +    } else {
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
 +    }
- 
++#else
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&cccd_md.write_perm);
++#endif
+
      cccd_md.vloc = BLE_GATTS_VLOC_STACK;
- 
-@@ -252,8 +256,13 @@
- 
+
+@@ -252,8 +264,23 @@
+
      memset(&attr_md, 0, sizeof(attr_md));
- 
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+
++#if PEER_MANAGER_ENABLED
 +    if (p_nus_init->encrypt) {
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        if (p_nus_init->mitmProtect) {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.write_perm);
++        } else {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        }
 +    } else {
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
 +    }
- 
++#else
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++#endif
+
      attr_md.vloc    = BLE_GATTS_VLOC_STACK;
      attr_md.rd_auth = 0;
-@@ -305,8 +314,13 @@
- 
+@@ -305,8 +332,23 @@
+
      memset(&attr_md, 0, sizeof(attr_md));
- 
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
--    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
+
++#if PEER_MANAGER_ENABLED
 +    if (p_nus_init->encrypt) {
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        if (p_nus_init->mitmProtect) {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(&attr_md.write_perm);
++        } else {
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.read_perm);
++            BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(&attr_md.write_perm);
++        }
 +    } else {
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
-+      BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
++        BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
 +    }
- 
++#else
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.read_perm);
+     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&attr_md.write_perm);
++#endif
+
      attr_md.vloc    = BLE_GATTS_VLOC_STACK;
      attr_md.rd_auth = 0;
+@@ -438,3 +480,4 @@
+
+
+ #endif // NRF_MODULE_ENABLED(BLE_NUS)
++
 --- a/targetlibs/nrf5x_15_3/components/ble/ble_services/ble_nus/ble_nus.h	2018-03-22 15:25:08.000000000 +0000
-+++ b/targetlibs/nrf5x_15_3/components/ble/ble_services/ble_nus/ble_nus.h	2020-05-13 10:26:53.632988548 +0100
-@@ -173,6 +173,7 @@
++++ b/targetlibs/nrf5x_15_3/components/ble/ble_services/ble_nus/ble_nus.h 2023-08-14 10:36:56.914007933 +0200
+@@ -173,6 +173,10 @@
  typedef struct
  {
      ble_nus_data_handler_t data_handler; /**< Event handler to be called for handling received data. */
++#if PEER_MANAGER_ENABLED
 +    bool encrypt; //< GW added - require encryption
++    bool mitmProtect; //< require mitm protection
++#endif
  } ble_nus_init_t;
 
 


### PR DESCRIPTION
If a passkey is set using `NRF.setSecurity()`, it was previosly possible for another device to pair without having to supply that passkey, by supplying a combination of io capabilities that result in using unauthenticated "just works" pairing (see the bluetooth spec v5.0, vol 3, part H, page 2313, table 2.8).  
This change fixes that behaviour by taking a look at the supplied io capabilities during pairing, and rejecting anything that would result in an unauthenticated connection.

Setting mitm also causes the UART to require a connection that is mitm protected.

Because we need the currently configured security parameters in the `PM_EVT_CONN_SEC_PARAMS_REQ` event, they are now written to the static variable `m_sec_params` every time `jsble_update_security()` is called. Reading from that variable should be safe, because `jsble_update_security()` is called before registering the event handler with `pm_register(pm_evt_handler)`, so `m_sec_params` should be properly initialised once `PM_EVT_CONN_SEC_PARAMS_REQ` is fired.

This additionally adds a flag `BLE_IS_NOT_PAIRABLE`, that allows disabling pairing altogether by rejecting all security procedures. There is currently no way to set that flag though.

I could only test this for Bangle.js 2, as that is the only Espruino device I own; hopefully CI builds still work and nothing breaks on a real device :sweat_smile: