### PR TITLE
getPressure: handle error when we don't have an exception

### DIFF
--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -31,6 +31,7 @@
 #include "jswrap_heatshrink.h"
 #include "jswrap_espruino.h"
 #include "jswrap_terminal.h"
+#include "jswrap_error.h"
 #include "jsflash.h"
 #include "graphics.h"
 #include "bitmap_font_6x8.h"
@@ -5073,27 +5074,38 @@ JsVar *jswrap_banglejs_getPressure() {
   /* Occasionally on some devices (https://github.com/espruino/Espruino/issues/2137)
   you can get an I2C error. This stops the error from being fired when getPressure
   is called and instead rejects the promise. */
+  JsVar *exception = jspGetException();
+  if (exception) {
+    jspromise_reject(promisePressure, exception);
+    jsvUnLock2(promisePressure, exception);
+    JsVar *r = promisePressure;
+    promisePressure = 0;
+    return r;
+  }
+
   bool hadError = jspHasError();
   if (hadError) {
-    JsVar *exception = jspGetException();
+    JsVar *msg = jsvNewFromString("I2C barometer error");
+    JsVar *exception = jswrap_internalerror_constructor(msg);
     jspromise_reject(promisePressure, exception);
-    jsvUnLock2(promisePressure,exception);
+    jsvUnLock2(promisePressure, exception);
+    JsVar *r = promisePressure;
     promisePressure = 0;
-  } else {
-    int powerOnTimeout = 500;
+    return r;
+  }
+
+  int powerOnTimeout = 500;
 #ifdef PRESSURE_DEVICE_BMP280_EN
-    if (PRESSURE_DEVICE_BMP280_EN)
-      powerOnTimeout = 750; // some devices seem to need this long to boot reliably
+  if (PRESSURE_DEVICE_BMP280_EN)
+    powerOnTimeout = 750; // some devices seem to need this long to boot reliably
 #endif
 #ifdef PRESSURE_DEVICE_SPL06_007_EN
-    if (PRESSURE_DEVICE_SPL06_007_EN)
-      powerOnTimeout = 400; // on SPL06 we may actually be leaving it *too long* before requesting data, and it starts to do another reading
+  if (PRESSURE_DEVICE_SPL06_007_EN)
+    powerOnTimeout = 400; // on SPL06 we may actually be leaving it *too long* before requesting data, and it starts to do another reading
 #endif
-    jsvUnLock(jsiSetTimeout(jswrap_banglejs_getPressure_callback, powerOnTimeout));
-    return jsvLockAgain(promisePressure);
-  }
+  jsvUnLock(jsiSetTimeout(jswrap_banglejs_getPressure_callback, powerOnTimeout));
+  return jsvLockAgain(promisePressure);
 #endif
-  return 0;
 }
 
 /*JSON{

--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -5088,7 +5088,7 @@ JsVar *jswrap_banglejs_getPressure() {
     JsVar *msg = jsvNewFromString("I2C barometer error");
     JsVar *exception = jswrap_internalerror_constructor(msg);
     jspromise_reject(promisePressure, exception);
-    jsvUnLock2(promisePressure, exception);
+    jsvUnLock3(promisePressure, exception, msg);
     JsVar *r = promisePressure;
     promisePressure = 0;
     return r;


### PR DESCRIPTION
This handles an I2C error, originally ocurring in #2137, found again by chance in an [unrelated PR](https://github.com/espruino/BangleApps/pull/3104).

When we create a promise for `getPressure`, we now look at both `jspGetException` and then `jspHasError` (separately).
If the former is null but we have an error, we raise an exception about the I2C communication with the barometer.

Previous behaviour would raise an exception with no payload, leading to the `Uncaught Error: Unhandled promise rejection: undefined` seen in the BangleApps pull request above.