### PR TITLE
Added C_ONLY_FLAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ endif
 INCLUDE?=-I$(ROOT) -I$(ROOT)/targets -I$(ROOT)/src -I$(GENDIR)
 LIBS?=
 DEFINES?=
+C_ONLY_FLAGS?=
 CFLAGS?=-Wall -Wextra -Wconversion -Werror=implicit-function-declaration -fno-strict-aliasing -g
 CFLAGS+=-Wno-packed-bitfield-compat # remove warnings from packed var usage
 
@@ -230,7 +231,8 @@ endif
 ifdef DEBUG
 #OPTIMIZEFLAGS=-Os -g
  ifeq ($(FAMILY),ESP8266)
-  OPTIMIZEFLAGS=-g -Os -std=gnu11 -fgnu89-inline -Wl,--allow-multiple-definition
+  OPTIMIZEFLAGS=-g -Os -Wl,--allow-multiple-definition
+  C_ONLY_FLAGS= -std=gnu11 -fgnu89-inline
  else
   OPTIMIZEFLAGS=-g
  endif
@@ -816,10 +818,10 @@ $(PLATFORM_CONFIG_FILE): boards/$(BOARD).py scripts/build_platform_config.py
 
 # If realpath exists, use relative paths
 ifneq ("$(shell ${REALPATH} --version > /dev/null;echo "$$?")","0")
-compile=$(CC) $(CFLAGS) $< -o $@
+compile=$(CC) $(C_ONLY_FLAGS) $(CFLAGS) $< -o $@
 else
 # when macros use __FILE__ this stops us including the whole build path
-compile=$(CC) $(CFLAGS) $(shell ${REALPATH} --relative-to $(shell pwd) $<) -o $@
+compile=$(CC) $(C_ONLY_FLAGS) $(CFLAGS) $(shell ${REALPATH} --relative-to $(shell pwd) $<) -o $@
 endif
 
 link=$(LD) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,9 @@ endif
 INCLUDE?=-I$(ROOT) -I$(ROOT)/targets -I$(ROOT)/src -I$(GENDIR)
 LIBS?=
 DEFINES?=
-C_ONLY_FLAGS?=
-CFLAGS?=-Wall -Wextra -Wconversion -Werror=implicit-function-declaration -fno-strict-aliasing -g
+
+CFLAGS_C_COMPILER?= -Werror=implicit-function-declaration
+CFLAGS?=-Wall -Wextra -Wconversion -fno-strict-aliasing -g
 CFLAGS+=-Wno-packed-bitfield-compat # remove warnings from packed var usage
 
 CCFLAGS?= # specific flags when compiling cc files
@@ -232,7 +233,7 @@ ifdef DEBUG
 #OPTIMIZEFLAGS=-Os -g
  ifeq ($(FAMILY),ESP8266)
   OPTIMIZEFLAGS=-g -Os -Wl,--allow-multiple-definition
-  C_ONLY_FLAGS= -std=gnu11 -fgnu89-inline
+  CFLAGS_C_COMPILER= -std=gnu11 -fgnu89-inline
  else
   OPTIMIZEFLAGS=-g
  endif
@@ -818,10 +819,10 @@ $(PLATFORM_CONFIG_FILE): boards/$(BOARD).py scripts/build_platform_config.py
 
 # If realpath exists, use relative paths
 ifneq ("$(shell ${REALPATH} --version > /dev/null;echo "$$?")","0")
-compile=$(CC) $(C_ONLY_FLAGS) $(CFLAGS) $< -o $@
+compile=$(CC) $(CFLAGS_C_COMPILER) $(CFLAGS) $< -o $@
 else
 # when macros use __FILE__ this stops us including the whole build path
-compile=$(CC) $(C_ONLY_FLAGS) $(CFLAGS) $(shell ${REALPATH} --relative-to $(shell pwd) $<) -o $@
+compile=$(CC) $(CFLAGS_C_COMPILER) $(CFLAGS) $(shell ${REALPATH} --relative-to $(shell pwd) $<) -o $@
 endif
 
 link=$(LD) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)

--- a/make/family/EMBED.make
+++ b/make/family/EMBED.make
@@ -2,7 +2,7 @@
 # in other projects. It doesn't contain any of the hardware access code, just the basic
 # JS interpreter. See boards/EMBED.py
 
-C_ONLY_FLAGS += -std=gnu99
+CFLAGS_C_COMPILER += -std=gnu99
 DEFINES += -DESPR_EMBED=1
 INCLUDE += -I$(ROOT)/targets/embed
 SOURCES +=                              \

--- a/make/family/EMBED.make
+++ b/make/family/EMBED.make
@@ -2,7 +2,7 @@
 # in other projects. It doesn't contain any of the hardware access code, just the basic
 # JS interpreter. See boards/EMBED.py
 
-CFLAGS += -std=gnu99
+C_ONLY_FLAGS += -std=gnu99
 DEFINES += -DESPR_EMBED=1
 INCLUDE += -I$(ROOT)/targets/embed
 SOURCES +=                              \

--- a/make/family/ESP32.make
+++ b/make/family/ESP32.make
@@ -6,7 +6,8 @@ ESP32=1
 
 CFLAGS+=-Og -Wpointer-arith -Wno-error=unused-function -Wno-error=unused-but-set-variable \
 -Wno-error=unused-variable -Wall -ffunction-sections -fdata-sections -mlongcalls -nostdlib \
--MMD -MP -std=gnu99 -fstrict-volatile-bitfields -fgnu89-inline -mfix-esp32-psram-cache-issue
+-MMD -MP -fstrict-volatile-bitfields -fgnu89-inline -mfix-esp32-psram-cache-issue
+C_ONLY_FLAGS += -std=gnu99
 SOURCES += targets/esp32/jshardware.c \
 targets/esp32/jshardwareESP32.c \
 targets/esp32/esp32_neopixel.c

--- a/make/family/ESP32.make
+++ b/make/family/ESP32.make
@@ -7,7 +7,7 @@ ESP32=1
 CFLAGS+=-Og -Wpointer-arith -Wno-error=unused-function -Wno-error=unused-but-set-variable \
 -Wno-error=unused-variable -Wall -ffunction-sections -fdata-sections -mlongcalls -nostdlib \
 -MMD -MP -fstrict-volatile-bitfields -fgnu89-inline -mfix-esp32-psram-cache-issue
-C_ONLY_FLAGS += -std=gnu99
+CFLAGS_C_COMPILER += -std=gnu99
 SOURCES += targets/esp32/jshardware.c \
 targets/esp32/jshardwareESP32.c \
 targets/esp32/esp32_neopixel.c

--- a/make/family/ESP8266.make
+++ b/make/family/ESP8266.make
@@ -6,12 +6,13 @@ ESP8266=1
 # Enable link-time optimisations (inlining across files), use -Os 'cause else we end up with
 # too large a firmware (-Os is -O2 without optimizations that increase code size)
 ifndef DISABLE_LTO
-OPTIMIZEFLAGS+=-Os -g -std=gnu11 -fgnu89-inline -fno-fat-lto-objects -Wl,--allow-multiple-definition
+OPTIMIZEFLAGS+=-Os -g -fno-fat-lto-objects -Wl,--allow-multiple-definition
 #OPTIMIZEFLAGS+=-DLINK_TIME_OPTIMISATION # this actually slows things down!
 else
 # DISABLE_LTO is necessary in order to analyze static string sizes (see: topstring makefile target)
-OPTIMIZEFLAGS+=-Os -std=gnu11 -fgnu89-inline -Wl,--allow-multiple-definition
+OPTIMIZEFLAGS+=-Os -Wl,--allow-multiple-definition
 endif
+C_ONLY_FLAGS= -std=gnu11 -fgnu89-inline
 
 ET_FM               ?= qio      # Valid values are keep, qio, qout, dio, dout
 

--- a/make/family/ESP8266.make
+++ b/make/family/ESP8266.make
@@ -12,7 +12,7 @@ else
 # DISABLE_LTO is necessary in order to analyze static string sizes (see: topstring makefile target)
 OPTIMIZEFLAGS+=-Os -Wl,--allow-multiple-definition
 endif
-C_ONLY_FLAGS= -std=gnu11 -fgnu89-inline
+CFLAGS_C_COMPILER= -std=gnu11 -fgnu89-inline
 
 ET_FM               ?= qio      # Valid values are keep, qio, qout, dio, dout
 

--- a/make/family/LINUX.make
+++ b/make/family/LINUX.make
@@ -28,7 +28,7 @@ endif
 ifdef MACOSX
   CCFLAGS += -DTF_LITE_DISABLE_X86_NEON
 else
-  C_ONLY_FLAGS += -std=gnu99
+  CFLAGS_C_COMPILER += -std=gnu99
 endif
 DEFINES += -DLINUX
 INCLUDE += -I$(ROOT)/targets/linux

--- a/make/family/LINUX.make
+++ b/make/family/LINUX.make
@@ -28,7 +28,7 @@ endif
 ifdef MACOSX
   CCFLAGS += -DTF_LITE_DISABLE_X86_NEON
 else
-  CFLAGS += -std=gnu99
+  C_ONLY_FLAGS += -std=gnu99
 endif
 DEFINES += -DLINUX
 INCLUDE += -I$(ROOT)/targets/linux


### PR DESCRIPTION
So the problem is that the [.cc files](https://github.com/espruino/Espruino/blob/e5ffc93c2ca76bfdfc688b1be32ba9306d09cf77/Makefile#L844) take all the CFLAGS because of that it also grabs the "-std=GNUXX" flags.   

So i added another flag to separate out the flags that can only exist on a c file.

Error Message

CC obj/libs/tensorflow/tensorflow/lite/core/api/error_reporter.cc.o
cc1plus: warning: ‘-Werror=’ argument ‘-Werror=-std=gnu99’ is not valid for C++