### PR TITLE
ble: allow configuring device privacy

### DIFF
--- a/libs/bluetooth/bluetooth.h
+++ b/libs/bluetooth/bluetooth.h
@@ -381,6 +381,8 @@ void jsble_central_setWhitelist(bool whitelist);
 void jsble_central_eraseBonds();
 /// Try to resolve a bonded peer's address from a random private resolvable address
 JsVar *jsble_resolveAddress(JsVar *address);
+JsVar *jsble_getPrivacy();
+void jsble_setPrivacy(JsVar *options);
 #endif
 
 #endif // BLUETOOTH_H

--- a/libs/bluetooth/bluetooth_utils.c
+++ b/libs/bluetooth/bluetooth_utils.c
@@ -210,6 +210,131 @@ const char *bleVarToUUIDAndUnLock(ble_uuid_t *uuid, JsVar *v) {
   return r;
 }
 
+#if PEER_MANAGER_ENABLED
+bool bleVarToPrivacy(JsVar *options, pm_privacy_params_t *privacy) {
+  if (jsvIsObject(options)) {
+    bool invalidOption = false;
+    memset(privacy, 0, sizeof(pm_privacy_params_t));
+    privacy->privacy_mode = BLE_GAP_PRIVACY_MODE_OFF;
+    privacy->private_addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE;
+    privacy->private_addr_cycle_s = 0; // use default address change cycle
+    privacy->p_device_irk = NULL; // use device default irk
+    // privacy mode
+    {
+      JsVar *privacyModeVar = jsvObjectGetChildIfExists(options, "privacy_mode");
+      if (privacyModeVar && jsvIsString(privacyModeVar)) {
+        if (jsvIsStringEqual(privacyModeVar, "off")) {
+          privacy->privacy_mode = BLE_GAP_PRIVACY_MODE_OFF;
+        } else if (jsvIsStringEqual(privacyModeVar, "device_privacy")) {
+          privacy->privacy_mode = BLE_GAP_PRIVACY_MODE_DEVICE_PRIVACY;
+        } else {
+          invalidOption = true;
+        }
+      } else {
+        invalidOption = true;
+      }
+      jsvUnLock(privacyModeVar);
+    }
+    // other options are only relevant if privacy_mode is something other than off
+    if (privacy->privacy_mode != BLE_GAP_PRIVACY_MODE_OFF) {
+      // private addr type
+      {
+        JsVar *privacyAddrTypeVar = jsvObjectGetChildIfExists(options, "private_addr_type");
+        if (privacyAddrTypeVar && jsvIsString(privacyAddrTypeVar)) {
+          if (jsvIsStringEqual(privacyAddrTypeVar, "random_private_resolvable")) {
+            privacy->private_addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE;
+          } else if (jsvIsStringEqual(privacyAddrTypeVar, "random_private_non_resolvable")) {
+            privacy->private_addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE;
+          } else {
+            invalidOption = true;
+          }
+        } else {
+          invalidOption = true;
+        }
+        jsvUnLock(privacyAddrTypeVar);
+      }
+      // private addr cycle s
+      {
+        JsVar *privateAddrCycleSVar = jsvObjectGetChildIfExists(options, "private_addr_cycle_s");
+        if (privateAddrCycleSVar && jsvIsInt(privateAddrCycleSVar)) {
+          privacy->private_addr_cycle_s = jsvGetInteger(privateAddrCycleSVar);
+        } else {
+          invalidOption = true;
+        }
+        jsvUnLock(privateAddrCycleSVar);
+      }
+    }
+    return !invalidOption;
+  }
+  return false;
+}
+
+JsVar *blePrivacyToVar(pm_privacy_params_t *privacy) {
+  JsVar *result = jsvNewObject();
+  if (!result) return 0;
+  if (privacy) {
+    char *privacy_mode_str = "";
+    switch (privacy->privacy_mode) {
+      case BLE_GAP_PRIVACY_MODE_OFF:
+        privacy_mode_str = "off";
+        break;
+      case BLE_GAP_PRIVACY_MODE_DEVICE_PRIVACY:
+        privacy_mode_str = "device_privacy";
+        break;
+    }
+    char *addr_type_str = "";
+    switch (privacy->private_addr_type) {
+      case BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE:
+        addr_type_str = "random_private_resolvable";
+        break;
+      case BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE:
+        addr_type_str = "random_private_non_resolvable";
+        break;
+    }
+    jsvObjectSetChildAndUnLock(result, "privacy_mode", jsvNewFromString(privacy_mode_str));
+    // other options are only relevant if privacy_mode is something other than off
+    if (privacy->privacy_mode != BLE_GAP_PRIVACY_MODE_OFF) {
+      jsvObjectSetChildAndUnLock(result, "private_addr_type", jsvNewFromString(addr_type_str));
+      jsvObjectSetChildAndUnLock(result, "private_addr_cycle_s", jsvNewFromInteger(privacy->private_addr_cycle_s));
+    }
+    return result;
+  }
+  jsvUnLock(result);
+  return 0;
+}
+
+bool blePrivacyVarEqual(JsVar *a, JsVar *b) {
+  if (jsvIsUndefined(a) && jsvIsUndefined(b)) {
+    return true;
+  }
+  if (jsvIsObject(a) && jsvIsObject(b)) {
+    bool privacyModeEqual = false;
+    {
+      JsVar *privacyModeA = jsvObjectGetChildIfExists(a, "privacy_mode");
+      JsVar *privacyModeB = jsvObjectGetChildIfExists(b, "privacy_mode");
+      privacyModeEqual = jsvIsEqual(privacyModeA, privacyModeB);
+      jsvUnLock2(privacyModeA, privacyModeB);
+    }
+    bool privateAddrTypeEqual = false;
+    {
+      JsVar *privateAddrTypeA = jsvObjectGetChildIfExists(a, "private_addr_type");
+      JsVar *privateAddrTypeB = jsvObjectGetChildIfExists(b, "private_addr_type");
+      privateAddrTypeEqual = jsvIsEqual(privateAddrTypeA, privateAddrTypeB);
+      jsvUnLock2(privateAddrTypeA, privateAddrTypeB);
+    }
+    bool privateAddrCycleSEqual = false;
+    {
+      JsVar *privateAddrCycleSA = jsvObjectGetChildIfExists(a, "private_addr_cycle_s");
+      JsVar *privateAddrCycleSB = jsvObjectGetChildIfExists(b, "private_addr_cycle_s");
+      privateAddrCycleSEqual = jsvIsEqual(privateAddrCycleSA, privateAddrCycleSB);
+      jsvUnLock2(privateAddrCycleSA, privateAddrCycleSB);
+    }
+    return privacyModeEqual && privateAddrTypeEqual && privateAddrCycleSEqual;
+  }
+  return false;
+}
+#endif // PEER_MANAGER_ENABLED
+
 /// Queue an event on the 'NRF' object. Also calls jshHadEvent()
 void bleQueueEventAndUnLock(const char *name, JsVar *data) {
   //jsiConsolePrintf("[%s] %j\n", name, data);

--- a/libs/bluetooth/bluetooth_utils.h
+++ b/libs/bluetooth/bluetooth_utils.h
@@ -14,6 +14,9 @@
 
 #include "jsvar.h"
 #include "bluetooth.h"
+#if PEER_MANAGER_ENABLED
+#include "peer_manager_types.h"
+#endif
 
 #define BLE_SCAN_EVENT                  JS_EVENT_PREFIX"blescan"
 #define BLE_WRITE_EVENT                 JS_EVENT_PREFIX"blew"
@@ -33,6 +36,7 @@
 #define BLE_NAME_GATT_SERVER_LEN        11 // include null terminator
 #define BLE_NAME_SECURITY               "BLE_SEC"
 #define BLE_NAME_MAC_ADDRESS            "BLE_MAC"
+#define BLE_NAME_PRIVACY                "BLE_PRIV"
 #if ESPR_BLUETOOTH_ANCS
 #define BLE_NAME_ANCS                   "BLE_ANCS"
 #define BLE_NAME_AMS                    "BLE_AMS"
@@ -69,6 +73,12 @@ const char *bleVarToUUID(ble_uuid_t *uuid, JsVar *v);
 
 /// Same as bleVarToUUID, but unlocks v
 const char *bleVarToUUIDAndUnLock(ble_uuid_t *uuid, JsVar *v);
+
+#if PEER_MANAGER_ENABLED
+bool bleVarToPrivacy(JsVar *options, pm_privacy_params_t *privacy);
+JsVar *blePrivacyToVar(pm_privacy_params_t *privacy);
+bool blePrivacyVarEqual(JsVar *a, JsVar *b);
+#endif // PEER_MANAGER_ENABLED
 
 /// Queue an event on the 'NRF' object. Also calls jshHadEvent()
 void bleQueueEventAndUnLock(const char *name, JsVar *data);

--- a/libs/bluetooth/jswrap_bluetooth.h
+++ b/libs/bluetooth/jswrap_bluetooth.h
@@ -95,6 +95,8 @@ void jswrap_ble_eraseBonds();
 JsVar *jswrap_ble_getAddress();
 void jswrap_ble_setAddress(JsVar *address);
 JsVar *jswrap_ble_resolveAddress(JsVar *address);
+JsVar *jswrap_ble_getPrivacy();
+void jswrap_ble_setPrivacy(JsVar *options);
 
 /// Used by bluetooth.c internally when it needs to set up advertising at first
 JsVar *jswrap_ble_getCurrentAdvertisingData();


### PR DESCRIPTION
This allows using a random private resolvable address to prevent being tracked.

There are now two new methods: `NRF.setPrivacy()` and `NRF.getPrivacy()`, to set and get the current privacy settings.

One thing that (currently) cannot be configured is our IRK. Should be possible to add this as well, but I'd rather not do that, because that would complicate things a bit.

I always get a bit nervous when working directly with pointers, hopefully I'm not leaking any memory and / or freeing memory too early.

The initial setup with Gadgetbridge can be kind of weird and create a bunch of devices that don't actually exist, but everything works without (noticable) issues after that.

Something that bugs me is that if we run this on startup in addition to `NRF.setSecurity()` we may trigger a softdevice restart twice.

ToDo:

- [x] add nicer docs to explain what exactly `NRF.setPrivacy()` expects.
- [ ] try to figure out why Gadgetbridge may add devices that don't exist on initial setup

