### PR TITLE
Bangle_setUI_Q3: fix btn back handler was not always rm:ed correctly

### DIFF
--- a/libs/js/banglejs/Bangle_setUI_Q3.js
+++ b/libs/js/banglejs/Bangle_setUI_Q3.js
@@ -10,11 +10,10 @@
     hadBackWidget = true; // if we had a back widget already, don't redraw at the end
     WIDGETS.back.remove(options.back); // only redraw when removing if we don't have options.back
   }
-  let clearBtnWatches = function() {
+  if (Bangle.btnWatches) {
     Bangle.btnWatches.forEach(clearWatch);
     delete Bangle.btnWatches;
   }
-  if (Bangle.btnWatches) clearBtnWatches();
   if (Bangle.swipeHandler) {
     Bangle.removeListener("swipe", Bangle.swipeHandler);
     delete Bangle.swipeHandler;
@@ -119,14 +118,12 @@
   if (options.redraw) // handler for redrawing the UI
     Bangle.uiRedraw = options.redraw;
   if (options.back) {
-    let isBtnBackFunc = false;
     // only add back button handler if there's no existing watch on BTN1
     if (Bangle.btnWatches===undefined) {
       Bangle.btnWatches = [ setWatch(function() {
-        Bangle.btnWatches = undefined;
+        Bangle.btnWatches = undefined; // watch doesn't repeat
         options.back();
       }, BTN1, {edge:"rising"}) ];
-      isBtnBackFunc = true;
     }
     // if we have widgets loaded *and* visible at the top, add a back widget (see #3788)
     if (global.WIDGETS && Bangle.appRect.y) {
@@ -146,7 +143,6 @@
         remove:function(noclear){
           var w = WIDGETS.back;
           if (w.area!="tl") noclear=true; // area="" is set by widget_utils.hide, so avoid drawing
-          if (isBtnBackFunc && Bangle.btnWatches) clearBtnWatches();
           Bangle.removeListener("touch", touchHandler);
           if (!noclear) g.reset().clearRect({x:w.x, y:w.y, w:24,h:24});
           delete WIDGETS.back;

--- a/libs/js/banglejs/Bangle_setUI_Q3.js
+++ b/libs/js/banglejs/Bangle_setUI_Q3.js
@@ -10,10 +10,11 @@
     hadBackWidget = true; // if we had a back widget already, don't redraw at the end
     WIDGETS.back.remove(options.back); // only redraw when removing if we don't have options.back
   }
-  if (Bangle.btnWatches) {
+  let clearBtnWatches = function() {
     Bangle.btnWatches.forEach(clearWatch);
     delete Bangle.btnWatches;
   }
+  if (Bangle.btnWatches) clearBtnWatches();
   if (Bangle.swipeHandler) {
     Bangle.removeListener("swipe", Bangle.swipeHandler);
     delete Bangle.swipeHandler;
@@ -118,13 +119,15 @@
   if (options.redraw) // handler for redrawing the UI
     Bangle.uiRedraw = options.redraw;
   if (options.back) {
-    var btnWatch;
+    let isBtnBackFunc = false;
     // only add back button handler if there's no existing watch on BTN1
-    if (Bangle.btnWatches===undefined) 
-      btnWatch = setWatch(function() {
-        btnWatch = undefined;
+    if (Bangle.btnWatches===undefined) {
+      Bangle.btnWatches = [ setWatch(function() {
+        Bangle.btnWatches = undefined;
         options.back();
-      }, BTN1, {edge:"rising"});
+      }, BTN1, {edge:"rising"}) ];
+      isBtnBackFunc = true;
+    }
     // if we have widgets loaded *and* visible at the top, add a back widget (see #3788)
     if (global.WIDGETS && Bangle.appRect.y) {
       // add our own touch handler for touching in the top left
@@ -143,7 +146,7 @@
         remove:function(noclear){
           var w = WIDGETS.back;
           if (w.area!="tl") noclear=true; // area="" is set by widget_utils.hide, so avoid drawing
-          if (btnWatch) clearWatch(btnWatch);
+          if (isBtnBackFunc && Bangle.btnWatches) clearBtnWatches();
           Bangle.removeListener("touch", touchHandler);
           if (!noclear) g.reset().clearRect({x:w.x, y:w.y, w:24,h:24});
           delete WIDGETS.back;


### PR DESCRIPTION
Using the recent `messagegui` updates in combination with Fastload Utils exposed a bug with `Bangle.setUI` where back on hw button watches could end up not cleared after setting up a the UI of the clock after `unreadTimeout` of `messagegui` ran out. This seems to fix that, when testing this special case at least. I just finished the changes so have not tested for long.

@gfwilliams please say if we should change something before merge.

When this looks good I can fix the Bangle.js 1 implementation as well.