### PR TITLE
build: upload .uf2 image to espruino.com

### DIFF
--- a/scripts/ci_upload.sh
+++ b/scripts/ci_upload.sh
@@ -22,5 +22,5 @@ fi
 
 if [[ -n \"$UPLOADTOKEN\" ]]; then 
   cd bin
-  ls -d  *.bin *.hex *.tgz *.zip  2> /dev/null | xargs -I {} curl -v -F "binary=@{}" "http://www.espruino.com/travis_upload.php?commit=$COMMIT&branch=$BRANCH&token=$UPLOADTOKEN"; 
+  ls -d  *.bin *.hex *.uf2 *.tgz *.zip  2> /dev/null | xargs -I {} curl -v -F "binary=@{}" "https://www.espruino.com/travis_upload.php?commit=$COMMIT&branch=$BRANCH&token=$UPLOADTOKEN";
 fi


### PR DESCRIPTION
This adds `*.uf2` to the list of files the `ci_upload.sh` script tries to upload to espruino.com.  
And also changes the address from http to https (which ideally shouldn't break anything).

Reason for doing this: I'd like to have the XiaoBLE UF2 image show up [here](https://www.espruino.com/binaries/travis/master/) instead of the `.hex` file.

I don't really see any value in having both the `.hex` file and `.uf2` file, so ideally the `.hex` file wouldn't show up in GitHub CI builds or on espruino.com, but I've currently got no idea how to cleanly do that :see_no_evil:

This probably won't work without adjusting that `travis_upload.php` though...