### PR TITLE
Bangle_showClock: Set Bangle.CLOCK=1

### DIFF
--- a/libs/js/banglejs/Bangle_showClock.js
+++ b/libs/js/banglejs/Bangle_showClock.js
@@ -1,3 +1,4 @@
 (function() {
+  Bangle.CLOCK=1;
   Bangle.load(".bootcde");
 })

--- a/libs/js/banglejs/Bangle_showClock.min.js
+++ b/libs/js/banglejs/Bangle_showClock.min.js
@@ -1,1 +1,1 @@
-(function(){Bangle.load(".bootcde")})
+(function(){Bangle.CLOCK=1;Bangle.load(".bootcde");})


### PR DESCRIPTION
Background:
  When moving from an app where e.g. `widanclk` (analog clock widget) is
  in use to the clock with a Bangle.showClock call the widget will not
  hide immediately.

The fix:
  Makes it so widgets that should hide on clock are hidden immediately
  when fast loading the clock, at the same time as the red back button
  widget.