### PR TITLE
Python3 build docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -785,7 +785,7 @@ endif
 
 docs:
 	@echo ================================== Generating Board docs
-	$(Q)python2.7 scripts/build_docs.py $(WRAPPERSOURCES) $(DEFINES) -B$(BOARD)
+	$(Q)python scripts/build_docs.py $(WRAPPERSOURCES) $(DEFINES) -B$(BOARD)
 	@echo functions.html created
 
 $(WRAPPERFILE): scripts/build_jswrapper.py $(WRAPPERSOURCES)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -14,8 +14,7 @@
 # ----------------------------------------------------------------------------------------
 
 # Needs:
-#    pip install markdown
-#    pip install markdown-urlize
+#    pip install markdown2
 #
 # See common.py -> get_jsondata for command line options
 
@@ -26,7 +25,7 @@ import sys;
 import os;
 import common
 import urllib3
-import markdown
+import markdown2
 import html.entities as htmlentitydefs
 
 sys.path.append(".");
@@ -79,7 +78,7 @@ def html(s):
   htmlFile.write(s +"\n");
 
 def htmlify(d,current):
-  d = markdown.markdown(d, extensions=['mdx_urlize'], tab_length=2)
+  d = markdown2.markdown(d)
   # replace <code> with newlines with pre
   idx = d.find("<code>")
   end = d.find("</code>", idx)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -25,9 +25,9 @@ import json;
 import sys;
 import os;
 import common
-import urllib2
+import urllib3
 import markdown
-import htmlentitydefs
+import html.entities as htmlentitydefs
 
 sys.path.append(".");
 scriptdir = os.path.dirname(os.path.realpath(__file__))
@@ -45,6 +45,7 @@ sys.path.append(basedir+"boards");
 # --- skipping MDN links dump and validation to complete quicker
 
 htmldev = False
+http = urllib3.PoolManager()
 
 jsondatas = common.get_jsondata(True)
 
@@ -72,10 +73,10 @@ if os.path.isfile(mdnURLFile):
   valid_mdn_urls = json.loads(open(mdnURLFile, "r").read())
 
 # start writing
-htmlFile = open('functions.html', 'w')
+htmlFile = open('functions.html', 'w', encoding="utf-8")
 def html(s):
   print(s);
-  htmlFile.write(s.encode('utf-8')+"\n");
+  htmlFile.write(s +"\n");
 
 def htmlify(d,current):
   d = markdown.markdown(d, extensions=['mdx_urlize'], tab_length=2)
@@ -182,11 +183,11 @@ def insert_mdn_link(jsondata):
     else:
       print("Checking URL "+url)
       try:
-        connection = urllib2.urlopen(url)
-        code = connection.getcode()
+        connection =  http.request('GET', url)
+        code = connection.status
         connection.close()
-      except urllib2.HTTPError, e:
-        code = e.getcode()
+      except urllib3.HTTPError(e):
+        code = e.status
       if code==200: valid_mdn_urls['valid'].append(url)
       else: valid_mdn_urls['invalid'].append(url)
     if code==200:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -19,6 +19,7 @@ import re;
 import json;
 import sys;
 import os;
+import importlib;
 import traceback;
 # Local
 import pinutils;

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -19,7 +19,7 @@ import re;
 import json;
 import sys;
 import os;
-import importlib;
+import traceback;
 # Local
 import pinutils;
 
@@ -145,7 +145,7 @@ def get_jsondata(is_for_document, parseArgs = True, boardObject = False):
           print("WARNING: Ignoring unknown file type: " + arg)
     if not explicit_files:
       print("Scanning for jswrap.c files")
-      jswraps = subprocess.check_output(["find", ".", "-name", "jswrap*.c"]).strip().split("\n")
+      jswraps = subprocess.check_output(["find", ".", "-name", "jswrap*.c"]).strip().decode("utf-8").split("\n")
 
     if board:
       board.defines = defines
@@ -254,21 +254,25 @@ def get_jsondata(is_for_document, parseArgs = True, boardObject = False):
                 print(dropped_prefix+" because of #if "+jsondata["#if"]+ " -> "+expr)
                 drop = True
           if not drop and "patch" in jsondata:
-            targetjsondata = [x for x in jsondatas if x["type"]==jsondata["type"] and x["class"]==jsondata["class"] and x["name"]==jsondata["name"]][0]
-            for key in jsondata:
-               if not key in ["type","class","name","patch"]:
-                 print("Copying "+key+" --- "+jsondata[key]);
-                 targetjsondata[key] = jsondata[key]
+            targetjsondata = [x for x in jsondatas if x["type"]==jsondata["type"] and x["class"]==jsondata["class"] and x["name"]==jsondata["name"]]
+            if len(targetjsondata) > 0:
+              targetjsondata = targetjsondata[0]
+              for key in jsondata:
+                if not key in ["type","class","name","patch"]:
+                  print("Copying "+key+" --- "+jsondata[key])
+                  targetjsondata[key] = jsondata[key]
             drop = True 
           if not drop:
             jsondatas.append(jsondata)
         except ValueError as e:
           sys.stderr.write( "JSON PARSE FAILED for " +  jsonstring + " - "+ str(e) + "\n")
-          print(''.join(traceback.format_exception(None, exc_obj, exc_obj.__traceback__)))          
+          exc_obj = sys.exc_info()
+          print(''.join(traceback.format_exception(exc_obj)))           
           exit(1)
         except Exception as e:
           sys.stderr.write( "JSON PARSE FAILED for " + jsonstring + " - "+str(e) + "\n" )
-          print(''.join(traceback.format_exception(None, exc_obj, exc_obj.__traceback__)))
+          exc_obj = sys.exc_info()
+          print(''.join(traceback.format_exception(exc_obj)))
           exit(1)
     print("Scanning finished.")
 


### PR DESCRIPTION
Made the build_doc script work with python3.  Mostly just migrating the libraries to newer version. 

Library change  
I needed to switch out mdx_urlize for markdown2 because this extension doesn't support the latest markdown python library.  It seems that it will never.  Somebody did a pull request in 2022 with the fix for it and it still hasn't been accepted.  https://github.com/r0wb0t/markdown-urlize/pull/17

Affected libraries.  EspruinoDocs will need to be told to use python not python2.7
https://github.com/espruino/EspruinoDocs/blob/master/build.sh#L31
