### PR TITLE
BLE: always return privacy info from NRF.getSecurityStatus()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
           : nRF5x: ensure TIMER1_IRQHandler doesn't always wake idle loop up (fix #1900)
             Puck.js: On v2.1 ensure Puck.mag behaves like other variants - just returning the last reading (avoids glitches when used with Puck.magOn)
             Fix escaping of `\r` in built-in modules, fixed regression that stopped Espruino WiFi 2v25 from connecting to Wifi
+            BLE: always return privacy info from NRF.getSecurityStatus(), regardless of connection state
 
      2v25 : ESP32C3: Get analogRead working correctly
             Graphics: Adjust image alignment when rotating images to avoid cropping (fix #2535)

--- a/targets/nrf5x/bluetooth.c
+++ b/targets/nrf5x/bluetooth.c
@@ -3411,6 +3411,9 @@ JsVar *jsble_get_security_status(uint16_t conn_handle) {
   if (conn_handle == m_peripheral_conn_handle) {
     jsvObjectSetChildAndUnLock(result, "connectionInterval", jsvNewFromInteger(blePeriphConnectionInterval));
   }
+#ifdef ESPR_BLE_PRIVATE_ADDRESS_SUPPORT
+  jsvObjectSetChildAndUnLock(result, "privacy", jsble_getPrivacy());
+#endif // ESPR_BLE_PRIVATE_ADDRESS_SUPPORT
   if (conn_handle == BLE_CONN_HANDLE_INVALID) {
     jsvObjectSetChildAndUnLock(result, "connected", jsvNewFromBool(false));
     return result;
@@ -3422,9 +3425,6 @@ JsVar *jsble_get_security_status(uint16_t conn_handle) {
     jsvObjectSetChildAndUnLock(result, "encrypted", jsvNewFromBool(status.encrypted));
     jsvObjectSetChildAndUnLock(result, "mitm_protected", jsvNewFromBool(status.mitm_protected));
     jsvObjectSetChildAndUnLock(result, "bonded", jsvNewFromBool(status.bonded));
-#ifdef ESPR_BLE_PRIVATE_ADDRESS_SUPPORT
-    jsvObjectSetChildAndUnLock(result, "privacy", jsble_getPrivacy());
-#endif // ESPR_BLE_PRIVATE_ADDRESS_SUPPORT
 #ifndef SAVE_ON_FLASH
     if (status.connected && conn_handle==m_peripheral_conn_handle)
       jsvObjectSetChildAndUnLock(result, "connected_addr", bleAddrToStr(m_peripheral_addr));


### PR DESCRIPTION
This fixes `NRF.getSecurityStatus()` only returning privacy info while connected and makes it return privacy info regardless of connection state.

I somehow missed this when adding BLE private address support.