### PR TITLE
typescript: add menu scroller

### DIFF
--- a/libs/pixljs/jswrap_pixljs.c
+++ b/libs/pixljs/jswrap_pixljs.c
@@ -570,7 +570,16 @@ type MenuInstance = {
   draw: () => void;
   move: (n: number) => void;
   select: () => void;
+  scroller?: MenuScroller; // BangleJS 2
 };
+
+/**
+ * Menu scroller.
+ *\/
+type MenuScroller = {
+  scroll: number;
+};
+
 */
 
 /*JSON{


### PR DESCRIPTION
... for banglejs2 only, the easiest way to do this being to indicate it as optional