### PR TITLE
Bugfix for #2456 (PR #2230) - Date library bug fixes

### DIFF
--- a/boards/PICO_R1_3.py
+++ b/boards/PICO_R1_3.py
@@ -46,6 +46,7 @@ info = {
      'DEFINES+=-DUSE_USB_OTG_FS=1  -DPICO -DPICO_1V3',
      'DEFINES+=-DPIN_NAMES_DIRECT=1', # Package skips out some pins, so we can't assume each port starts from 0
      'DEFINES += -DESPR_USE_STEPPER_TIMER=1', # Build in the code for stepping using the timer
+     'DEFINES += -DESPR_LIMIT_DATE_RANGE', # not enough code memory left for the full range of Date()
      'STLIB=STM32F401xE',
      'PRECOMPILED_OBJS+=$(ROOT)/targetlibs/stm32f4/lib/startup_stm32f401xx.o'
    ]

--- a/libs/filesystem/jswrap_fs.c
+++ b/libs/filesystem/jswrap_fs.c
@@ -358,7 +358,7 @@ JsVar *jswrap_fs_stat(JsVar *path) {
       date.month = (int)(((info.fdate>>5)&15)-1);  // TomWS: Month is 0 based.
       date.day = (int)((info.fdate)&31);
       TimeInDay td;
-      td.daysSinceEpoch = fromCalenderDate(&date);
+      td.daysSinceEpoch = fromCalendarDate(&date);
       td.hour = (int)((info.ftime>>11)&31);
       td.min = (int)((info.ftime>>5)&63);
       td.sec = (int)((info.ftime)&63);

--- a/libs/misc/nmea.c
+++ b/libs/misc/nmea.c
@@ -184,7 +184,7 @@ JsVar *nmea_to_jsVar(NMEAFixInfo *gpsFix) {
       date.month = gpsFix->month-1; // 1 based to 0 based
       date.year = 2000+gpsFix->year;
       TimeInDay td;
-      td.daysSinceEpoch = fromCalenderDate(&date);
+      td.daysSinceEpoch = fromCalendarDate(&date);
       td.hour = gpsFix->hour;
       td.min = gpsFix->min;
       td.sec = gpsFix->sec;

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -30,7 +30,7 @@ int getDayNumberFromDate(int y, int m, int d) {
   
   if (ans>1265579) {
     jsExceptionHere(JSET_ERROR, "Date out of bounds");
-    return 0;
+    return 0; // Need to head off any overflow error
   }
   if (m < 2) {
     y--;
@@ -55,21 +55,21 @@ void getDateFromDayNumber(int day, int *y, int *m, int *date) {
   a += 146095;
   a = (a < 0) ? ((a-36523)/36524) : (a/36524);
   a = day + a - ((a < 0) ? ((a-3)/4) : (a/4));
-  b = (int)(((a<<2)+2877911-((a<0) ? 1460 : 0))/1461);
-  c = (int)(a + 719600 - 365*b - (((b<0) ? (b-3) : b)/4));
+  b = ((a<<2)+2877911-((a<0) ? 1460 : 0))/1461;
+  c = a + 719600 - 365*b - (((b<0) ? (b-3) : b)/4);
   d = (5*c-1)/153; // Floor behaviour not needed, as c is always positive
-  if (date) *date=(int)(c-30*d-((3*d)/5));
+  if (date) *date=c-30*d-((3*d)/5);
   if (m) {
     if (d<14)
-      *m=(int)(d-2);
+      *m=d-2;
     else
-      *m=(int)(d-14);
+      *m=d-14;
   }
   if (y) {
     if (d>13)
-      *y=(int)(b+1);
+      *y=b+1;
     else
-      *y=(int)b;
+      *y=b;
   }
 }
 

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -27,7 +27,8 @@ const char *DAYNAMES = "Sun\0Mon\0Tue\0Wed\0Thu\0Fri\0Sat";
 // https://github.com/deirdreobyrne/CalendarAndDST
 int getDayNumberFromDate(int y, int m, int d) {
   int ans;
-
+  
+  if (y<1601) jsExceptionHere(JSET_ERROR, "Date library starts in 1601");
   if (m < 2) {
     y--;
     m+=12;
@@ -41,6 +42,8 @@ int getDayNumberFromDate(int y, int m, int d) {
 void getDateFromDayNumber(int day, int *y, int *m, int *date) {
   int a = day + 135081;
   int b,c,d;
+
+  if (day < -134774) jsExceptionHere(JSET_ERROR, "Date library starts in 1601");
   a = (a-(a/146097)+146095)/36524;
   a = day + a - (a>>2);
   b = ((a<<2)+2877911)/1461;

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -23,35 +23,15 @@ const int BASE_DOW = 4;
 const char *MONTHNAMES = "Jan\0Feb\0Mar\0Apr\0May\0Jun\0Jul\0Aug\0Sep\0Oct\0Nov\0Dec";
 const char *DAYNAMES = "Sun\0Mon\0Tue\0Wed\0Thu\0Fri\0Sat";
 
-int checkDaySinceEpoch(int d) {
-  if (d<-462962961 || d>462962961) {
-    jsExceptionHere(JSET_ERROR, "Date out of bounds");
-    return 0;
-  }
-  return -1;
-}
-
-int checkYear(int y) {
-  if (y<-1265579 || y>1269518) {
-    jsExceptionHere(JSET_ERROR, "Year out of bounds");
-    return 0;
-  }
-  return -1;
-}
-
-int checkTime(JsVarFloat ms) {
-  if (ms < -4.0e-16 || ms > 4.0e16) {
-    jsExceptionHere(JSET_ERROR, "Date out of bounds");
-    return 0;
-  }
-  return -1;
-}
-
 // Convert y,m,d into a number of days since 1970, where 0<=m<=11
 // https://github.com/deirdreobyrne/CalendarAndDST
 int getDayNumberFromDate(int y, int m, int d) {
-  int ans;
+  int ans = y<0 ? -y : y;
   
+  if (ans>1265579) {
+    jsExceptionHere(JSET_ERROR, "Date out of bounds");
+    return 0;
+  }
   if (m < 2) {
     y--;
     m+=12;
@@ -127,40 +107,38 @@ JsVarFloat getDstChangeTime(int y, int dow_number, int dow, int month, int day_o
 // https://github.com/deirdreobyrne/CalendarAndDST
 int jsdGetEffectiveTimeZone(JsVarFloat ms, bool is_local_time, bool *is_dst) {
 #ifndef ESPR_NO_DAYLIGHT_SAVING
-  if (checkTime(ms)) {
-    JsVar *dst = jsvObjectGetChildIfExists(execInfo.hiddenRoot, JS_DST_SETTINGS_VAR);
-    if ((dst) && (jsvIsArrayBuffer(dst)) && (jsvGetLength(dst) == 12) && (dst->varData.arraybuffer.type == ARRAYBUFFERVIEW_INT16)) {
-      int y;
-      JsVarInt dstSetting[12];
-      JsvArrayBufferIterator it;
+  JsVar *dst = jsvObjectGetChildIfExists(execInfo.hiddenRoot, JS_DST_SETTINGS_VAR);
+  if ((dst) && (jsvIsArrayBuffer(dst)) && (jsvGetLength(dst) == 12) && (dst->varData.arraybuffer.type == ARRAYBUFFERVIEW_INT16)) {
+    int y;
+    JsVarInt dstSetting[12];
+    JsvArrayBufferIterator it;
 
-      jsvArrayBufferIteratorNew(&it, dst, 0);
-      y = 0;
-      while (y < 12) {
-        dstSetting[y++]=jsvArrayBufferIteratorGetIntegerValue(&it);
-        jsvArrayBufferIteratorNext(&it);
-      }
-      jsvArrayBufferIteratorFree(&it);
-      jsvUnLock(dst);
-      if (dstSetting[0]) {
-        JsVarFloat sec = ms/1000;
-        JsVarFloat dstStart,dstEnd;
-        bool dstActive;
-
-        getDateFromDayNumber((int)(sec/86400),&y,0,0);
-        dstStart = getDstChangeTime(y, dstSetting[2], dstSetting[3], dstSetting[4], dstSetting[5], dstSetting[6], 1, dstSetting[0], dstSetting[1], is_local_time);
-        dstEnd = getDstChangeTime(y, dstSetting[7], dstSetting[8], dstSetting[9], dstSetting[10], dstSetting[11], 0, dstSetting[0], dstSetting[1], is_local_time);
-        if (dstStart < dstEnd) { // Northern hemisphere
-          dstActive = (sec >= dstStart) && (sec < dstEnd);
-        } else { // Southern hemisphere
-          dstActive = (sec < dstEnd) || (sec >= dstStart);
-        }
-        if (is_dst) *is_dst = dstActive;
-        return dstActive ? dstSetting[0]+dstSetting[1] : dstSetting[1];
-      }
-    } else {
-      jsvUnLock(dst);
+    jsvArrayBufferIteratorNew(&it, dst, 0);
+    y = 0;
+    while (y < 12) {
+      dstSetting[y++]=jsvArrayBufferIteratorGetIntegerValue(&it);
+      jsvArrayBufferIteratorNext(&it);
     }
+    jsvArrayBufferIteratorFree(&it);
+    jsvUnLock(dst);
+    if (dstSetting[0]) {
+      JsVarFloat sec = ms/1000;
+      JsVarFloat dstStart,dstEnd;
+      bool dstActive;
+
+      getDateFromDayNumber((int)(sec/86400),&y,0,0);
+      dstStart = getDstChangeTime(y, dstSetting[2], dstSetting[3], dstSetting[4], dstSetting[5], dstSetting[6], 1, dstSetting[0], dstSetting[1], is_local_time);
+      dstEnd = getDstChangeTime(y, dstSetting[7], dstSetting[8], dstSetting[9], dstSetting[10], dstSetting[11], 0, dstSetting[0], dstSetting[1], is_local_time);
+      if (dstStart < dstEnd) { // Northern hemisphere
+        dstActive = (sec >= dstStart) && (sec < dstEnd);
+      } else { // Southern hemisphere
+        dstActive = (sec < dstEnd) || (sec >= dstStart);
+      }
+      if (is_dst) *is_dst = dstActive;
+      return dstActive ? dstSetting[0]+dstSetting[1] : dstSetting[1];
+    }
+  } else {
+    jsvUnLock(dst);
   }
 #endif
   if (is_dst) *is_dst = false;
@@ -177,25 +155,22 @@ void setCorrectTimeZone(TimeInDay *td) {
  * condense them into one op. */
 TimeInDay getTimeFromMilliSeconds(JsVarFloat ms_in, bool forceGMT) {
   TimeInDay t;
-  if (checkTime(ms_in)) {
-    t.zone = forceGMT ? 0 : jsdGetEffectiveTimeZone(ms_in, false, &(t.is_dst));
-    ms_in += t.zone*60000;
-    t.daysSinceEpoch = (int)(ms_in / MSDAY);
+  t.zone = forceGMT ? 0 : jsdGetEffectiveTimeZone(ms_in, false, &(t.is_dst));
+  ms_in += t.zone*60000;
+  t.daysSinceEpoch = (int)(ms_in / MSDAY);
 
-    if (ms_in < -4.0e-16 || ms_in > 4.0e16) jsExceptionHere(JSET_ERROR, "Date out of bounds");
-    if (forceGMT) t.is_dst = false;
-    int ms = (int)(ms_in - ((JsVarFloat)t.daysSinceEpoch * MSDAY));
-    if (ms<0) {
-      ms += MSDAY;
-      t.daysSinceEpoch--;
-    }
-    int s = ms / 1000;
-    t.ms = ms % 1000;
-    t.hour = s / 3600;
-    s = s % 3600;
-    t.min = s/60;
-    t.sec = s%60;
+  if (forceGMT) t.is_dst = false;
+  int ms = (int)(ms_in - ((JsVarFloat)t.daysSinceEpoch * MSDAY));
+  if (ms<0) {
+    ms += MSDAY;
+    t.daysSinceEpoch--;
   }
+  int s = ms / 1000;
+  t.ms = ms % 1000;
+  t.hour = s / 3600;
+  s = s % 3600;
+  t.min = s/60;
+  t.sec = s%60;
 
   return t;
 }
@@ -207,29 +182,24 @@ JsVarFloat fromTimeInDay(TimeInDay *td) {
 CalendarDate getCalendarDate(int d) {
   CalendarDate date;
 
-  if (checkDaySinceEpoch(d)) {
-    getDateFromDayNumber(d, &date.year, &date.month, &date.day);
-    date.daysSinceEpoch = d;
-    // Calculate day of week. Sunday is 0
-    date.dow=(date.daysSinceEpoch+BASE_DOW)%7;
-    if (date.dow<0) date.dow+=7;
-  }
+  getDateFromDayNumber(d, &date.year, &date.month, &date.day);
+  date.daysSinceEpoch = d;
+  // Calculate day of week. Sunday is 0
+  date.dow=(date.daysSinceEpoch+BASE_DOW)%7;
+  if (date.dow<0) date.dow+=7;
   return date;
 };
 
 int fromCalendarDate(CalendarDate *date) {
-  if (checkYear(date->year)) {
-    while (date->month < 0) {
-      date->year--;
-      date->month += 12;
-    }
-    while (date->month > 11) {
-      date->year++;
-      date->month -= 12;
-    }
-    return getDayNumberFromDate(date->year, date->month, date->day);
+  while (date->month < 0) {
+    date->year--;
+    date->month += 12;
   }
-  return 0;
+  while (date->month > 11) {
+    date->year++;
+    date->month -= 12;
+  }
+  return getDayNumberFromDate(date->year, date->month, date->day);
 };
 
 
@@ -295,12 +265,9 @@ JsVarFloat jswrap_date_now() {
 
 
 JsVar *jswrap_date_from_milliseconds(JsVarFloat time) {
-  if (checkTime(time)) {
-    JsVar *d = jspNewObject(0,"Date");
-    jswrap_date_setTime(d, time);
-    return d;
-  }
-  return jsvNewNull();
+  JsVar *d = jspNewObject(0,"Date");
+  jswrap_date_setTime(d, time);
+  return d;
 }
 
 
@@ -337,17 +304,9 @@ JsVar *jswrap_date_constructor(JsVar *args) {
     else
       jsExceptionHere(JSET_TYPEERROR, "Variables of type %t are not supported in date constructor", arg);
     jsvUnLock(arg);
-    if (!checkTime(time)) {
-      jsExceptionHere(JSET_ERROR, "Date out of bounds");
-      return jsvNewNull();
-    }
   } else {
     CalendarDate date;
     date.year = (int)jsvGetIntegerAndUnLock(jsvGetArrayItem(args, 0));
-    if (!checkYear(date.year)) {
-      jsExceptionHere(JSET_ERROR,"Year out of bounds");
-      return jsvNewNull();
-    }
     date.month = (int)(jsvGetIntegerAndUnLock(jsvGetArrayItem(args, 1)));
     date.day = (int)(jsvGetIntegerAndUnLock(jsvGetArrayItem(args, 2)));
     TimeInDay td;
@@ -429,6 +388,10 @@ JsVarFloat jswrap_date_getTime(JsVar *date) {
 Set the time/date of this Date class
  */
 JsVarFloat jswrap_date_setTime(JsVar *date, JsVarFloat timeValue) {
+  if (abs(timeValue) > 4.0e-16) {
+    jsExceptionHere(JSET_ERROR, "Date out of bounds");
+    return 0.0;
+  }
   if (date)
     jsvObjectSetChildAndUnLock(date, "ms", jsvNewFromFloat(timeValue));
   return timeValue;
@@ -673,11 +636,11 @@ JsVarFloat jswrap_date_setDate(JsVar *parent, int dayValue) {
   "name" : "setMonth",
   "generate" : "jswrap_date_setMonth",
   "params" : [
-    ["yearValue","int","The month, between 0 and 11"],
+    ["monthValue","int","The month, between 0 and 11"],
     ["dayValue","JsVar","[optional] the day, between 0 and 31"]
   ],
   "return" : ["float","The number of milliseconds since 1970"],
-  "typescript" : "setMonth(yearValue: number, dayValue?: number): number;"
+  "typescript" : "setMonth(monthValue: number, dayValue?: number): number;"
 }
 Month of the year 0..11
  */
@@ -708,19 +671,16 @@ JsVarFloat jswrap_date_setMonth(JsVar *parent, int monthValue, JsVar *dayValue) 
 }
  */
 JsVarFloat jswrap_date_setFullYear(JsVar *parent, int yearValue, JsVar *monthValue, JsVar *dayValue) {
-  if (checkYear(yearValue)) {
-    TimeInDay td = getTimeFromDateVar(parent, false/*system timezone*/);
-    CalendarDate d = getCalendarDate(td.daysSinceEpoch);
-    d.year = yearValue;
-    if (jsvIsNumeric(monthValue))
-      d.month = jsvGetInteger(monthValue);
-    if (jsvIsNumeric(dayValue))
-      d.day = jsvGetInteger(dayValue);
-    td.daysSinceEpoch = fromCalendarDate(&d);
-    setCorrectTimeZone(&td);
-    return jswrap_date_setTime(parent, fromTimeInDay(&td));
-  }
-  return jswrap_date_getTime(parent);
+  TimeInDay td = getTimeFromDateVar(parent, false/*system timezone*/);
+  CalendarDate d = getCalendarDate(td.daysSinceEpoch);
+  d.year = yearValue;
+  if (jsvIsNumeric(monthValue))
+    d.month = jsvGetInteger(monthValue);
+  if (jsvIsNumeric(dayValue))
+    d.day = jsvGetInteger(dayValue);
+  td.daysSinceEpoch = fromCalendarDate(&d);
+  setCorrectTimeZone(&td);
+  return jswrap_date_setTime(parent, fromTimeInDay(&td));
 }
 
 

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -25,14 +25,13 @@ const char *DAYNAMES = "Sun\0Mon\0Tue\0Wed\0Thu\0Fri\0Sat";
 
 #ifdef ESPR_LIMIT_DATE_RANGE
 // This rounds towards zero - which is not what the algorithm needs. Hence the range for Date() is further limited when ESPR_LIMIT_DATE_RANGE is set
-int integerDivideFloor(int a, int b) {
-  return a/b;
-}
+#define INTEGER_DIVIDE_FLOOR(a,b) ((a)/(b))
 #else
 // This rounds down, which is what the algorithm needs
 int integerDivideFloor(int a, int b) {
   return (a < 0 ? a-b+1 : a)/b;
 }
+#define INTEGER_DIVIDE_FLOOR(a,b) integerDivideFloor((a),(b))
 #endif
 
 
@@ -54,8 +53,8 @@ int getDayNumberFromDate(int y, int m, int d) {
     m+=12;
   }
   // #2456 was created by integer division rounding towards zero, rather than the FLOOR-behaviour required by the algorithm.
-  ans = integerDivideFloor(y,100);
-  return 365*y + integerDivideFloor(y,4) - ans + integerDivideFloor(ans,4) + 30*m + ((3*m+6)/5) + d - 719531;
+  ans = INTEGER_DIVIDE_FLOOR(y,100);
+  return 365*y + INTEGER_DIVIDE_FLOOR(y,4) - ans + INTEGER_DIVIDE_FLOOR(ans,4) + 30*m + ((3*m+6)/5) + d - 719531;
 }
 
 // Convert a number of days since 1970 into y,m,d. 0<=m<=11
@@ -65,10 +64,10 @@ void getDateFromDayNumber(int day, int *y, int *m, int *date) {
   int b,c,d;
 
   // Bug #2456 fixed here too
-  a = integerDivideFloor(a - integerDivideFloor(a,146097) + 146095,36524);
-  a = day + a - integerDivideFloor(a,4);
-  b = integerDivideFloor((a<<2)+2877911,1461);
-  c = a + 719600 - 365*b - integerDivideFloor(b,4);
+  a = INTEGER_DIVIDE_FLOOR(a - INTEGER_DIVIDE_FLOOR(a,146097) + 146095,36524);
+  a = day + a - INTEGER_DIVIDE_FLOOR(a,4);
+  b = INTEGER_DIVIDE_FLOOR((a<<2)+2877911,1461);
+  c = a + 719600 - 365*b - INTEGER_DIVIDE_FLOOR(b,4);
   d = (5*c-1)/153; // Floor behaviour not needed, as c is always positive
   if (date) *date=c-30*d-((3*d)/5);
   if (m) {

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -24,7 +24,13 @@ const char *MONTHNAMES = "Jan\0Feb\0Mar\0Apr\0May\0Jun\0Jul\0Aug\0Sep\0Oct\0Nov\
 const char *DAYNAMES = "Sun\0Mon\0Tue\0Wed\0Thu\0Fri\0Sat";
 
 #ifdef ESPR_LIMIT_DATE_RANGE
-#define INTEGER_DIVIDE_FLOOR(a,b) (a/b)
+
+int integerDivideFloor(int a, int b) {
+  return a/b;
+}
+
+#define INTEGER_DIVIDE_FLOOR(a,b) integerDivideFloor(a,b)
+
 #else
 #define INTEGER_DIVIDE_FLOOR(a,b) ((a<0 ? a-b+1 : a)/b)
 #endif
@@ -36,9 +42,9 @@ int getDayNumberFromDate(int y, int m, int d) {
   int ans;
   
 #ifdef ESPR_LIMIT_DATE_RANGE
-  if (y < 1601 || y > 1250000) {
+  if (y < 1500 || y >= 1250000) { // Should actually work down to 1101, but since the Gregorian calendar started in 1582 . . .
 #else
-  if (y < -1265580 || y > 1269519) {
+  if (y < -1250000 || y >= 1250000) {
 #endif
     jsExceptionHere(JSET_ERROR, "Date out of bounds");
     return 0; // Need to head off any overflow error
@@ -402,9 +408,9 @@ Set the time/date of this Date class
  */
 JsVarFloat jswrap_date_setTime(JsVar *date, JsVarFloat timeValue) {
 #ifdef ESPR_LIMIT_DATE_RANGE
-  if (timeValue < -1.16e13 || timeValue > 3.0e16) {
+  if (timeValue < -1.48317696e13 || timeValue >= 3.93840543168E+016) { // This should actually work down to 1101AD . . .
 #else
-  if (fabs(timeValue) > 4.0e16) {
+  if (timeValue < -3.95083256832E+016 || timeValue >= 3.93840543168E+016) {
 #endif
     jsExceptionHere(JSET_ERROR, "Date out of bounds");
     return 0.0;

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -388,7 +388,7 @@ JsVarFloat jswrap_date_getTime(JsVar *date) {
 Set the time/date of this Date class
  */
 JsVarFloat jswrap_date_setTime(JsVar *date, JsVarFloat timeValue) {
-  if (abs(timeValue) > 4.0e-16) {
+  if (fabs(timeValue) > 4.0e16) {
     jsExceptionHere(JSET_ERROR, "Date out of bounds");
     return 0.0;
   }

--- a/src/jswrap_date.c
+++ b/src/jswrap_date.c
@@ -402,7 +402,7 @@ Set the time/date of this Date class
  */
 JsVarFloat jswrap_date_setTime(JsVar *date, JsVarFloat timeValue) {
 #ifdef ESPR_LIMIT_DATE_RANGE
-  if (timeValue < -1.16e13 || timeValue > 3.0e16)
+  if (timeValue < -1.16e13 || timeValue > 3.0e16) {
 #else
   if (fabs(timeValue) > 4.0e16) {
 #endif

--- a/src/jswrap_date.h
+++ b/src/jswrap_date.h
@@ -41,7 +41,7 @@ void setCorrectTimeZone(TimeInDay *td);
 TimeInDay getTimeFromMilliSeconds(JsVarFloat ms_in, bool forceGMT);
 JsVarFloat fromTimeInDay(TimeInDay *td);
 CalendarDate getCalendarDate(int d);
-int fromCalenderDate(CalendarDate *date);
+int fromCalendarDate(CalendarDate *date);
 
 JsVarFloat jswrap_date_now();
 JsVar *jswrap_date_from_milliseconds(JsVarFloat time);

--- a/targets/nrf5x/bluetooth_ancs.c
+++ b/targets/nrf5x/bluetooth_ancs.c
@@ -289,7 +289,7 @@ void ble_cts_handle_time(BLEPending blep, char *buffer, size_t bufferLen) {
   date.month = time.month-1; // JS months are 0-11, but CTS uses 1-12
   date.day = time.day;
   TimeInDay td;
-  td.daysSinceEpoch = fromCalenderDate(&date);
+  td.daysSinceEpoch = fromCalendarDate(&date);
   td.hour = time.hours;
   td.min = time.minutes;
   td.sec = time.seconds;

--- a/targets/stm32/jshardware.c
+++ b/targets/stm32/jshardware.c
@@ -1536,7 +1536,7 @@ JsSysTime jshGetRTCSystemTime() {
   cdate.month = date.RTC_Month-1; // 1..12 -> 0..11
   cdate.year = 2000+date.RTC_Year; // 0..99 -> 2000..2099
   cdate.dow = date.RTC_WeekDay%7; // 1(monday)..7 -> 0(sunday)..6
-  ctime.daysSinceEpoch = fromCalenderDate(&cdate);
+  ctime.daysSinceEpoch = fromCalendarDate(&cdate);
   ctime.zone = 0;
   ctime.ms = 0;
   ctime.sec = time.RTC_Seconds;

--- a/tests/test_date.js
+++ b/tests/test_date.js
@@ -4,6 +4,8 @@ try { new Date(4.1e16); pass--; } catch(e) { };
 try { new Date(-4.1e16); pass--; } catch(e) { };
 try { new Date(2000000,0); pass--; } catch(e) { };
 try { new Date(-2000000,0); pass--; } catch(e) { };
+// This next Date() constructor use to give a segfault. However it is now out of range for the PICO_R1_3
+try { a = new Date(-12,8).toString(); if (!(a== "Wed Aug 31 -12 00:00:00 GMT+0000")) pass--; } catch (e) { };
 
 var gmt = [
 [ Date.parse("2011-10-20") , 1319068800000.0 ],
@@ -17,8 +19,9 @@ var gmt = [
 [ new Date("Fri, 20 Jun 2014 15:27:22 GMT").toString(), "Fri Jun 20 2014 15:27:22 GMT+0000"],
 [ new Date("Fri, 20 Jun 2014 15:27:22 GMT").toISOString(), "2014-06-20T15:27:22.000Z"],
 [ new Date("Fri, 20 Jun 2014 17:27:22 GMT+0200").toISOString(), "2014-06-20T15:27:22.000Z"],
-[ new Date("5000-1-1").toISOString(), "5000-01-01T00:00:00.000Z"],
-[ new Date(-12,8).toString(), "Wed Aug 31 -12 00:00:00 GMT+0000"]
+[ new Date("5000-1-1").toString(), "Wed Jan 1 5000 00:00:00 GMT+0000"],
+[ new Date(1500,0,1).toString(), "Mon Jan 1 1500 00:00:00 GMT+0000"],
+[ new Date(1500,0,1).getTime(), -14831769600000]
 ];
 
 gmt.forEach(function(n) { if (n[0]==n[1]) pass++; });

--- a/tests/test_date.js
+++ b/tests/test_date.js
@@ -11,7 +11,8 @@ var gmt = [
 [ new Date(807926400000.0).toString() , "Wed Aug 9 1995 00:00:00 GMT+0000" ],
 [ new Date("Fri, 20 Jun 2014 15:27:22 GMT").toString(), "Fri Jun 20 2014 15:27:22 GMT+0000"],
 [ new Date("Fri, 20 Jun 2014 15:27:22 GMT").toISOString(), "2014-06-20T15:27:22.000Z"],
-[ new Date("Fri, 20 Jun 2014 17:27:22 GMT+0200").toISOString(), "2014-06-20T15:27:22.000Z"]
+[ new Date("Fri, 20 Jun 2014 17:27:22 GMT+0200").toISOString(), "2014-06-20T15:27:22.000Z"],
+[ new Date("5000-1-1").toISOString(), "5000-01-01T00:00:00.000Z"]
 ];
 
 gmt.forEach(function(n) { if (n[0]==n[1]) pass++; });

--- a/tests/test_date.js
+++ b/tests/test_date.js
@@ -17,7 +17,8 @@ var gmt = [
 [ new Date("Fri, 20 Jun 2014 15:27:22 GMT").toString(), "Fri Jun 20 2014 15:27:22 GMT+0000"],
 [ new Date("Fri, 20 Jun 2014 15:27:22 GMT").toISOString(), "2014-06-20T15:27:22.000Z"],
 [ new Date("Fri, 20 Jun 2014 17:27:22 GMT+0200").toISOString(), "2014-06-20T15:27:22.000Z"],
-[ new Date("5000-1-1").toISOString(), "5000-01-01T00:00:00.000Z"]
+[ new Date("5000-1-1").toISOString(), "5000-01-01T00:00:00.000Z"],
+[ new Date(-12,8).toString(), "Wed Aug 31 -12 00:00:00 GMT+0000"]
 ];
 
 gmt.forEach(function(n) { if (n[0]==n[1]) pass++; });

--- a/tests/test_date.js
+++ b/tests/test_date.js
@@ -1,5 +1,10 @@
 pass=0;
 
+try { new Date(4.1e16); pass--; } catch(e) { };
+try { new Date(-4.1e16); pass--; } catch(e) { };
+try { new Date(2000000,0); pass--; } catch(e) { };
+try { new Date(-2000000,0); pass--; } catch(e) { };
+
 var gmt = [
 [ Date.parse("2011-10-20") , 1319068800000.0 ],
 [ Date.parse("2011-10-20T14:48:12.345") , 1319122092345.0 ],


### PR DESCRIPTION
There were two things wrong with the Date library

1. The algorithm required divisions to round down, but integer division rounds-towards-zero. This was creating artifacts like negative month numbers.
2. There was no range checking on the inputs. Inputs large enough in magnitude could cause overflows in some of the integer operations.

Also the spelling on the function "fromCalendarDate" has been corrected. And the documentation for the "setMonth" method was wrong.

Date now implements the Gregorian calendar for over 1.2 million years either side of the present. Inputs outside that range will throw an error. Note that the Gregorian calendar actually came into existence in 1582, but memory is too tight on some platforms (notably PICO_R1_3) to do anything intelligent with that fact.