### PR TITLE
Revert "Fix lexing of regex at the start of a if/loop"

### DIFF
--- a/src/jslex.c
+++ b/src/jslex.c
@@ -840,7 +840,6 @@ void jslGetNextToken() {
           lastToken=='{' ||
           lastToken=='}' ||
           lastToken=='(' ||
-          lastToken==')' ||
           lastToken==',' ||
           lastToken==';' ||
           lastToken==':') {


### PR DESCRIPTION
Reverts espruino/Espruino#2529 - it breaks `(1)/2`!