### PR TITLE
Disabling unused warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ INCLUDE?=-I$(ROOT) -I$(ROOT)/targets -I$(ROOT)/src -I$(GENDIR)
 LIBS?=
 DEFINES?=
 CFLAGS?=-Wall -Wextra -Wconversion -Werror=implicit-function-declaration -fno-strict-aliasing -g
+CFLAGS+=-Wno-unused-function -Wno-unused-variable -Wno-unused-parameter #optional disabled comments to clean up build
 CFLAGS+=-Wno-packed-bitfield-compat # remove warnings from packed var usage
 
 CCFLAGS?= # specific flags when compiling cc files


### PR DESCRIPTION
Removing warning is usually a bad thing, but for a project that supports so many devices and pieces of hardware i think these kinds of errors are hard to avoid.  

So personally i remove these warnings to make potentially larger more problematic problems easier to see.  

But this is just a suggestion.