### PR TITLE
XiaoBLE: fixup comments about recovery in board file

### DIFF
--- a/boards/XIAOBLE.py
+++ b/boards/XIAOBLE.py
@@ -24,7 +24,7 @@ make clean && BOARD=XIAOBLE RELEASE=1 make
 # The board should automatically disconnect after copying is finished, and reboot into Espruino,
 # which turns on the red led for a short time after starting up.
 
-# If you accidentally put some stuff in .boot0 that prevents you from interacting with Espruino:
+# If you accidentally put some stuff in .bootcde that prevents you from interacting with Espruino:
 # Pull pin D1 to 3.3 V / high (important: make sure you use 3.3 V; higher voltages may cause damage) and reset the board,
 # by either pressing the reset button or cutting the power and powering it up again.
 # This behaviour is archived by configuring pin D1 as BTN1.
@@ -92,6 +92,8 @@ devices = {
     "LED1": {"pin": "D11"},
     "LED2": {"pin": "D13"},
     "LED3": {"pin": "D12"},
+    # not an actual button; you can pull this pin to 3V3 on boot
+    # to get the same behaviour as on other boards when booting with BTN1 pressed
     "BTN1": {"pin": "D1", "pinstate" : "IN_PULLDOWN"},
     "BAT": {
         "pin_charging": "D23",


### PR DESCRIPTION
This changes the comment in the board file about recovering from bad boot js to mention `.bootcde` instead of `.boot0`.