### PR TITLE
Fix parsing of multiple expressions without newlines/semis

### DIFF
--- a/tests/test_parse_exprs.js
+++ b/tests/test_parse_exprs.js
@@ -1,0 +1,4 @@
+f = function() { console.log("hi") }
+
+// should error:
+f() 1+2 f()


### PR DESCRIPTION
This fixes parsing such as:
```javascript
>a=[1,2]
=[ 1, 2 ]
>b = a[1]0          // <----------------
=0
>b = a[1]5          // <----------------
=5

>f=()=>{}
=function () {}
>b = f()5          // <----------------
=5
>b = f()5*2          // <----------------
=10

>f=()=>console.log("hi")
=function () { ... }
>b = f()5*2          // <----------------
hi
=10
>b = f()5*2 3          // <----------------
hi
=3
>b = f()5*2 3 6          // <----------------
hi
=6
>b = f()5*2 f() f()          // <----------------
hi
hi
hi
=undefined
>b = f()5*2 f() f() "abc"          // <----------------
hi
hi
hi
="abc"
```