### PR TITLE
ESP32: Regression fix, cannot build without Bluetooth.

### DIFF
--- a/targets/esp32/main.c
+++ b/targets/esp32/main.c
@@ -83,7 +83,9 @@ static void espruinoTask(void *data) {
 #endif
   while(1) {
     jsiLoop();   // Perform the primary loop processing
+#ifdef BLUETOOTH
     gatts_sendNUSNotificationIfNotEmpty();
+#endif
   }
 }
 


### PR DESCRIPTION
Added `#ifdef BLUETOOTH` to overcome compilation error.

```
targets/esp32/main.c:86:5: error: implicit declaration of function 'gatts_sendNUSNotificationIfNotEmpty' [-Werror=implicit-function-declaration]
     gatts_sendNUSNotificationIfNotEmpty();
```