### PR TITLE
Building EMSCRIPTEN boards on the latest EMCC

### DIFF
--- a/make/family/EMSCRIPTEN.make
+++ b/make/family/EMSCRIPTEN.make
@@ -6,5 +6,5 @@ targets/emscripten/jshardware.c
 LIBS += -lc
 #LIBS += -lstdc++
 CFLAGS += -Wno-unused-function -Wno-switch
-LDFLAGS += -s EXPORTED_FUNCTIONS='["_jsInit","_jsIdle","_jsKill","_jshPushIOCharEvent","_jsSendPinWatchEvent","_jsSendTouchEvent","_jshGetDeviceToTransmit","_jshGetCharToTransmit","_jsGfxChanged","_jsGfxGetPtr"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall"]' -s WASM=0 -s ASSERTIONS=1 --memory-init-file 0 -Oz 
+LDFLAGS += -s EXPORTED_FUNCTIONS='["_jsInit","_jsIdle","_jsKill","_jshPushIOCharEvent","_jsSendPinWatchEvent","_jsSendTouchEvent","_jshGetDeviceToTransmit","_jshGetCharToTransmit","_jsGfxChanged","_jsGfxGetPtr"]' -s EXPORTED_RUNTIME_METHODS='["ccall"]' -s WASM=0 -s ASSERTIONS=1 --memory-init-file 0 -Oz 
 

--- a/targets/emscripten/jshardware.c
+++ b/targets/emscripten/jshardware.c
@@ -31,6 +31,14 @@
 
 #define FLASH_UNITARY_WRITE_SIZE 4
 #define FAKE_FLASH_BLOCKSIZE 4096
+
+// ----------------------------------------------------------------------------
+/*Reason - Needed for latest build of EMCC(3.1.55).  Else unreferenced function*/
+EM_JS(void, emscripten_memcpy_js, (uint8_t* dest, uint8_t* src, size_t numBytes), {
+  var destHeap = new Uint8Array(Module.HEAPU8.buffer, dest, numBytes);
+  var srcHeap = new Uint8Array(Module.HEAPU8.buffer, src, numBytes);
+  destHeap.set(srcHeap);
+});
 // ----------------------------------------------------------------------------
 
 Pin eventFlagsToPin[16];

--- a/targets/emscripten/jshardware.c
+++ b/targets/emscripten/jshardware.c
@@ -33,7 +33,7 @@
 #define FAKE_FLASH_BLOCKSIZE 4096
 
 // ----------------------------------------------------------------------------
-/*Reason - Needed for latest build of EMCC(3.1.55).  Else unreferenced function*/
+/*Reason - Needed for latest build of EMCC(3.1.55).  Else undefined symbol*/
 EM_JS(void, emscripten_memcpy_js, (uint8_t* dest, uint8_t* src, size_t numBytes), {
   var destHeap = new Uint8Array(Module.HEAPU8.buffer, dest, numBytes);
   var srcHeap = new Uint8Array(Module.HEAPU8.buffer, src, numBytes);


### PR DESCRIPTION
So this pull is updated to work with the latest EMCC.  So there's just two changes.  

* One is a name change on the build
* The other is a javascript function definition.  

I'm not entirely what changed to necessitate this function needing to be defined.  But it seemed to fix the problem.   

Error

error: undefined symbol: emscripten_memcpy_js (referenced by root reference (e.g. compiled C/C++ code))