### PR TITLE
Fix lexing of regex at the start of a if/loop

### DIFF
--- a/src/jslex.c
+++ b/src/jslex.c
@@ -840,6 +840,7 @@ void jslGetNextToken() {
           lastToken=='{' ||
           lastToken=='}' ||
           lastToken=='(' ||
+          lastToken==')' ||
           lastToken==',' ||
           lastToken==';' ||
           lastToken==':') {


### PR DESCRIPTION
This only really appears in code (espruino/BangleApps#3498) which is minified to something like:
```javascript
var b=E.getPowerUsage(),
  c=E.getBattery(),
  a=0;

for(var d in b.device)
  /^(LCD|LED)/.test(d) || (a += b.device[d]);
```

... resulting in:

```
Uncaught SyntaxError: Got '^' expected EOF
 at line 1 col 109 in widbattpwr.wid.js
...attery(),a=0;for(var d in b.device)/^(LCD|LED)/.test(d)||(a+=b.device[...
                                        ^
 at line 1 col 110 in widbattpwr.wid.js
...ttery(),a=0;for(var d in b.device)/^(LCD|LED)/.test(d)||(a+=b.device[d...
                                        ^
```

So while the code runs fine normally, installing it via the proper route minifies it and leads to it being unable to run.

---

This is the case for both `if` statements and loops:

```javascript
>for(;0;)/a/;
Uncaught SyntaxError: Got ';' expected EOF
 at line 1 col 9
for(;0;)/a/;
        ^
 at line 1 col 12
for(;0;)/a/;
           ^
>for(x in [])/a/;
Uncaught SyntaxError: Got ';' expected EOF
 at line 1 col 13
for(x in [])/a/;
            ^
 at line 1 col 16
for(x in [])/a/;
               ^
```

while & if statements:

```javascript
>while(0)/a/;
Uncaught SyntaxError: Got ';' expected EOF
 at line 1 col 9
while(0)/a/;
        ^
 at line 1 col 12
while(0)/a/;
           ^
>if(0)/a/;
Uncaught SyntaxError: Got '/' expected EOF
 at line 1 col 6
if(0)/a/;
     ^
>if(0)3;
=undefined
```

The issue is that we don't lex regex immediately after a close-paren, so the fix is quite straightforward.