### PR TITLE
Build emulators in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,35 @@ jobs:
           bin/*.tgz
           bin/*.zip
  
+  # emulator builds
+  build_emulator:
+    runs-on: ubuntu-20.04
+    strategy:
+      # devices to build for
+      matrix:  # banglejs,   banglejs2
+        board: [EMSCRIPTEN, EMSCRIPTEN2]
+      # try and build for all devices even if one fails
+      fail-fast: false 
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: make ${{ matrix.board }}
+      env:
+        TRAVIS: 1
+        RELEASE: 1
+        BOARD: ${{ matrix.board }} 
+        UPLOADTOKEN: ${{ secrets.UPLOADTOKEN }}  
+      run: |
+        source ./scripts/provision.sh  ${{ matrix.board }}
+        make
+        ./scripts/ci_upload.sh
+    - name: Upload ${{ matrix.board }} build artifact
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: ${{ matrix.board }}
+        path: |
+          bin/*.js
  
 # Disable doc building for now 
 #  docs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,22 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
-      git-ref:
-        description: Git Ref (Optional)    
-        required: false
+      enable_main:
+        description: Build default boards (linux, ESP, Microbit)
+        type: boolean
+        default: true
+      enable_dfu:
+        description: Build boards with DFU (puckjs, pixljs, banglejs)
+        type: boolean
+        default: true
+      enable_padded:
+        description: Build boards with bootloader padding (espruinoboard, -wifi, pico)
+        type: boolean
+        default: true
+      enable_emulator:
+        description: Build emulator for banglejs
+        type: boolean
+        default: true
       
 
 permissions:
@@ -21,6 +34,7 @@ jobs:
 
   # normal builds
   build_main:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.enable_main }}
     runs-on: ubuntu-20.04
     strategy:
       # devices to build for
@@ -55,6 +69,7 @@ jobs:
         
   # Builds with DFU_UPDATE_BUILD=1        
   build_dfu:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.enable_dfu }}
     runs-on: ubuntu-20.04
     strategy:
       # devices to build for
@@ -89,6 +104,7 @@ jobs:
        
   # Builds with PAD_FOR_BOOTLOADER=1
   build_padded:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.enable_padded }}
     runs-on: ubuntu-20.04
     strategy:
       # devices to build for
@@ -123,6 +139,7 @@ jobs:
  
   # emulator builds
   build_emulator:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.enable_emulator }}
     runs-on: ubuntu-20.04
     strategy:
       # devices to build for

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ arm-gnu-toolchain*
 *.c#
 /function_keywords.js
 /functions.html
+/targetlibs/emscripten/emsdk
 /targetlibs/nrf5x_11
 /targetlibs/nrf5x_12/examples
 /targetlibs/nrf5x_12/documentation/

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -44,6 +44,8 @@ if [ "$BOARDNAME" = "ALL" ]; then
   PROVISION_STM32F4=1
   PROVISION_STM32L4=1 
   PROVISION_RASPBERRYPI=1 
+  PROVISION_EMSCRIPTEN=1
+  PROVISION_EMSCRIPTEN2=1
 else
   FAMILY=`scripts/get_board_info.py $BOARDNAME 'board.chip["family"]'`
   if [ "$FAMILY" = "" ]; then
@@ -275,3 +277,21 @@ if [ "$ARM" = "1" ]; then
 	      export PATH=$PATH:`pwd`/$EXPECTEDARMGCCFILENAME/bin
     fi
 fi
+
+#--------------------------------------------------------------------------------
+EMSCRIPTEN_VERSION="3.1.54"
+
+if [ "$PROVISION_EMSCRIPTEN" = "1" ] || [ "$PROVISION_EMSCRIPTEN2" = "1" ]; then
+    echo ===== EMULATOR
+    echo Installing Emscripten $EMSCRIPTEN_VERSION
+    if [ ! -d "targetlibs/emscripten/emsdk" ]; then
+        mkdir targetlibs/emscripten
+        cd targetlibs/emscripten
+        git clone --depth=1 https://github.com/emscripten-core/emsdk
+        cd ../..
+    fi
+    ./targetlibs/emscripten/emsdk/emsdk install $EMSCRIPTEN_VERSION
+    ./targetlibs/emscripten/emsdk/emsdk activate $EMSCRIPTEN_VERSION
+    source ./targetlibs/emscripten/emsdk/emsdk_env.sh
+fi
+#--------------------------------------------------------------------------------


### PR DESCRIPTION
It is currently a lot of work to set up your environment so that you can compile the banglejs emulators. I suggest adding a new workflow file that anyone can run to quickly and easily compile the emulators.

The workflow does not run by default, so it does not have any negative impact on the normal use of this repo. It is just available as something that users can manually trigger in their own local forks.