### PR TITLE
ble: allow disabling pairing with NRF.setSecurity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@
             nRF5x: Ensure we don't start advertising immediately after softdevice restart if NRF.sleep() was used
             Bangle.js2: Ensure `HRM-raw.raw` is set correctly after we moved to binary hrm algorithm
             nRF5x: Add `NRF.on("passkey", ...)` to allow passkey pairing with `NRF.setSecurity({mitm:1, display:1});`
+            nrf52: Allow disabling pairing with `NRF.setSecurity({pair:0})`
             
      2v18 : Fix drawString with setClipRect with 90/270-degree rotation (fix #2343)
             Pico/Wifi: Enabled JIT compiler

--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -3599,7 +3599,9 @@ NRF.setSecurity({
                   // - sent via the `BluetoothDevice.passkey` event
   keyboard : bool // default false, can this device enter a passkey
                   // - request sent via the `BluetoothDevice.passkeyRequest` event
+  pair : bool // default true, allow other devices to pair with this device
   bond : bool // default true, Perform bonding
+              // This stores info from pairing in flash and allows reconnecting without having to pair each time
   mitm : bool // default false, Man In The Middle protection
   lesc : bool // default false, LE Secure Connections
   passkey : // default "", or a 6 digit passkey to use (display must be true for this)
@@ -3607,7 +3609,7 @@ NRF.setSecurity({
                 // the 16 byte pairing code supplied here is used
   encryptUart : bool // default false (unless oob or passkey specified)
                      // This sets the BLE UART service such that it
-                     // is encrypted and can only be used from a bonded connection
+                     // is encrypted and can only be used from a paired connection
 });
 ```
 

--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -2140,6 +2140,16 @@ void jsble_update_security() {
     JsVar *v;
     if (jsvGetBoolAndUnLock(jsvObjectGetChildIfExists(options, "encryptUart")))
       encryptUart = true;
+    {
+      JsVar *pair;
+      pair = jsvObjectGetChildIfExists(options, "pair");
+      if (!jsvIsUndefined(pair) && !jsvGetBool(pair)) {
+        bleStatus |= BLE_IS_NOT_PAIRABLE;
+      } else {
+        bleStatus &= ~BLE_IS_NOT_PAIRABLE;
+      }
+      jsvUnLock(pair);
+    }
     // Check for passkey
     uint8_t passkey[BLE_GAP_PASSKEY_LEN+1];
     memset(passkey, 0, sizeof(passkey));


### PR DESCRIPTION
This adds a new `pair` option to `NRF.setSecurity`.

That option defaults to `true` and allows disabling pairing by setting it to `false` using functionality added in ea5f55fe007f1ad753985db2bd19a4df55759266.

Example usage: `NRF.setSecurity({pair:0})`