### PR TITLE
fix overlays being cut off from the top

### DIFF
--- a/libs/graphics/lcd_memlcd.c
+++ b/libs/graphics/lcd_memlcd.c
@@ -319,7 +319,7 @@ void lcdMemLCD_flip(JsGraphics *gfx) {
     // initialise image layer
     GfxDrawImageLayer l;
     l.x1 = 0;
-    l.y1 = ovY;
+    l.y1 = ovY<<8;
     l.img = overlayImg;
     l.rotate = isRotated180 ? 3.141592 : 0;
     l.scale = 1;


### PR DESCRIPTION
Previously, overlays were always positioned at y=0 and the y pos was cut off from the top part of the buffer.

That behaviour was introduced by: fdbf0bfd2
Since that commit, the coordinates of a `GfxDrawImageLayer` were changed to be the position in pixels, shifted to the left by 8 bits.
The overlay y position now has to be shifted to the left by 8 bits as well, before assigning it to the y start coordinate of a `GfxDrawImageLayer`.

Closes #2520 (See that issue for screenshots and some more info.)