### PR TITLE
typescript: fix `NRFSecurityStatus` & `setLCDOverlay`

### DIFF
--- a/libs/banglejs/jswrap_bangle.c
+++ b/libs/banglejs/jswrap_bangle.c
@@ -2412,7 +2412,7 @@ void jswrap_banglejs_setLCDOffset(int y) {
       "setLCDOverlay(img: any, x: number, y: number): void;",
       "setLCDOverlay(): void;",
       "setLCDOverlay(img: any, x: number, y: number, options: { id : string, remove: () => void }): void;",
-      "setLCDOverlay(img: any, options: { id : string }}): void;"
+      "setLCDOverlay(img: any, options: { id : string }): void;"
     ]
 }
 Overlay an image or graphics instance on top of the contents of the graphics buffer.

--- a/libs/bluetooth/jswrap_bluetooth.c
+++ b/libs/bluetooth/jswrap_bluetooth.c
@@ -3741,9 +3741,11 @@ void jswrap_ble_setSecurity(JsVar *options) {
 /*TYPESCRIPT
 type NRFSecurityStatus = {
   advertising: boolean,
-  privacy?: false || {
-    mode: string,
-    addr_type: string,
+  privacy?: ShortBoolean | {
+    mode: "off"
+  } | {
+    mode: "device_privacy" | "network_privacy",
+    addr_type: "random_private_resolvable" | "random_private_non_resolvable",
     addr_cycle_s: number,
   },
 } & (


### PR DESCRIPTION
- `setLCDOverlay`: typo
- `NRFSecurityStatus`: `||` -> `|` and improved string + boolean types