### PR TITLE
update micro:bit v2

### DIFF
--- a/boards/MICROBIT2.py
+++ b/boards/MICROBIT2.py
@@ -17,7 +17,6 @@ import pinutils;
 
 # TODO:
 # Move to SDK17 with proper nRF52833 support
-#   - expand RAM to 128k
 # Proper event handling for accelerometer/etc
 # Functions for sound
 
@@ -59,9 +58,9 @@ chip = {
   'part' : "NRF52832", # actually 52833 but we're using SDK12 for this at the moment, and it doesn't support it
   'family' : "NRF52",
   'package' : "QFN48",
-  'ram' : 64,
+  'ram' : 128,
   'flash' : 512,
-  'speed' : 64, # TODO: actually 128k
+  'speed' : 64,
   'usart' : 1,
   'spi' : 1,
   'i2c' : 1,

--- a/boards/MICROBIT2.py
+++ b/boards/MICROBIT2.py
@@ -43,7 +43,12 @@ info = {
    ],
    'makefile' : [
      'DEFINES += -DCONFIG_GPIO_AS_PINRESET', # Allow the reset pin to work
+     'DEFINES += -DNRF_BLE_GATT_MAX_MTU_SIZE=53 -DNRF_BLE_MAX_MTU_SIZE=53', # increase MTU from default of 23
+     'DEFINES += -DCENTRAL_LINK_COUNT=2 -DNRF_SDH_BLE_CENTRAL_LINK_COUNT=2', # allow two outgoing connections at once
+     'LDFLAGS += -Xlinker --defsym=LD_APP_RAM_BASE=0x3290', # set RAM base to match MTU=53 + CENTRAL_LINK_COUNT=2
+     'LDFLAGS += -nostartfiles', 'ASFLAGS += -D__STARTUP_CLEAR_BSS -D__START=main', # Save ~300b by not including CRT startup code
      'DEFINES += -DNEOPIXEL_SCK_PIN=27 -DNEOPIXEL_LRCK_PIN=18', # SCK pin needs defining as something unused for neopixel (HW errata means they can't be disabled) 
+     'DEFINES+=-DESPR_PACKED_SYMPTR', # Pack builtin symbols' offset into pointer to save 2 bytes/symbol
      'DEFINES += -DGPIO_COUNT=2 -DP1_PIN_NUM=16 -DNRF_P1_BASE=0x50000300UL "-DNRF_P1=((NRF_GPIO_Type*)NRF_P1_BASE)"', # Hack for 52833 on SDK12
      'DEFINES += -DMICROBIT', # enable microbit-specific stuff
      'INCLUDE += -I$(ROOT)/libs/microbit',

--- a/boards/MICROBIT2.py
+++ b/boards/MICROBIT2.py
@@ -38,7 +38,8 @@ info = {
 #     'NET',
      'GRAPHICS',
      'NEOPIXEL',
-     'TENSORFLOW'
+     'TENSORFLOW',
+     'JIT'
    ],
    'makefile' : [
      'DEFINES += -DCONFIG_GPIO_AS_PINRESET', # Allow the reset pin to work


### PR DESCRIPTION
- fix board info to reflect 128k of ram
- enable JIT
- enable MTU 58, 2 centrals, packed symbols, trimmed startup code  like in other nrf52 boards 
