### PR TITLE
fix microbit1 compiler flags to clear bss section properly

### DIFF
--- a/boards/MICROBIT1.py
+++ b/boards/MICROBIT1.py
@@ -37,7 +37,7 @@ info = {
      'DEFINES+=-DESPR_NO_DAYLIGHT_SAVING',
      'DEFINES+=-DJSVAR_FORCE_NO_INLINE=1',
      'CFLAGS += -ffreestanding', # needed for SAVE_ON_FLASH_EXTREME (jswrap_math, __aeabi_dsub)
-     'CFLAGS += -D__STARTUP_CLEAR_BSS -DLD_NOSTARTFILES',
+     'ASFLAGS += -D__STARTUP_CLEAR_BSS -D__START=main',
      'LDFLAGS += -nostartfiles',
      'BLACKLIST=boards/MICROBIT1.blocklist', # force some stuff to be removed to save space
      'DEFINES+=-DCONFIG_GPIO_AS_PINRESET', # Allow the reset pin to work

--- a/targets/nrf5x/main.c
+++ b/targets/nrf5x/main.c
@@ -44,8 +44,3 @@ int main() {
   //jshKill();
 }
 
-#ifdef LD_NOSTARTFILES
-void _start(){
-  main();
-}
-#endif


### PR DESCRIPTION
CFLAGS are not actually passed to .S files, we need ASFLAGS for that

also there is easier way to use `main()` as `_start()` via -D__START=main - this also verifies flags are passed properly otherwise it fails in linker not finding `_start`

This can be merged as is for microbit1 however there are unclear issues with makefiles.

**1.**
 
 nrf51 adds .o file to PRECOMPILED_OBJS here https://github.com/espruino/Espruino/blob/master/make/family/NRF51.make#L15 and this works fine, however nrf52 has .S files there in many places like here https://github.com/espruino/Espruino/blob/master/make/family/NRF52.make#L25 except  here https://github.com/espruino/Espruino/blob/master/make/family/NRF52.make#L63

When I tried to put .S to nrf51 makefile instead of .o it did not pass ASFLAGS properly (nor CFLAGS) so the .o variant is a good one here.

However when I tried to add same lines
```
     'ASFLAGS += -D__STARTUP_CLEAR_BSS -D__START=main',
     'LDFLAGS += -nostartfiles',
```
 to BANGLEJS board file it worked fine despite .S! Or maybe it uses the `.o` makefile  variant here too (?)

Why there are .S files in PRECOMPILED_**OBJS** ?

And btw it saves about 300 bytes in BANGLE build - `1688b free` vs  `1380b free`

**2.**

targetlibs/nrf5x_12/components/toolchain/gcc/gcc_startup_nrf5(2|1).o files are not cleared on `make clean` so if you try to build locally for two boards with different flags old .o file  with different flags gets reused. Won't affect pipeline builds so can be merged for microbit1 despite possible other nrf51 builds not having the flag.