### PR TITLE
allow to switch between USB_CDC and UART for ESP32C3 boards

### DIFF
--- a/boards/ESP32C3_IDF4.py
+++ b/boards/ESP32C3_IDF4.py
@@ -74,6 +74,7 @@ info = {
      'DEFINES+=-DESP_STACK_SIZE=25000',
      'DEFINES+=-DJSVAR_MALLOC', # Allocate space for variables at jsvInit time
      'DEFINES+=-DUSE_FONT_6X8',
+     'DEFINES+=-DUSB_CDC',      # Disable USB_CDC if board has uart interface      
      'ESP32_FLASH_MAX=1572864'
    ]
  }

--- a/targets/esp32/jshardwareUart.c
+++ b/targets/esp32/jshardwareUart.c
@@ -87,11 +87,13 @@ void initSerial(IOEventFlags device,JshUSARTInfo *inf){
 
 void initConsole(){
 #ifdef CONFIG_IDF_TARGET_ESP32C3
+  #ifdef USB_CDC
   /* Configure USB-CDC */
   usb_serial_jtag_driver_config_t usb_serial_config = {.tx_buffer_size = 128,
                                                        .rx_buffer_size = 128};
 
   ESP_ERROR_CHECK(usb_serial_jtag_driver_install(&usb_serial_config));
+  #endif
 #endif
 
   uart_config_t uart_config = {
@@ -117,7 +119,11 @@ void consoleToEspruino(){
   ticksToWait = 50 / portTICK_RATE_MS;
 #endif
 #ifdef CONFIG_IDF_TARGET_ESP32C3
+  #ifdef USB_CDC
   int len = usb_serial_jtag_read_bytes(rxbuf, sizeof(rxbuf), ticksToWait);
+  #else
+  int len = uart_read_bytes(uart_console, rxbuf, sizeof(rxbuf), ticksToWait);  // Read data from UART
+  #endif
 #else
   int len = uart_read_bytes(uart_console, rxbuf, sizeof(rxbuf), ticksToWait);  // Read data from UART
 #endif


### PR DESCRIPTION
  'DEFINES+=-DUSB_CDC', # Disable this line to use serial interface

Tested with both ESP32C3 boards. Please let me know if this is ok or you want me to change anything.