### PR TITLE
clean gcc startup code also for nrf5x SDK >=15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -890,7 +890,7 @@ clean:
 	$(Q)rm -f $(BINDIR)/espruino_embedded.h
 	$(Q)rm -f $(BINDIR)/espruino_embedded.c
 	$(Q)rm -f $(BINDIR)/jstypes.h
-	$(Q)rm -f $(ROOT)/targetlibs/nrf5x_*/components/toolchain/gcc/gcc_startup_nrf5*.o $(ROOT)/targetlibs/stm32f4/lib/startup_stm32f4*.o $(ROOT)/targetlibs/stm32f1/lib/startup_stm32f10x_*.o
+	$(Q)rm -f $(ROOT)/targetlibs/nrf5x_*/components/toolchain/gcc/gcc_startup_nrf5*.o $(ROOT)/targetlibs/nrf5x_*/modules/nrfx/mdk/gcc_startup_nrf5*.o $(ROOT)/targetlibs/stm32f4/lib/startup_stm32f4*.o $(ROOT)/targetlibs/stm32f1/lib/startup_stm32f10x_*.o
 
 wrappersources:
 	$(info WRAPPERSOURCES=$(WRAPPERSOURCES))


### PR DESCRIPTION
For SDK15 and up the gcc startup code is  in different location.
When not properly cleaned it breaks when gcc startup code is built with different flags for different boards.
This is follow-up fix to PR #2510 which makes building with different flags possible.