### PR TITLE
added the defines to the platform file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -716,7 +716,7 @@ OBJS = $(PRECOMPILED_OBJS) $(SOURCEOBJS)
 # -nodefaultlibs -nostdlib -nostartfiles
 
 # -fdata-sections -ffunction-sections are to help remove unused code
-CFLAGS += $(OPTIMIZEFLAGS) -c $(ARCHFLAGS) $(DEFINES) $(INCLUDE)
+CFLAGS += $(OPTIMIZEFLAGS) -c $(ARCHFLAGS) $(DEFINES) $(INCLUDE) -DESPR_AUTOCOMPLETE_NOT_REQUIRED
 
 # -Wl,--gc-sections helps remove unused code
 # -Wl,--whole-archive checks for duplicates
@@ -811,7 +811,7 @@ endif # NRF5X
 
 $(PLATFORM_CONFIG_FILE): boards/$(BOARD).py scripts/build_platform_config.py
 	@echo ================================== Generating platform configs
-	$(Q)$(PYTHON) scripts/build_platform_config.py $(BOARD) $(HEADERFILENAME)
+	$(Q)$(PYTHON) scripts/build_platform_config.py $(BOARD) $(HEADERFILENAME) "$(DEFINES)"
 
 # If realpath exists, use relative paths
 ifneq ("$(shell ${REALPATH} --version > /dev/null;echo "$$?")","0")

--- a/Makefile
+++ b/Makefile
@@ -809,9 +809,10 @@ $(LINKER_FILE): scripts/build_linker.py
 endif # EFM32
 endif # NRF5X
 
+DEFINES_ESCAPED = $(shell echo $(DEFINES) | sed 's/"/\\"/g')
 $(PLATFORM_CONFIG_FILE): boards/$(BOARD).py scripts/build_platform_config.py
 	@echo ================================== Generating platform configs
-	$(Q)$(PYTHON) scripts/build_platform_config.py $(BOARD) $(HEADERFILENAME) "$(DEFINES)"
+	$(Q)$(PYTHON) scripts/build_platform_config.py $(BOARD) $(HEADERFILENAME) "$(DEFINES_ESCAPED)"
 
 # If realpath exists, use relative paths
 ifneq ("$(shell ${REALPATH} --version > /dev/null;echo "$$?")","0")

--- a/Makefile
+++ b/Makefile
@@ -809,7 +809,8 @@ $(LINKER_FILE): scripts/build_linker.py
 endif # EFM32
 endif # NRF5X
 
-DEFINES_ESCAPED = $(shell echo $(DEFINES) | sed 's/"/\\"/g')
+DEFINES_NULL_STRING = $(subst \0,\\0,$(DEFINES))
+DEFINES_ESCAPED = $(shell echo  $(DEFINES_NULL_STRING)  | sed 's/"/\\"/g')
 $(PLATFORM_CONFIG_FILE): boards/$(BOARD).py scripts/build_platform_config.py
 	@echo ================================== Generating platform configs
 	$(Q)$(PYTHON) scripts/build_platform_config.py $(BOARD) $(HEADERFILENAME) "$(DEFINES_ESCAPED)"

--- a/scripts/build_platform_config.py
+++ b/scripts/build_platform_config.py
@@ -35,11 +35,15 @@ import pinutils;
 # Now scan AF file
 print("Script location "+scriptdir)
 
-if len(sys.argv)!=3:
+if not (len(sys.argv)==3 or len(sys.argv)==4):
   print("ERROR, USAGE: build_platform_config.py BOARD_NAME HEADERFILENAME")
   exit(1)
 boardname = sys.argv[1]
 headerFilename = sys.argv[2]
+defines = []
+if len(sys.argv)==4:
+  defines = sys.argv[3]
+  
 print("HEADER_FILENAME "+headerFilename)
 print("BOARD "+boardname)
 # import the board def
@@ -553,6 +557,22 @@ codeOut("#define IS_PIN_USED_INTERNALLY(PIN) (("+")||(".join(usedPinChecks)+"))"
 codeOut("#define IS_PIN_A_LED(PIN) (("+")||(".join(ledChecks)+"))")
 codeOut("#ifndef IS_PIN_A_BUTTON")
 codeOut("#define IS_PIN_A_BUTTON(PIN) (("+")||(".join(btnChecks)+"))")
+
+# add makefile defines
+if len(defines) > 2:
+  codeOut("\n#ifndef ESPR_AUTOCOMPLETE_NOT_REQUIRED")
+  for define in defines.strip().split():
+    if not define.startswith("-D"):
+      continue
+    define = define[2:]
+    if "=" in define:
+      defSplit = define.split("=")
+      codeOut("\t#define " + defSplit[0] + " " + defSplit[1])
+    else:
+      codeOut("\t#define " + define)
+  codeOut("#endif")
+# end makefile defines
+  
 codeOut("#endif")
 
 codeOut("""

--- a/scripts/build_platform_config.py
+++ b/scripts/build_platform_config.py
@@ -557,6 +557,7 @@ codeOut("#define IS_PIN_USED_INTERNALLY(PIN) (("+")||(".join(usedPinChecks)+"))"
 codeOut("#define IS_PIN_A_LED(PIN) (("+")||(".join(ledChecks)+"))")
 codeOut("#ifndef IS_PIN_A_BUTTON")
 codeOut("#define IS_PIN_A_BUTTON(PIN) (("+")||(".join(btnChecks)+"))")
+codeOut("#endif")
 
 # add makefile defines
 if len(defines) > 2:
@@ -572,8 +573,6 @@ if len(defines) > 2:
       codeOut("\t#define " + define)
   codeOut("#endif")
 # end makefile defines
-  
-codeOut("#endif")
 
 codeOut("""
 #endif // _PLATFORM_CONFIG_H


### PR DESCRIPTION
Based on the topics [here](https://github.com/espruino/Espruino/pull/2468), I've edited the code to put the defines in the platform_config.h


**Key points**

**How**
So what about this: we modify the Makefile to call scripts/build_platform_config.py $(BOARD) $(HEADERFILENAME) $(DEFINES) and then modify build_platform_config to pick up those defines from the command line and create a block like out define.

**No side effects**
