### PR TITLE
ESP32 - fix jshCanWatch for ESP32 & ESP32S3

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -501,7 +501,7 @@ bool jshCanWatch(
 #ifdef CONFIG_IDF_TARGET_ESP32C3
   return (pin!=18) && (pin!=19); // USB
 #else
-  return pin == 0 || ( pin >= 12 && pin <= 19 ) || pin == 21 ||  pin == 22 || ( pin >= 25 && pin <= 27 ) || ( pin >= 34 && pin <= 39 );
+  return !( pin == 0 || ( pin >= 12 && pin <= 19 ) || pin == 21 ||  pin == 22 || ( pin >= 25 && pin <= 27 ) || ( pin >= 34 && pin <= 39 ));
 #endif
 }
 


### PR DESCRIPTION
setWatch on ESP32 and ESP32S3 retruns `WARNING: Unable to set watch. You may already have a watch on a pin with the same number (eg. A0 and B0),
or this pin cannot be used with watch` for vaild pins,