### PR TITLE
Fix NUCLEOF411RE binary

### DIFF
--- a/boards/NUCLEOF411RE.py
+++ b/boards/NUCLEOF411RE.py
@@ -27,16 +27,15 @@ info = {
  'build' : {
    'optimizeflags' : '-O3',
    'libraries' : [
+     'NET',
      'GRAPHICS',
      'NEOPIXEL'
    ],
    'makefile' : [
-     'DEFINES+=-DSAVE_ON_FLASH_MATH', 
-     'DEFINES+=-DESPR_PACKED_SYMPTR', # Pack builtin symbols' offset into pointer to save 2 bytes/symbol
      'WRAPPERSOURCES+=targets/nucleo/jswrap_nucleo.c',
      'DEFINES+=-DUSE_USB_OTG_FS=1',
      'DEFINES+=-DPIN_NAMES_DIRECT=1', # Package skips out some pins, so we can't assume each port starts from 0
-     'STLIB=STM32F401xE',
+     'STLIB=STM32F411xE',
      'PRECOMPILED_OBJS+=$(ROOT)/targetlibs/stm32f4/lib/startup_stm32f401xx.o'
    ]
   }


### PR DESCRIPTION
Looks like this commit https://github.com/espruino/Espruino/commit/29a243226ea2ec15a68f8aed9bd3c7ff736c185c broke the Nucleo F411 binary, details here: https://forum.espruino.com/conversations/396990/#comment17415645 

Reverted the mentioned commit's changes to the F411 board file, and changed `'STLIB=STM32F401xE'` to `'STLIB=STM32F411xE'` since it's a 411 :) No idea if that makes any difference... 
Did some basic testing, so far it seems to work fine.

Edit: don't have a 401 Nucleo, so I have no idea if whether that binary works...