### PR TITLE
Object.defineProperty can be called on functions and arrays (and the root)

### DIFF
--- a/src/jswrap_object.c
+++ b/src/jswrap_object.c
@@ -607,8 +607,8 @@ will be ignored.
 
  */
 JsVar *jswrap_object_defineProperty(JsVar *parent, JsVar *propName, JsVar *desc) {
-  if (!jsvIsObject(parent)) {
-    jsExceptionHere(JSET_ERROR, "First argument must be Object, got %t", parent);
+  if (!jsvIsObject(parent) && !jsvIsFunction(parent) && !jsvIsArray(parent)) {
+    jsExceptionHere(JSET_ERROR, "First argument must be Object, Function or Array, got %t", parent);
     return 0;
   }
   if (!jsvIsObject(desc)) {


### PR DESCRIPTION
This permits `Object.defineProperty(Bangle, ...)`, for example

Closes #2501