### PR TITLE
ble: use peer manager function for iterating over known peers

### DIFF
--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -3643,7 +3643,7 @@ JsVar *jsble_resolveAddress(JsVar *address) {
       memset(&peer_data_bonding, 0, sizeof(peer_data_bonding));
       // iterate over all known peers
       pm_peer_id_t peer_id = PM_PEER_ID_INVALID;
-      while ((peer_id = pdb_next_peer_id_get(peer_id)) != PM_PEER_ID_INVALID) {
+      while ((peer_id = pm_next_peer_id_get(peer_id)) != PM_PEER_ID_INVALID) {
         if (pm_peer_data_bonding_load(peer_id, &peer_data_bonding) == NRF_SUCCESS){
           // address match?
           if (im_address_resolve(&addr, &peer_data_bonding.peer_ble_id.id_info)) {


### PR DESCRIPTION
This swaps `pdb_next_peer_id_get` for `pm_next_peer_id_get`. They both do the same thing, but using `pm_next_peer_id_get` allows the build to work without other changes on SDK 15_3.

I should probably have already used the peer manager function in the initial PR...