### PR TITLE
+ field stripping allows to use formatted .csv files

### DIFF
--- a/boards/pins/stm32l496.csv
+++ b/boards/pins/stm32l496.csv
@@ -1,184 +1,184 @@
-LQFP64,WLCSP100,LQFP100,BGA132,UFBGA169,LQFP144,Name,Type,IO,Notes,Alternate,Additional
-,,,,C3,,PI11,I/O,FT,,EVENTOUT,
-,B9,1,B2,D3,1,PE2,I/O,FT_l,,TRACECK/TIM3_ETR/TSC_G7_IO1/LCD_SEG38/FMC_A23/SAI1_MCLK_A/EVENTOUT,
-,B10,2,A1,D2,2,PE3,I/O,FT_l,,TRACED0/TIM3_CH1/TSC_G7_IO2/LCD_SEG39/FMC_A19/SAI1_SD_B/EVENTOUT,
-,C8,3,B1,D1,3,PE4,I/O,FT,,TRACED1/TIM3_CH2/DFSDM1_DATIN3/TSC_G7_IO3/DCMI_D4/FMC_A20/SAI1_FS_A/EVENTOUT,
-,D8,4,C2,E4,4,PE5,I/O,FT,,TRACED2/TIM3_CH3/DFSDM1_CKIN3/TSC_G7_IO4/DCMI_D6/FMC_A21/SAI1_SCK_A/EVENTOUT,
-,E7,5,D2,E3,5,PE6,I/O,FT,,TRACED3/TIM3_CH4/DCMI_D7/FMC_A22/SAI1_SD_A/EVENTOUT,RTC_TAMP3/WKUP3
-1,C10,6,E2,E2,6,VBAT,S,,,,
-2,C9,7,C1,E1,7,PC13,I/O,FT,,EVENTOUT,RTC_TAMP1/RTC_TS/RTC_OUT/WKUP2
-3,D10,8,D1,F1,8,PC14-OSC32_IN (PC14),I/O,FT,,EVENTOUT,OSC32_IN
-4,E10,9,E1,G1,9,PC15-OSC32_OUT (PC15),I/O,FT,,EVENTOUT,OSC32_OUT
-,,,D6,F5,10,PF0,I/O,FT_f,,I2C2_SDA/FMC_A0/EVENTOUT,
-,,,D5,F4,11,PF1,I/O,FT_f,,I2C2_SCL/FMC_A1/EVENTOUT,
-,,,D4,F3,12,PF2,I/O,FT,,I2C2_SMBA/FMC_A2/EVENTOUT,
-,,,E4,G3,13,PF3,I/O,FT_a,,FMC_A3/EVENTOUT,ADC3_IN6
-,,,F3,G4,14,PF4,I/O,FT_a,,FMC_A4/EVENTOUT,ADC3_IN7
-,,,F4,G5,15,PF5,I/O,FT_a,,FMC_A5/EVENTOUT,ADC3_IN8
-,D9,10,F2,F2,16,VSS,S,,,,
-,E9,11,G2,G2,17,VDD,S,,,,
-,,,,,18,PF6,I/O,FT_a,,TIM5_ETR/TIM5_CH1/QUADSPI_BK1_IO3/SAI1_SD_B/EVENTOUT,ADC3_IN9
-,,,,,19,PF7,I/O,FT_a,,TIM5_CH2/QUADSPI_BK1_IO2/SAI1_MCLK_B/EVENTOUT,ADC3_IN10
-,,,,,20,PF8,I/O,FT_a,,TIM5_CH3/QUADSPI_BK1_IO0/SAI1_SCK_B/EVENTOUT,ADC3_IN11
-,,,,,21,PF9,I/O,FT_a,,TIM5_CH4/QUADSPI_BK1_IO1/SAI1_FS_B/TIM15_CH1/EVENTOUT,ADC3_IN12
-,,,,H4,22,PF10,I/O,FT_a,,QUADSPI_CLK/DCMI_D11/TIM15_CH2/EVENTOUT,ADC3_IN13
-5,F10,12,F1,H1,23,PH0-OSC_IN (PH0),I/O,FT,,EVENTOUT,OSC_IN
-6,G10,13,G1,J1,24,PH1-OSC_OUT (PH1),I/O,FT,,EVENTOUT,OSC_OUT
-7,E8,14,H2,H3,25,NRST,I-O,RST,,,
-8,F9,15,H1,J2,26,PC0,I/O,FT_fla,,LPTIM1_IN1/I2C4_SCL/I2C3_SCL/DFSDM1_DATIN4/LPUART1_RX/LCD_SEG18/LPTIM2_IN1/EVENTOUT,ADC123_IN1
-9,F8,16,J2,J3,27,PC1,I/O,FT_fla,,TRACED0/LPTIM1_OUT/I2C4_SDA/SPI2_MOSI/I2C3_SDA/DFSDM1_CKIN4/LPUART1_TX/QUADSPI_BK2_IO0/LCD_SEG19/SAI1_SD_A/EVENTOUT,ADC123_IN2
-10,H10,17,J3,J4,28,PC2,I/O,FT_la,,LPTIM1_IN2/SPI2_MISO/DFSDM1_CKOUT/QUADSPI_BK2_IO1/LCD_SEG20/EVENTOUT,ADC123_IN3
-11,F7,18,K2,K1,29,PC3,I/O,FT_a,,LPTIM1_ETR/SPI2_MOSI/QUADSPI_BK2_IO2/LCD_VLCD/SAI1_SD_A/LPTIM2_ETR/EVENTOUT,ADC123_IN4
-,H9,19,,,30,VSSA,S,,,,
-,G8,20,,,31,VREF-,S,,,,
-12,,,J1,K2,,VSSA/VREF-,S,,,,
-,G7,21,L1,L1,32,VREF+,S,,,,VREFBUF_OUT
-,J10,22,M1,L2,33,VDDA,S,,,,
-13,,,,,,VDDA/VREF+,,,,,
-14,G9,23,L2,K3,34,PA0,I/O,FT_a,,TIM2_CH1/TIM5_CH1/TIM8_ETR/USART2_CTS/UART4_TX/SAI1_EXTCLK/TIM2_ETR/EVENTOUT,OPAMP1_VINP/ADC12_IN5/RTC_TAMP2/WKUP1
-,,,M3,M1,,OPAMP1_VINM,I,TT,,,
-15,H8,24,M2,N2,35,PA1,I/O,FT_la,,TIM2_CH2/TIM5_CH2/I2C1_SMBA/SPI1_SCK/USART2_RTS_DE/UART4_RX/LCD_SEG0/TIM15_CH1N/EVENTOUT,OPAMP1_VINM/ADC12_IN6
-16,H7,25,K3,N1,36,PA2,I/O,FT_la,,TIM2_CH3/TIM5_CH3/USART2_TX/LPUART1_TX/QUADSPI_BK1_NCS/LCD_SEG1/SAI2_EXTCLK/TIM15_CH1/EVENTOUT,ADC12_IN7/WKUP4/LSCO
-17,J9,26,L3,M2,37,PA3,I/O,TT,,TIM2_CH4/TIM5_CH4/USART2_RX/LPUART1_RX/QUADSPI_CLK/LCD_SEG2/SAI1_MCLK_A/TIM15_CH2/EVENTOUT,OPAMP1_VOUT/ADC12_IN8
-18,K10,27,E3,H2,38,VSS,S,,,,
-19,J8,28,H3,G13,39,VDD,S,,,,
-20,F6,29,J4,L3,40,PA4,I/O,TT_a,,SPI1_NSS/SPI3_NSS/USART2_CK/DCMI_HSYNC/SAI1_FS_B/LPTIM2_OUT/EVENTOUT,ADC12_IN9/DAC1_OUT1
-21,G6,30,K4,K4,41,PA5,I/O,TT_a,,TIM2_CH1/TIM2_ETR/TIM8_CH1N/SPI1_SCK/LPTIM2_ETR/EVENTOUT,ADC12_IN10/DAC1_OUT2
-22,K9,31,L4,M4,42,PA6,I/O,FT_la,,TIM1_BKIN/TIM3_CH1/TIM8_BKIN/DCMI_PIXCLK/SPI1_MISO/USART3_CTS/LPUART1_CTS/QUADSPI_BK1_IO3/LCD_SEG3/TIM1_BKIN_COMP2/TIM8_BKIN_COMP2/TIM16_CH1/EVENTOUT,OPAMP2_VINP/ADC12_IN11
-,,,M4,N4,,OPAMP2_VINM,I,TT,,,
-23,J7,32,J5,L4,43,PA7,I/O,FT_fla,,TIM1_CH1N/TIM3_CH2/TIM8_CH1N/I2C3_SCL/SPI1_MOSI/QUADSPI_BK1_IO2/LCD_SEG4/TIM17_CH1/EVENTOUT,OPAMP2_VINM/ADC12_IN12
-24,H6,33,K5,H5,44,PC4,I/O,FT_la,,USART3_TX/QUADSPI_BK2_IO3/LCD_SEG22/EVENTOUT,COMP1_INM/ADC12_IN13
-25,K8,34,L5,J5,45,PC5,I/O,FT_la,,USART3_RX/LCD_SEG23/EVENTOUT,COMP1_INP/ADC12_IN14/WKUP5
-26,J6,35,M5,K5,46,PB0,I/O,TT_la,,TIM1_CH2N/TIM3_CH3/TIM8_CH2N/SPI1_NSS/USART3_CK/QUADSPI_BK1_IO1/LCD_SEG5/COMP1_OUT/SAI1_EXTCLK/EVENTOUT,OPAMP2_VOUT/ADC12_IN15
-27,K7,36,M6,L5,47,PB1,I/O,FT_la,,TIM1_CH3N/TIM3_CH4/TIM8_CH3N/DFSDM1_DATIN0/USART3_RTS_DE/LPUART1_RTS_DE/QUADSPI_BK1_IO0/LCD_SEG6/LPTIM2_IN1/EVENTOUT,COMP1_INM/ADC12_IN16
-28,F5,37,L6,N5,48,PB2,I/O,FT_a,,RTC_OUT/LPTIM1_OUT/I2C3_SMBA/DFSDM1_CKIN0/LCD_VLCD/EVENTOUT,COMP1_INP
-,,,K6,M5,49,PF11,I/O,FT,,DCMI_D12/EVENTOUT,
-,,,J7,N6,50,PF12,I/O,FT,,FMC_A6/EVENTOUT,
-,,,,,51,VSS,S,,,,
-,,,,A8,52,VDD,S,,,,
-,,,K7,M6,53,PF13,I/O,FT,,I2C4_SMBA/DFSDM1_DATIN6/FMC_A7/EVENTOUT,
-,,,J8,L6,54,PF14,I/O,FT_f,,I2C4_SCL/DFSDM1_CKIN6/TSC_G8_IO1/FMC_A8/EVENTOUT,
-,,,J9,K6,55,PF15,I/O,FT_f,,I2C4_SDA/TSC_G8_IO2/FMC_A9/EVENTOUT,
-,,,H9,J6,56,PG0,I/O,FT,,TSC_G8_IO3/FMC_A10/EVENTOUT,
-,,,G9,H6,57,PG1,I/O,FT,,TSC_G8_IO4/FMC_A11/EVENTOUT,
-,K6,38,M7,L7,58,PE7,I/O,FT,,TIM1_ETR/DFSDM1_DATIN2/FMC_D4/SAI1_SD_B/EVENTOUT,
-,K5,39,L7,K7,59,PE8,I/O,FT,,TIM1_CH1N/DFSDM1_CKIN2/FMC_D5/SAI1_SCK_B/EVENTOUT,
-,J5,40,M8,J7,60,PE9,I/O,FT,,TIM1_CH1/DFSDM1_CKOUT/FMC_D6/SAI1_FS_B/EVENTOUT,
-,,,F6,M7,61,VSS,S,,,,
-,,,G6,N7,62,VDD,S,,,,
-,H5,41,L8,H7,63,PE10,I/O,FT,,TIM1_CH2N/DFSDM1_DATIN4/TSC_G5_IO1/QUADSPI_CLK/FMC_D7/SAI1_MCLK_B/EVENTOUT,
-,K4,42,M9,N8,64,PE11,I/O,FT,,TIM1_CH2/DFSDM1_CKIN4/TSC_G5_IO2/QUADSPI_BK1_NCS/FMC_D8/EVENTOUT,
-,G5,43,L9,M8,65,PE12,I/O,FT,,TIM1_CH3N/SPI1_NSS/DFSDM1_DATIN5/TSC_G5_IO3/QUADSPI_BK1_IO0/FMC_D9/EVENTOUT,
-,G4,44,M10,L8,66,PE13,I/O,FT,,TIM1_CH3/SPI1_SCK/DFSDM1_CKIN5/TSC_G5_IO4/QUADSPI_BK1_IO1/FMC_D10/EVENTOUT,
-,J4,45,M11,K8,67,PE14,I/O,FT,,TIM1_CH4/TIM1_BKIN2/TIM1_BKIN2_COMP2/SPI1_MISO/QUADSPI_BK1_IO2/FMC_D11/EVENTOUT,
-,H4,46,M12,J8,68,PE15,I/O,FT,,TIM1_BKIN/TIM1_BKIN_COMP1/SPI1_MOSI/QUADSPI_BK1_IO3/FMC_D12/EVENTOUT,
-29,K3,47,L10,N9,69,PB10,I/O,FT_fl,,TIM2_CH3/I2C4_SCL/I2C2_SCL/SPI2_SCK/DFSDM1_DATIN7/USART3_TX/LPUART1_RX/TSC_SYNC/QUADSPI_CLK/LCD_SEG10/COMP1_OUT/SAI1_SCK_A/EVENTOUT,
-30,J3,48,L11,H8,70,PB11,I/O,FT_fl,,TIM2_CH4/I2C4_SDA/I2C2_SDA/DFSDM1_CKIN7/USART3_RX/LPUART1_TX/QUADSPI_BK1_NCS/LCD_SEG11/COMP2_OUT/EVENTOUT,
-,,,,,,VDD12,S,,,,
-,,,,K9,,PH4,I/O,FT_f,,I2C2_SCL/EVENTOUT,
-,,,,L9,,PH5,I/O,FT_f,,I2C2_SDA/DCMI_PIXCLK/EVENTOUT,
-,,,,N10,,PH8,I/O,FT_f,,I2C3_SDA/DCMI_HSYNC/EVENTOUT,
-,,,,M9,,PH10,I/O,FT,,TIM5_CH1/DCMI_D1/EVENTOUT,
-,,,,M10,,PH11,I/O,FT,,TIM5_CH2/DCMI_D2/EVENTOUT,
-,,,,M3,,VSS,S,,,,
-,,,,N3,,VDD,S,,,,
-,,,,M11,,VSS,S,,,,
-31,K2,49,F12,L13,71,VSS,S,,,,
-32,K1,50,G12,L12,72,VDD,S,,,,
-,,,,N11,,VDD,S,,,,
-33,J1,51,L12,N12,73,PB12,I/O,FT_l,,TIM1_BKIN/TIM1_BKIN_COMP2/I2C2_SMBA/SPI2_NSS/DFSDM1_DATIN1/USART3_CK/LPUART1_RTS_DE/TSC_G1_IO1/CAN2_RX/LCD_SEG12/SWPMI1_IO/SAI2_FS_A/TIM15_BKIN/EVENTOUT,
-34,J2,52,K12,N13,74,PB13,I/O,FT_fl,,TIM1_CH1N/I2C2_SCL/SPI2_SCK/DFSDM1_CKIN1/USART3_CTS/LPUART1_CTS/TSC_G1_IO2/CAN2_TX/LCD_SEG13/SWPMI1_TX/SAI2_SCK_A/TIM15_CH1N/EVENTOUT,
-35,H2,53,K11,M13,75,PB14,I/O,FT_fl,,TIM1_CH2N/TIM8_CH2N/I2C2_SDA/SPI2_MISO/DFSDM1_DATIN2/USART3_RTS_DE/TSC_G1_IO3/LCD_SEG14/SWPMI1_RX/SAI2_MCLK_A/TIM15_CH1/EVENTOUT,
-36,H1,54,K10,M12,76,PB15,I/O,FT_l,,RTC_REFIN/TIM1_CH3N/TIM8_CH3N/SPI2_MOSI/DFSDM1_CKIN2/TSC_G1_IO4/LCD_SEG15/SWPMI1_SUSPEND/SAI2_SD_A/TIM15_CH2/EVENTOUT,
-,H3,55,K9,L11,77,PD8,I/O,FT_l,,USART3_TX/DCMI_HSYNC/LCD_SEG28/FMC_D13/EVENTOUT,
-,G2,56,K8,L10,78,PD9,I/O,FT_l,,USART3_RX/DCMI_PIXCLK/LCD_SEG29/FMC_D14/SAI2_MCLK_A/EVENTOUT,
-,G1,57,J12,J13,79,PD10,I/O,FT_l,,USART3_CK/TSC_G6_IO1/LCD_SEG30/FMC_D15/SAI2_SCK_A/EVENTOUT,
-,,58,J11,K12,80,PD11,I/O,FT_l,,I2C4_SMBA/USART3_CTS/TSC_G6_IO2/LCD_SEG31/FMC_A16/SAI2_SD_A/LPTIM2_ETR/EVENTOUT,
-,,59,J10,K11,81,PD12,I/O,FT_fl,,TIM4_CH1/I2C4_SCL/USART3_RTS_DE/TSC_G6_IO3/LCD_SEG32/FMC_A17/SAI2_FS_A/LPTIM2_IN1/EVENTOUT,
-,,60,H12,K13,82,PD13,I/O,FT_fl,,TIM4_CH2/I2C4_SDA/TSC_G6_IO4/LCD_SEG33/FMC_A18/LPTIM2_OUT/EVENTOUT,
-,,,,H12,83,VSS,S,,,,
-,F1,,,H13,84,VDD,S,,,,
-,G3,61,H11,K10,85,PD14,I/O,FT_l,,TIM4_CH3/LCD_SEG34/FMC_D0/EVENTOUT,
-,F4,62,H10,H11,86,PD15,I/O,FT_l,,TIM4_CH4/LCD_SEG35/FMC_D1/EVENTOUT,
-,,,G10,J12,87,PG2,I/O,FT_s,,SPI1_SCK/FMC_A12/SAI2_SCK_B/EVENTOUT,
-,,,F9,J11,88,PG3,I/O,FT_s,,SPI1_MISO/FMC_A13/SAI2_FS_B/EVENTOUT,
-,,,F10,J10,89,PG4,I/O,FT_s,,SPI1_MOSI/FMC_A14/SAI2_MCLK_B/EVENTOUT,
-,,,E9,J9,90,PG5,I/O,FT_s,,SPI1_NSS/LPUART1_CTS/FMC_A15/SAI2_SD_B/EVENTOUT,
-,,,G4,G11,91,PG6,I/O,FT_s,,I2C3_SMBA/LPUART1_RTS_DE/EVENTOUT,
-,,,H4,H10,92,PG7,I/O,FT_fs,,I2C3_SCL/LPUART1_TX/FMC_INT/SAI1_MCLK_A/EVENTOUT,
-,,,J6,H9,93,PG8,I/O,FT_fs,,I2C3_SDA/LPUART1_RX/EVENTOUT,
-,,,,F13,94,VSS,S,,,,
-,,,,F12,95,VDDIO2,S,,,,
-37,F2,63,E12,F11,96,PC6,I/O,FT_l,,TIM3_CH1/TIM8_CH1/DFSDM1_CKIN3/TSC_G4_IO1/DCMI_D0/LCD_SEG24/SDMMC1_D6/SAI2_MCLK_A/EVENTOUT,
-38,F3,64,E11,G12,97,PC7,I/O,FT_l,,TIM3_CH2/TIM8_CH2/DFSDM1_DATIN3/TSC_G4_IO2/DCMI_D1/LCD_SEG25/SDMMC1_D7/SAI2_MCLK_B/EVENTOUT,
-39,E1,65,E10,G10,98,PC8,I/O,FT_l,,TIM3_CH3/TIM8_CH3/TSC_G4_IO3/DCMI_D2/LCD_SEG26/SDMMC1_D0/EVENTOUT,
-40,E2,66,D12,G9,99,PC9,I/O,FT_fl,,TIM8_BKIN2/TIM3_CH4/TIM8_CH4/DCMI_D3/I2C3_SDA/TSC_G4_IO4/OTG_FS_NOE/LCD_SEG27/SDMMC1_D1/SAI2_EXTCLK/TIM8_BKIN2_COMP1/EVENTOUT,
-41,E3,67,D11,G8,100,PA8,I/O,FT_fl,,MCO/TIM1_CH1/USART1_CK/OTG_FS_SOF/LCD_COM0/SWPMI1_IO/SAI1_SCK_A/LPTIM2_OUT/EVENTOUT,
-42,D3,68,D10,F10,101,PA9,I/O,FT_flu,,TIM1_CH2/SPI2_SCK/DCMI_D0/USART1_TX/LCD_COM1/SAI1_FS_A/TIM15_BKIN/EVENTOUT,OTG_FS_VBUS
-43,D2,69,C12,F9,102,PA10,I/O,FT_flu,,TIM1_CH3/DCMI_D1/USART1_RX/OTG_FS_ID/LCD_COM2/SAI1_SD_A/TIM17_BKIN/EVENTOUT,
-44,D1,70,B12,E13,103,PA11,I/O,FT_u,,TIM1_CH4/TIM1_BKIN2/SPI1_MISO/USART1_CTS/CAN1_RX/OTG_FS_DM/TIM1_BKIN2_COMP1/EVENTOUT,
-45,C1,71,A12,D13,104,PA12,I/O,FT_u,,TIM1_ETR/SPI1_MOSI/USART1_RTS_DE/CAN1_TX/OTG_FS_DP/EVENTOUT,
-46,C2,72,A11,A11,105,PA13(JTMS-SWDIO),I/O,FT,,JTMS/SWDIO/IR_OUT/OTG_FS_NOE/SWPMI1_TX/SAI1_SD_B/EVENTOUT,
-47,B1,,,,,VSS,S,,,,
-48,A1,73,C11,E12,106,VDDUSB,S,,,,
-,,74,F11,C12,107,VSS,S,,,,
-,,75,G11,C13,108,VDD,S,,,,
-,,,,E11,,PH6,I/O,FT,,I2C2_SMBA/DCMI_D8/EVENTOUT,
-,,,,D12,,PH7,I/O,FT_f,,I2C3_SCL/DCMI_D9/EVENTOUT,
-,,,,D11,,PH9,I/O,FT,,I2C3_SMBA/DCMI_D0/EVENTOUT,
-,,,,B13,,PH12,I/O,FT,,TIM5_CH3/DCMI_D3/EVENTOUT,
-,,,,A13,,PH14,I/O,FT,,TIM8_CH2N/DCMI_D4/EVENTOUT,
-,,,,B12,,PH15,I/O,FT,,TIM8_CH3N/DCMI_D11/EVENTOUT,
-,,,,A12,,PI0,I/O,FT,,TIM5_CH4/SPI2_NSS/DCMI_D13/EVENTOUT,
-,,,,C11,,PI8,I/O,FT,,DCMI_D12/EVENTOUT,
-,,,,B11,,PI1,I/O,FT,,SPI2_SCK/DCMI_D8/EVENTOUT,
-,,,,B10,,PI2,I/O,FT,,TIM8_CH4/SPI2_MISO/DCMI_D9/EVENTOUT,
-,,,,C10,,PI3,I/O,FT,,TIM8_ETR/SPI2_MOSI/DCMI_D10/EVENTOUT,
-,,,,D10,,PI4,I/O,FT,,TIM8_BKIN/DCMI_D5/EVENTOUT,
-,,,,E10,,PI5,I/O,FT,,TIM8_CH1/DCMI_VSYNC/EVENTOUT,
-,,,,C9,,PH13,I/O,FT,,TIM8_CH1N/CAN1_TX/EVENTOUT,
-,,,,B9,,PI6,I/O,FT,,TIM8_CH2/DCMI_D6/EVENTOUT,
-49,B2,76,A10,A10,109,PA14(JTCK-SWCLK),I/O,FT,,JTCK/SWCLK/LPTIM1_OUT/I2C1_SMBA/I2C4_SMBA/OTG_FS_SOF/SWPMI1_RX/SAI1_FS_B/EVENTOUT,
-50,A2,77,A9,A9,110,PA15(JTDI),I/O,FT_l,,JTDI/TIM2_CH1/TIM2_ETR/USART2_RX/SPI1_NSS/SPI3_NSS/USART3_RTS_DE/UART4_RTS_DE/TSC_G3_IO1/LCD_SEG17/SWPMI1_SUSPEND/SAI2_FS_B/EVENTOUT,
-51,D4,78,B11,D9,111,PC10,I/O,FT_l,,TRACED1/SPI3_SCK/USART3_TX/UART4_TX/TSC_G3_IO2/DCMI_D8/LCD_COM4/LCD_SEG28/LCD_SEG40/SDMMC1_D2/SAI2_SCK_B/EVENTOUT,
-52,C3,79,C10,E9,112,PC11,I/O,FT_l,,QUADSPI_BK2_NCS/SPI3_MISO/USART3_RX/UART4_RX/TSC_G3_IO3/DCMI_D4/LCD_COM5/LCD_SEG29/LCD_SEG41/SDMMC1_D3/SAI2_MCLK_B/EVENTOUT,
-53,C4,80,B10,F8,113,PC12,I/O,FT_l,,TRACED3/SPI3_MOSI/USART3_CK/UART5_TX/TSC_G3_IO4/DCMI_D9/LCD_COM6/LCD_SEG30/LCD_SEG42/SDMMC1_CK/SAI2_SD_B/EVENTOUT,
-,B3,81,C9,B8,114,PD0,I/O,FT,,SPI2_NSS/DFSDM1_DATIN7/CAN1_RX/FMC_D2/EVENTOUT,
-,A3,82,B9,C8,115,PD1,I/O,FT,,SPI2_SCK/DFSDM1_CKIN7/CAN1_TX/FMC_D3/EVENTOUT,
-54,E4,83,C8,D8,116,PD2,I/O,FT_l,,TRACED2/TIM3_ETR/USART3_RTS_DE/UART5_RX/TSC_SYNC/DCMI_D11/LCD_COM7/LCD_SEG31/LCD_SEG43/SDMMC1_CMD/EVENTOUT,
-,,84,B8,E8,117,PD3,I/O,FT,,SPI2_SCK/DCMI_D5/SPI2_MISO/DFSDM1_DATIN0/USART2_CTS/QUADSPI_BK2_NCS/FMC_CLK/EVENTOUT,
-,B4,85,B7,C7,118,PD4,I/O,FT,,SPI2_MOSI/DFSDM1_CKIN0/USART2_RTS_DE/QUADSPI_BK2_IO0/FMC_NOE/EVENTOUT,
-,E5,86,A6,D7,119,PD5,I/O,FT,,USART2_TX/QUADSPI_BK2_IO1/FMC_NWE/EVENTOUT,
-,,,,,120,VSS,S,,,,
-,A4,,,,121,VDD,S,,,,
-,D5,87,B6,E7,122,PD6,I/O,FT,,DCMI_D10/QUADSPI_BK2_IO1/DFSDM1_DATIN1/USART2_RX/QUADSPI_BK2_IO2/FMC_NWAIT/SAI1_SD_A/EVENTOUT,
-,C5,88,A5,F7,123,PD7,I/O,FT,,DFSDM1_CKIN1/USART2_CK/QUADSPI_BK2_IO3/FMC_NE1/EVENTOUT,
-,B5,,D9,B7,124,PG9,I/O,FT_s,,SPI3_SCK/USART1_TX/FMC_NCE/FMC_NE2/SAI2_SCK_A/TIM15_CH1N/EVENTOUT,
-,A5,,D8,D6,125,PG10,I/O,FT_s,,LPTIM1_IN1/SPI3_MISO/USART1_RX/FMC_NE3/SAI2_FS_A/TIM15_CH1/EVENTOUT,
-,D6,,G3,E6,126,PG11,I/O,FT_s,,LPTIM1_IN2/SPI3_MOSI/USART1_CTS/SAI2_MCLK_A/TIM15_CH2/EVENTOUT,
-,B6,,D7,F6,127,PG12,I/O,FT_s,,LPTIM1_ETR/SPI3_NSS/USART1_RTS_DE/FMC_NE4/SAI2_SD_A/EVENTOUT,
-,,,C7,G7,128,PG13,I/O,FT_fs,,I2C1_SDA/USART1_CK/FMC_A24/EVENTOUT,
-,,,C6,G6,129,PG14,I/O,FT_fs,,I2C1_SCL/FMC_A25/EVENTOUT,
-,,,F7,A7,130,VSS,S,,,,
-,A6,,G7,B6,131,VDDIO2,S,,,,
-,,,K1,C6,132,PG15,I/O,FT_s,,LPTIM1_OUT/I2C1_SMBA/DCMI_D13/EVENTOUT,
-55,C6,89,A8,A6,133,PB3(JTDO-TRACESWO),I/O,FT_la,,JTDO/TRACESWO/TIM2_CH2/SPI1_SCK/SPI3_SCK/USART1_RTS_DE/OTG_FS_CRS_SYNC/LCD_SEG7/SAI1_SCK_B/EVENTOUT,COMP2_INM
-56,C7,90,A7,A5,134,PB4(NJTRST),I/O,FT_fla,,NJTRST/TIM3_CH1/I2C3_SDA/SPI1_MISO/SPI3_MISO/USART1_CTS/UART5_RTS_DE/TSC_G2_IO1/DCMI_D12/LCD_SEG8/SAI1_MCLK_B/TIM17_BKIN/EVENTOUT,COMP2_INP
-57,B7,91,C5,B5,135,PB5,I/O,FT_l,,LPTIM1_IN1/TIM3_CH2/CAN2_RX/I2C1_SMBA/SPI1_MOSI/SPI3_MOSI/USART1_CK/UART5_CTS/TSC_G2_IO2/DCMI_D10/LCD_SEG9/COMP2_OUT/SAI1_SD_B/TIM16_BKIN/EVENTOUT,
-58,A7,92,B5,C5,136,PB6,I/O,FT_fa,,LPTIM1_ETR/TIM4_CH1/TIM8_BKIN2/I2C1_SCL/I2C4_SCL/DFSDM1_DATIN5/USART1_TX/CAN2_TX/TSC_G2_IO3/DCMI_D5/TIM8_BKIN2_COMP2/SAI1_FS_B/TIM16_CH1N/EVENTOUT,COMP2_INP
-59,D7,93,B4,D5,137,PB7,I/O,FT_fla,,LPTIM1_IN2/TIM4_CH2/TIM8_BKIN/I2C1_SDA/I2C4_SDA/DFSDM1_CKIN5/USART1_RX/UART4_CTS/TSC_G2_IO4/DCMI_VSYNC/LCD_SEG21/FMC_NL/TIM8_BKIN_COMP1/TIM17_CH1N/EVENTOUT,COMP2_INM/PVD_IN
-60,E6,94,A4,E5,138,PH3-BOOT0,I/O,FT,,EVENTOUT,
-61,B8,95,A3,C4,139,PB8,I/O,FT_fl,,TIM4_CH3/I2C1_SCL/DFSDM1_DATIN6/CAN1_RX/DCMI_D6/LCD_SEG16/SDMMC1_D4/SAI1_MCLK_A/TIM16_CH1/EVENTOUT,
-62,A8,96,B3,D4,140,PB9,I/O,FT_fl,,IR_OUT/TIM4_CH4/I2C1_SDA/SPI2_NSS/DFSDM1_CKIN6/CAN1_TX/DCMI_D7/LCD_COM3/SDMMC1_D5/SAI1_FS_A/TIM17_CH1/EVENTOUT,
-,,,,,,VDD12,S,,,,
-,,97,C3,A4,141,PE0,I/O,FT_l,,TIM4_ETR/DCMI_D2/LCD_SEG36/FMC_NBL0/TIM16_CH1/EVENTOUT,
-,,98,A2,B4,142,PE1,I/O,FT_l,,DCMI_D3/LCD_SEG37/FMC_NBL1/TIM17_CH1/EVENTOUT,
-,,,,,,VDD12,S,,,,
-63,A9,99,D3,B3,143,VSS,S,,,,
-64,A10,100,C4,A3,144,VDD,S,,,,
-,,,,C2,,VSS,S,,,,
-,,,,C1,,VDD,S,,,,
-,,,,A2,,PH2,I/O,FT,,QUADSPI_BK2_IO0/EVENTOUT,
-,,,,B2,,PI7,I/O,FT,,TIM8_CH3/DCMI_D7/EVENTOUT,
-,,,,B1,,PI9,I/O,FT,,CAN1_RX/EVENTOUT,
-,,,,A1,,PI10,I/O,FT,,EVENTOUT,
+LQFP64, WLCSP100, LQFP100, BGA132, UFBGA169, LQFP144, Name                 , Type, IO    , Notes, Alternate                                                                                                                                                  , Additional
+      ,         ,        ,       , C3      ,        , PI11                 , I/O , FT    ,      , EVENTOUT                                                                                                                                                   , 
+      , B9      ,       1, B2    , D3      ,       1, PE2                  , I/O , FT_l  ,      , TRACECK/TIM3_ETR/TSC_G7_IO1/LCD_SEG38/FMC_A23/SAI1_MCLK_A/EVENTOUT                                                                                         , 
+      , B10     ,       2, A1    , D2      ,       2, PE3                  , I/O , FT_l  ,      , TRACED0/TIM3_CH1/TSC_G7_IO2/LCD_SEG39/FMC_A19/SAI1_SD_B/EVENTOUT                                                                                           , 
+      , C8      ,       3, B1    , D1      ,       3, PE4                  , I/O , FT    ,      , TRACED1/TIM3_CH2/DFSDM1_DATIN3/TSC_G7_IO3/DCMI_D4/FMC_A20/SAI1_FS_A/EVENTOUT                                                                               , 
+      , D8      ,       4, C2    , E4      ,       4, PE5                  , I/O , FT    ,      , TRACED2/TIM3_CH3/DFSDM1_CKIN3/TSC_G7_IO4/DCMI_D6/FMC_A21/SAI1_SCK_A/EVENTOUT                                                                               , 
+      , E7      ,       5, D2    , E3      ,       5, PE6                  , I/O , FT    ,      , TRACED3/TIM3_CH4/DCMI_D7/FMC_A22/SAI1_SD_A/EVENTOUT                                                                                                        , RTC_TAMP3/WKUP3
+     1, C10     ,       6, E2    , E2      ,       6, VBAT                 , S   ,       ,      ,                                                                                                                                                            , 
+     2, C9      ,       7, C1    , E1      ,       7, PC13                 , I/O , FT    ,      , EVENTOUT                                                                                                                                                   , RTC_TAMP1/RTC_TS/RTC_OUT/WKUP2
+     3, D10     ,       8, D1    , F1      ,       8, PC14-OSC32_IN (PC14) , I/O , FT    ,      , EVENTOUT                                                                                                                                                   , OSC32_IN
+     4, E10     ,       9, E1    , G1      ,       9, PC15-OSC32_OUT (PC15), I/O , FT    ,      , EVENTOUT                                                                                                                                                   , OSC32_OUT
+      ,         ,        , D6    , F5      ,      10, PF0                  , I/O , FT_f  ,      , I2C2_SDA/FMC_A0/EVENTOUT                                                                                                                                   , 
+      ,         ,        , D5    , F4      ,      11, PF1                  , I/O , FT_f  ,      , I2C2_SCL/FMC_A1/EVENTOUT                                                                                                                                   , 
+      ,         ,        , D4    , F3      ,      12, PF2                  , I/O , FT    ,      , I2C2_SMBA/FMC_A2/EVENTOUT                                                                                                                                  , 
+      ,         ,        , E4    , G3      ,      13, PF3                  , I/O , FT_a  ,      , FMC_A3/EVENTOUT                                                                                                                                            , ADC3_IN6
+      ,         ,        , F3    , G4      ,      14, PF4                  , I/O , FT_a  ,      , FMC_A4/EVENTOUT                                                                                                                                            , ADC3_IN7
+      ,         ,        , F4    , G5      ,      15, PF5                  , I/O , FT_a  ,      , FMC_A5/EVENTOUT                                                                                                                                            , ADC3_IN8
+      , D9      ,      10, F2    , F2      ,      16, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      , E9      ,      11, G2    , G2      ,      17, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       ,         ,      18, PF6                  , I/O , FT_a  ,      , TIM5_ETR/TIM5_CH1/QUADSPI_BK1_IO3/SAI1_SD_B/EVENTOUT                                                                                                       , ADC3_IN9
+      ,         ,        ,       ,         ,      19, PF7                  , I/O , FT_a  ,      , TIM5_CH2/QUADSPI_BK1_IO2/SAI1_MCLK_B/EVENTOUT                                                                                                              , ADC3_IN10
+      ,         ,        ,       ,         ,      20, PF8                  , I/O , FT_a  ,      , TIM5_CH3/QUADSPI_BK1_IO0/SAI1_SCK_B/EVENTOUT                                                                                                               , ADC3_IN11
+      ,         ,        ,       ,         ,      21, PF9                  , I/O , FT_a  ,      , TIM5_CH4/QUADSPI_BK1_IO1/SAI1_FS_B/TIM15_CH1/EVENTOUT                                                                                                      , ADC3_IN12
+      ,         ,        ,       , H4      ,      22, PF10                 , I/O , FT_a  ,      , QUADSPI_CLK/DCMI_D11/TIM15_CH2/EVENTOUT                                                                                                                    , ADC3_IN13
+     5, F10     ,      12, F1    , H1      ,      23, PH0-OSC_IN (PH0)     , I/O , FT    ,      , EVENTOUT                                                                                                                                                   , OSC_IN
+     6, G10     ,      13, G1    , J1      ,      24, PH1-OSC_OUT (PH1)    , I/O , FT    ,      , EVENTOUT                                                                                                                                                   , OSC_OUT
+     7, E8      ,      14, H2    , H3      ,      25, NRST                 , I-O , RST   ,      ,                                                                                                                                                            , 
+     8, F9      ,      15, H1    , J2      ,      26, PC0                  , I/O , FT_fla,      , LPTIM1_IN1/I2C4_SCL/I2C3_SCL/DFSDM1_DATIN4/LPUART1_RX/LCD_SEG18/LPTIM2_IN1/EVENTOUT                                                                        , ADC123_IN1
+     9, F8      ,      16, J2    , J3      ,      27, PC1                  , I/O , FT_fla,      , TRACED0/LPTIM1_OUT/I2C4_SDA/SPI2_MOSI/I2C3_SDA/DFSDM1_CKIN4/LPUART1_TX/QUADSPI_BK2_IO0/LCD_SEG19/SAI1_SD_A/EVENTOUT                                        , ADC123_IN2
+    10, H10     ,      17, J3    , J4      ,      28, PC2                  , I/O , FT_la ,      , LPTIM1_IN2/SPI2_MISO/DFSDM1_CKOUT/QUADSPI_BK2_IO1/LCD_SEG20/EVENTOUT                                                                                       , ADC123_IN3
+    11, F7      ,      18, K2    , K1      ,      29, PC3                  , I/O , FT_a  ,      , LPTIM1_ETR/SPI2_MOSI/QUADSPI_BK2_IO2/LCD_VLCD/SAI1_SD_A/LPTIM2_ETR/EVENTOUT                                                                                , ADC123_IN4
+      , H9      ,      19,       ,         ,      30, VSSA                 , S   ,       ,      ,                                                                                                                                                            , 
+      , G8      ,      20,       ,         ,      31, VREF-                , S   ,       ,      ,                                                                                                                                                            , 
+    12,         ,        , J1    , K2      ,        , VSSA/VREF-           , S   ,       ,      ,                                                                                                                                                            , 
+      , G7      ,      21, L1    , L1      ,      32, VREF+                , S   ,       ,      ,                                                                                                                                                            , VREFBUF_OUT
+      , J10     ,      22, M1    , L2      ,      33, VDDA                 , S   ,       ,      ,                                                                                                                                                            , 
+    13,         ,        ,       ,         ,        , VDDA/VREF+           ,     ,       ,      ,                                                                                                                                                            , 
+    14, G9      ,      23, L2    , K3      ,      34, PA0                  , I/O , FT_a  ,      , TIM2_CH1/TIM5_CH1/TIM8_ETR/USART2_CTS/UART4_TX/SAI1_EXTCLK/TIM2_ETR/EVENTOUT                                                                               , OPAMP1_VINP/ADC12_IN5/RTC_TAMP2/WKUP1
+      ,         ,        , M3    , M1      ,        , OPAMP1_VINM          , I   , TT    ,      ,                                                                                                                                                            , 
+    15, H8      ,      24, M2    , N2      ,      35, PA1                  , I/O , FT_la ,      , TIM2_CH2/TIM5_CH2/I2C1_SMBA/SPI1_SCK/USART2_RTS_DE/UART4_RX/LCD_SEG0/TIM15_CH1N/EVENTOUT                                                                   , OPAMP1_VINM/ADC12_IN6
+    16, H7      ,      25, K3    , N1      ,      36, PA2                  , I/O , FT_la ,      , TIM2_CH3/TIM5_CH3/USART2_TX/LPUART1_TX/QUADSPI_BK1_NCS/LCD_SEG1/SAI2_EXTCLK/TIM15_CH1/EVENTOUT                                                             , ADC12_IN7/WKUP4/LSCO
+    17, J9      ,      26, L3    , M2      ,      37, PA3                  , I/O , TT    ,      , TIM2_CH4/TIM5_CH4/USART2_RX/LPUART1_RX/QUADSPI_CLK/LCD_SEG2/SAI1_MCLK_A/TIM15_CH2/EVENTOUT                                                                 , OPAMP1_VOUT/ADC12_IN8
+    18, K10     ,      27, E3    , H2      ,      38, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+    19, J8      ,      28, H3    , G13     ,      39, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+    20, F6      ,      29, J4    , L3      ,      40, PA4                  , I/O , TT_a  ,      , SPI1_NSS/SPI3_NSS/USART2_CK/DCMI_HSYNC/SAI1_FS_B/LPTIM2_OUT/EVENTOUT                                                                                       , ADC12_IN9/DAC1_OUT1
+    21, G6      ,      30, K4    , K4      ,      41, PA5                  , I/O , TT_a  ,      , TIM2_CH1/TIM2_ETR/TIM8_CH1N/SPI1_SCK/LPTIM2_ETR/EVENTOUT                                                                                                   , ADC12_IN10/DAC1_OUT2
+    22, K9      ,      31, L4    , M4      ,      42, PA6                  , I/O , FT_la ,      , TIM1_BKIN/TIM3_CH1/TIM8_BKIN/DCMI_PIXCLK/SPI1_MISO/USART3_CTS/LPUART1_CTS/QUADSPI_BK1_IO3/LCD_SEG3/TIM1_BKIN_COMP2/TIM8_BKIN_COMP2/TIM16_CH1/EVENTOUT      , OPAMP2_VINP/ADC12_IN11
+      ,         ,        , M4    , N4      ,        , OPAMP2_VINM          , I   , TT    ,      ,                                                                                                                                                            , 
+    23, J7      ,      32, J5    , L4      ,      43, PA7                  , I/O , FT_fla,      , TIM1_CH1N/TIM3_CH2/TIM8_CH1N/I2C3_SCL/SPI1_MOSI/QUADSPI_BK1_IO2/LCD_SEG4/TIM17_CH1/EVENTOUT                                                                , OPAMP2_VINM/ADC12_IN12
+    24, H6      ,      33, K5    , H5      ,      44, PC4                  , I/O , FT_la ,      , USART3_TX/QUADSPI_BK2_IO3/LCD_SEG22/EVENTOUT                                                                                                               , COMP1_INM/ADC12_IN13
+    25, K8      ,      34, L5    , J5      ,      45, PC5                  , I/O , FT_la ,      , USART3_RX/LCD_SEG23/EVENTOUT                                                                                                                               , COMP1_INP/ADC12_IN14/WKUP5
+    26, J6      ,      35, M5    , K5      ,      46, PB0                  , I/O , TT_la ,      , TIM1_CH2N/TIM3_CH3/TIM8_CH2N/SPI1_NSS/USART3_CK/QUADSPI_BK1_IO1/LCD_SEG5/COMP1_OUT/SAI1_EXTCLK/EVENTOUT                                                    , OPAMP2_VOUT/ADC12_IN15
+    27, K7      ,      36, M6    , L5      ,      47, PB1                  , I/O , FT_la ,      , TIM1_CH3N/TIM3_CH4/TIM8_CH3N/DFSDM1_DATIN0/USART3_RTS_DE/LPUART1_RTS_DE/QUADSPI_BK1_IO0/LCD_SEG6/LPTIM2_IN1/EVENTOUT                                       , COMP1_INM/ADC12_IN16
+    28, F5      ,      37, L6    , N5      ,      48, PB2                  , I/O , FT_a  ,      , RTC_OUT/LPTIM1_OUT/I2C3_SMBA/DFSDM1_CKIN0/LCD_VLCD/EVENTOUT                                                                                                , COMP1_INP
+      ,         ,        , K6    , M5      ,      49, PF11                 , I/O , FT    ,      , DCMI_D12/EVENTOUT                                                                                                                                          , 
+      ,         ,        , J7    , N6      ,      50, PF12                 , I/O , FT    ,      , FMC_A6/EVENTOUT                                                                                                                                            , 
+      ,         ,        ,       ,         ,      51, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , A8      ,      52, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        , K7    , M6      ,      53, PF13                 , I/O , FT    ,      , I2C4_SMBA/DFSDM1_DATIN6/FMC_A7/EVENTOUT                                                                                                                    , 
+      ,         ,        , J8    , L6      ,      54, PF14                 , I/O , FT_f  ,      , I2C4_SCL/DFSDM1_CKIN6/TSC_G8_IO1/FMC_A8/EVENTOUT                                                                                                           , 
+      ,         ,        , J9    , K6      ,      55, PF15                 , I/O , FT_f  ,      , I2C4_SDA/TSC_G8_IO2/FMC_A9/EVENTOUT                                                                                                                        , 
+      ,         ,        , H9    , J6      ,      56, PG0                  , I/O , FT    ,      , TSC_G8_IO3/FMC_A10/EVENTOUT                                                                                                                                , 
+      ,         ,        , G9    , H6      ,      57, PG1                  , I/O , FT    ,      , TSC_G8_IO4/FMC_A11/EVENTOUT                                                                                                                                , 
+      , K6      ,      38, M7    , L7      ,      58, PE7                  , I/O , FT    ,      , TIM1_ETR/DFSDM1_DATIN2/FMC_D4/SAI1_SD_B/EVENTOUT                                                                                                           , 
+      , K5      ,      39, L7    , K7      ,      59, PE8                  , I/O , FT    ,      , TIM1_CH1N/DFSDM1_CKIN2/FMC_D5/SAI1_SCK_B/EVENTOUT                                                                                                          , 
+      , J5      ,      40, M8    , J7      ,      60, PE9                  , I/O , FT    ,      , TIM1_CH1/DFSDM1_CKOUT/FMC_D6/SAI1_FS_B/EVENTOUT                                                                                                            , 
+      ,         ,        , F6    , M7      ,      61, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        , G6    , N7      ,      62, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      , H5      ,      41, L8    , H7      ,      63, PE10                 , I/O , FT    ,      , TIM1_CH2N/DFSDM1_DATIN4/TSC_G5_IO1/QUADSPI_CLK/FMC_D7/SAI1_MCLK_B/EVENTOUT                                                                                 , 
+      , K4      ,      42, M9    , N8      ,      64, PE11                 , I/O , FT    ,      , TIM1_CH2/DFSDM1_CKIN4/TSC_G5_IO2/QUADSPI_BK1_NCS/FMC_D8/EVENTOUT                                                                                           , 
+      , G5      ,      43, L9    , M8      ,      65, PE12                 , I/O , FT    ,      , TIM1_CH3N/SPI1_NSS/DFSDM1_DATIN5/TSC_G5_IO3/QUADSPI_BK1_IO0/FMC_D9/EVENTOUT                                                                                , 
+      , G4      ,      44, M10   , L8      ,      66, PE13                 , I/O , FT    ,      , TIM1_CH3/SPI1_SCK/DFSDM1_CKIN5/TSC_G5_IO4/QUADSPI_BK1_IO1/FMC_D10/EVENTOUT                                                                                 , 
+      , J4      ,      45, M11   , K8      ,      67, PE14                 , I/O , FT    ,      , TIM1_CH4/TIM1_BKIN2/TIM1_BKIN2_COMP2/SPI1_MISO/QUADSPI_BK1_IO2/FMC_D11/EVENTOUT                                                                            , 
+      , H4      ,      46, M12   , J8      ,      68, PE15                 , I/O , FT    ,      , TIM1_BKIN/TIM1_BKIN_COMP1/SPI1_MOSI/QUADSPI_BK1_IO3/FMC_D12/EVENTOUT                                                                                       , 
+    29, K3      ,      47, L10   , N9      ,      69, PB10                 , I/O , FT_fl ,      , TIM2_CH3/I2C4_SCL/I2C2_SCL/SPI2_SCK/DFSDM1_DATIN7/USART3_TX/LPUART1_RX/TSC_SYNC/QUADSPI_CLK/LCD_SEG10/COMP1_OUT/SAI1_SCK_A/EVENTOUT                        , 
+    30, J3      ,      48, L11   , H8      ,      70, PB11                 , I/O , FT_fl ,      , TIM2_CH4/I2C4_SDA/I2C2_SDA/DFSDM1_CKIN7/USART3_RX/LPUART1_TX/QUADSPI_BK1_NCS/LCD_SEG11/COMP2_OUT/EVENTOUT                                                  , 
+      ,         ,        ,       ,         ,        , VDD12                , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , K9      ,        , PH4                  , I/O , FT_f  ,      , I2C2_SCL/EVENTOUT                                                                                                                                          , 
+      ,         ,        ,       , L9      ,        , PH5                  , I/O , FT_f  ,      , I2C2_SDA/DCMI_PIXCLK/EVENTOUT                                                                                                                              , 
+      ,         ,        ,       , N10     ,        , PH8                  , I/O , FT_f  ,      , I2C3_SDA/DCMI_HSYNC/EVENTOUT                                                                                                                               , 
+      ,         ,        ,       , M9      ,        , PH10                 , I/O , FT    ,      , TIM5_CH1/DCMI_D1/EVENTOUT                                                                                                                                  , 
+      ,         ,        ,       , M10     ,        , PH11                 , I/O , FT    ,      , TIM5_CH2/DCMI_D2/EVENTOUT                                                                                                                                  , 
+      ,         ,        ,       , M3      ,        , VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , N3      ,        , VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , M11     ,        , VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+    31, K2      ,      49, F12   , L13     ,      71, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+    32, K1      ,      50, G12   , L12     ,      72, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , N11     ,        , VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+    33, J1      ,      51, L12   , N12     ,      73, PB12                 , I/O , FT_l  ,      , TIM1_BKIN/TIM1_BKIN_COMP2/I2C2_SMBA/SPI2_NSS/DFSDM1_DATIN1/USART3_CK/LPUART1_RTS_DE/TSC_G1_IO1/CAN2_RX/LCD_SEG12/SWPMI1_IO/SAI2_FS_A/TIM15_BKIN/EVENTOUT   , 
+    34, J2      ,      52, K12   , N13     ,      74, PB13                 , I/O , FT_fl ,      , TIM1_CH1N/I2C2_SCL/SPI2_SCK/DFSDM1_CKIN1/USART3_CTS/LPUART1_CTS/TSC_G1_IO2/CAN2_TX/LCD_SEG13/SWPMI1_TX/SAI2_SCK_A/TIM15_CH1N/EVENTOUT                      , 
+    35, H2      ,      53, K11   , M13     ,      75, PB14                 , I/O , FT_fl ,      , TIM1_CH2N/TIM8_CH2N/I2C2_SDA/SPI2_MISO/DFSDM1_DATIN2/USART3_RTS_DE/TSC_G1_IO3/LCD_SEG14/SWPMI1_RX/SAI2_MCLK_A/TIM15_CH1/EVENTOUT                           , 
+    36, H1      ,      54, K10   , M12     ,      76, PB15                 , I/O , FT_l  ,      , RTC_REFIN/TIM1_CH3N/TIM8_CH3N/SPI2_MOSI/DFSDM1_CKIN2/TSC_G1_IO4/LCD_SEG15/SWPMI1_SUSPEND/SAI2_SD_A/TIM15_CH2/EVENTOUT                                      , 
+      , H3      ,      55, K9    , L11     ,      77, PD8                  , I/O , FT_l  ,      , USART3_TX/DCMI_HSYNC/LCD_SEG28/FMC_D13/EVENTOUT                                                                                                            , 
+      , G2      ,      56, K8    , L10     ,      78, PD9                  , I/O , FT_l  ,      , USART3_RX/DCMI_PIXCLK/LCD_SEG29/FMC_D14/SAI2_MCLK_A/EVENTOUT                                                                                               , 
+      , G1      ,      57, J12   , J13     ,      79, PD10                 , I/O , FT_l  ,      , USART3_CK/TSC_G6_IO1/LCD_SEG30/FMC_D15/SAI2_SCK_A/EVENTOUT                                                                                                 , 
+      ,         ,      58, J11   , K12     ,      80, PD11                 , I/O , FT_l  ,      , I2C4_SMBA/USART3_CTS/TSC_G6_IO2/LCD_SEG31/FMC_A16/SAI2_SD_A/LPTIM2_ETR/EVENTOUT                                                                            , 
+      ,         ,      59, J10   , K11     ,      81, PD12                 , I/O , FT_fl ,      , TIM4_CH1/I2C4_SCL/USART3_RTS_DE/TSC_G6_IO3/LCD_SEG32/FMC_A17/SAI2_FS_A/LPTIM2_IN1/EVENTOUT                                                                 , 
+      ,         ,      60, H12   , K13     ,      82, PD13                 , I/O , FT_fl ,      , TIM4_CH2/I2C4_SDA/TSC_G6_IO4/LCD_SEG33/FMC_A18/LPTIM2_OUT/EVENTOUT                                                                                         , 
+      ,         ,        ,       , H12     ,      83, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      , F1      ,        ,       , H13     ,      84, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      , G3      ,      61, H11   , K10     ,      85, PD14                 , I/O , FT_l  ,      , TIM4_CH3/LCD_SEG34/FMC_D0/EVENTOUT                                                                                                                         , 
+      , F4      ,      62, H10   , H11     ,      86, PD15                 , I/O , FT_l  ,      , TIM4_CH4/LCD_SEG35/FMC_D1/EVENTOUT                                                                                                                         , 
+      ,         ,        , G10   , J12     ,      87, PG2                  , I/O , FT_s  ,      , SPI1_SCK/FMC_A12/SAI2_SCK_B/EVENTOUT                                                                                                                       , 
+      ,         ,        , F9    , J11     ,      88, PG3                  , I/O , FT_s  ,      , SPI1_MISO/FMC_A13/SAI2_FS_B/EVENTOUT                                                                                                                       , 
+      ,         ,        , F10   , J10     ,      89, PG4                  , I/O , FT_s  ,      , SPI1_MOSI/FMC_A14/SAI2_MCLK_B/EVENTOUT                                                                                                                     , 
+      ,         ,        , E9    , J9      ,      90, PG5                  , I/O , FT_s  ,      , SPI1_NSS/LPUART1_CTS/FMC_A15/SAI2_SD_B/EVENTOUT                                                                                                            , 
+      ,         ,        , G4    , G11     ,      91, PG6                  , I/O , FT_s  ,      , I2C3_SMBA/LPUART1_RTS_DE/EVENTOUT                                                                                                                          , 
+      ,         ,        , H4    , H10     ,      92, PG7                  , I/O , FT_fs ,      , I2C3_SCL/LPUART1_TX/FMC_INT/SAI1_MCLK_A/EVENTOUT                                                                                                           , 
+      ,         ,        , J6    , H9      ,      93, PG8                  , I/O , FT_fs ,      , I2C3_SDA/LPUART1_RX/EVENTOUT                                                                                                                               , 
+      ,         ,        ,       , F13     ,      94, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , F12     ,      95, VDDIO2               , S   ,       ,      ,                                                                                                                                                            , 
+    37, F2      ,      63, E12   , F11     ,      96, PC6                  , I/O , FT_l  ,      , TIM3_CH1/TIM8_CH1/DFSDM1_CKIN3/TSC_G4_IO1/DCMI_D0/LCD_SEG24/SDMMC1_D6/SAI2_MCLK_A/EVENTOUT                                                                 , 
+    38, F3      ,      64, E11   , G12     ,      97, PC7                  , I/O , FT_l  ,      , TIM3_CH2/TIM8_CH2/DFSDM1_DATIN3/TSC_G4_IO2/DCMI_D1/LCD_SEG25/SDMMC1_D7/SAI2_MCLK_B/EVENTOUT                                                                , 
+    39, E1      ,      65, E10   , G10     ,      98, PC8                  , I/O , FT_l  ,      , TIM3_CH3/TIM8_CH3/TSC_G4_IO3/DCMI_D2/LCD_SEG26/SDMMC1_D0/EVENTOUT                                                                                          , 
+    40, E2      ,      66, D12   , G9      ,      99, PC9                  , I/O , FT_fl ,      , TIM8_BKIN2/TIM3_CH4/TIM8_CH4/DCMI_D3/I2C3_SDA/TSC_G4_IO4/OTG_FS_NOE/LCD_SEG27/SDMMC1_D1/SAI2_EXTCLK/TIM8_BKIN2_COMP1/EVENTOUT                              , 
+    41, E3      ,      67, D11   , G8      ,     100, PA8                  , I/O , FT_fl ,      , MCO/TIM1_CH1/USART1_CK/OTG_FS_SOF/LCD_COM0/SWPMI1_IO/SAI1_SCK_A/LPTIM2_OUT/EVENTOUT                                                                        , 
+    42, D3      ,      68, D10   , F10     ,     101, PA9                  , I/O , FT_flu,      , TIM1_CH2/SPI2_SCK/DCMI_D0/USART1_TX/LCD_COM1/SAI1_FS_A/TIM15_BKIN/EVENTOUT                                                                                 , OTG_FS_VBUS
+    43, D2      ,      69, C12   , F9      ,     102, PA10                 , I/O , FT_flu,      , TIM1_CH3/DCMI_D1/USART1_RX/OTG_FS_ID/LCD_COM2/SAI1_SD_A/TIM17_BKIN/EVENTOUT                                                                                , 
+    44, D1      ,      70, B12   , E13     ,     103, PA11                 , I/O , FT_u  ,      , TIM1_CH4/TIM1_BKIN2/SPI1_MISO/USART1_CTS/CAN1_RX/OTG_FS_DM/TIM1_BKIN2_COMP1/EVENTOUT                                                                       , 
+    45, C1      ,      71, A12   , D13     ,     104, PA12                 , I/O , FT_u  ,      , TIM1_ETR/SPI1_MOSI/USART1_RTS_DE/CAN1_TX/OTG_FS_DP/EVENTOUT                                                                                                , 
+    46, C2      ,      72, A11   , A11     ,     105, PA13(JTMS-SWDIO)     , I/O , FT    ,      , JTMS/SWDIO/IR_OUT/OTG_FS_NOE/SWPMI1_TX/SAI1_SD_B/EVENTOUT                                                                                                  , 
+    47, B1      ,        ,       ,         ,        , VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+    48, A1      ,      73, C11   , E12     ,     106, VDDUSB               , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,      74, F11   , C12     ,     107, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,      75, G11   , C13     ,     108, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , E11     ,        , PH6                  , I/O , FT    ,      , I2C2_SMBA/DCMI_D8/EVENTOUT                                                                                                                                 , 
+      ,         ,        ,       , D12     ,        , PH7                  , I/O , FT_f  ,      , I2C3_SCL/DCMI_D9/EVENTOUT                                                                                                                                  , 
+      ,         ,        ,       , D11     ,        , PH9                  , I/O , FT    ,      , I2C3_SMBA/DCMI_D0/EVENTOUT                                                                                                                                 , 
+      ,         ,        ,       , B13     ,        , PH12                 , I/O , FT    ,      , TIM5_CH3/DCMI_D3/EVENTOUT                                                                                                                                  , 
+      ,         ,        ,       , A13     ,        , PH14                 , I/O , FT    ,      , TIM8_CH2N/DCMI_D4/EVENTOUT                                                                                                                                 , 
+      ,         ,        ,       , B12     ,        , PH15                 , I/O , FT    ,      , TIM8_CH3N/DCMI_D11/EVENTOUT                                                                                                                                , 
+      ,         ,        ,       , A12     ,        , PI0                  , I/O , FT    ,      , TIM5_CH4/SPI2_NSS/DCMI_D13/EVENTOUT                                                                                                                        , 
+      ,         ,        ,       , C11     ,        , PI8                  , I/O , FT    ,      , DCMI_D12/EVENTOUT                                                                                                                                          , 
+      ,         ,        ,       , B11     ,        , PI1                  , I/O , FT    ,      , SPI2_SCK/DCMI_D8/EVENTOUT                                                                                                                                  , 
+      ,         ,        ,       , B10     ,        , PI2                  , I/O , FT    ,      , TIM8_CH4/SPI2_MISO/DCMI_D9/EVENTOUT                                                                                                                        , 
+      ,         ,        ,       , C10     ,        , PI3                  , I/O , FT    ,      , TIM8_ETR/SPI2_MOSI/DCMI_D10/EVENTOUT                                                                                                                       , 
+      ,         ,        ,       , D10     ,        , PI4                  , I/O , FT    ,      , TIM8_BKIN/DCMI_D5/EVENTOUT                                                                                                                                 , 
+      ,         ,        ,       , E10     ,        , PI5                  , I/O , FT    ,      , TIM8_CH1/DCMI_VSYNC/EVENTOUT                                                                                                                               , 
+      ,         ,        ,       , C9      ,        , PH13                 , I/O , FT    ,      , TIM8_CH1N/CAN1_TX/EVENTOUT                                                                                                                                 , 
+      ,         ,        ,       , B9      ,        , PI6                  , I/O , FT    ,      , TIM8_CH2/DCMI_D6/EVENTOUT                                                                                                                                  , 
+    49, B2      ,      76, A10   , A10     ,     109, PA14(JTCK-SWCLK)     , I/O , FT    ,      , JTCK/SWCLK/LPTIM1_OUT/I2C1_SMBA/I2C4_SMBA/OTG_FS_SOF/SWPMI1_RX/SAI1_FS_B/EVENTOUT                                                                          , 
+    50, A2      ,      77, A9    , A9      ,     110, PA15(JTDI)           , I/O , FT_l  ,      , JTDI/TIM2_CH1/TIM2_ETR/USART2_RX/SPI1_NSS/SPI3_NSS/USART3_RTS_DE/UART4_RTS_DE/TSC_G3_IO1/LCD_SEG17/SWPMI1_SUSPEND/SAI2_FS_B/EVENTOUT                       , 
+    51, D4      ,      78, B11   , D9      ,     111, PC10                 , I/O , FT_l  ,      , TRACED1/SPI3_SCK/USART3_TX/UART4_TX/TSC_G3_IO2/DCMI_D8/LCD_COM4/LCD_SEG28/LCD_SEG40/SDMMC1_D2/SAI2_SCK_B/EVENTOUT                                          , 
+    52, C3      ,      79, C10   , E9      ,     112, PC11                 , I/O , FT_l  ,      , QUADSPI_BK2_NCS/SPI3_MISO/USART3_RX/UART4_RX/TSC_G3_IO3/DCMI_D4/LCD_COM5/LCD_SEG29/LCD_SEG41/SDMMC1_D3/SAI2_MCLK_B/EVENTOUT                                , 
+    53, C4      ,      80, B10   , F8      ,     113, PC12                 , I/O , FT_l  ,      , TRACED3/SPI3_MOSI/USART3_CK/UART5_TX/TSC_G3_IO4/DCMI_D9/LCD_COM6/LCD_SEG30/LCD_SEG42/SDMMC1_CK/SAI2_SD_B/EVENTOUT                                          , 
+      , B3      ,      81, C9    , B8      ,     114, PD0                  , I/O , FT    ,      , SPI2_NSS/DFSDM1_DATIN7/CAN1_RX/FMC_D2/EVENTOUT                                                                                                             , 
+      , A3      ,      82, B9    , C8      ,     115, PD1                  , I/O , FT    ,      , SPI2_SCK/DFSDM1_CKIN7/CAN1_TX/FMC_D3/EVENTOUT                                                                                                              , 
+    54, E4      ,      83, C8    , D8      ,     116, PD2                  , I/O , FT_l  ,      , TRACED2/TIM3_ETR/USART3_RTS_DE/UART5_RX/TSC_SYNC/DCMI_D11/LCD_COM7/LCD_SEG31/LCD_SEG43/SDMMC1_CMD/EVENTOUT                                                 , 
+      ,         ,      84, B8    , E8      ,     117, PD3                  , I/O , FT    ,      , SPI2_SCK/DCMI_D5/SPI2_MISO/DFSDM1_DATIN0/USART2_CTS/QUADSPI_BK2_NCS/FMC_CLK/EVENTOUT                                                                       , 
+      , B4      ,      85, B7    , C7      ,     118, PD4                  , I/O , FT    ,      , SPI2_MOSI/DFSDM1_CKIN0/USART2_RTS_DE/QUADSPI_BK2_IO0/FMC_NOE/EVENTOUT                                                                                      , 
+      , E5      ,      86, A6    , D7      ,     119, PD5                  , I/O , FT    ,      , USART2_TX/QUADSPI_BK2_IO1/FMC_NWE/EVENTOUT                                                                                                                 , 
+      ,         ,        ,       ,         ,     120, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      , A4      ,        ,       ,         ,     121, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      , D5      ,      87, B6    , E7      ,     122, PD6                  , I/O , FT    ,      , DCMI_D10/QUADSPI_BK2_IO1/DFSDM1_DATIN1/USART2_RX/QUADSPI_BK2_IO2/FMC_NWAIT/SAI1_SD_A/EVENTOUT                                                              , 
+      , C5      ,      88, A5    , F7      ,     123, PD7                  , I/O , FT    ,      , DFSDM1_CKIN1/USART2_CK/QUADSPI_BK2_IO3/FMC_NE1/EVENTOUT                                                                                                    , 
+      , B5      ,        , D9    , B7      ,     124, PG9                  , I/O , FT_s  ,      , SPI3_SCK/USART1_TX/FMC_NCE/FMC_NE2/SAI2_SCK_A/TIM15_CH1N/EVENTOUT                                                                                          , 
+      , A5      ,        , D8    , D6      ,     125, PG10                 , I/O , FT_s  ,      , LPTIM1_IN1/SPI3_MISO/USART1_RX/FMC_NE3/SAI2_FS_A/TIM15_CH1/EVENTOUT                                                                                        , 
+      , D6      ,        , G3    , E6      ,     126, PG11                 , I/O , FT_s  ,      , LPTIM1_IN2/SPI3_MOSI/USART1_CTS/SAI2_MCLK_A/TIM15_CH2/EVENTOUT                                                                                             , 
+      , B6      ,        , D7    , F6      ,     127, PG12                 , I/O , FT_s  ,      , LPTIM1_ETR/SPI3_NSS/USART1_RTS_DE/FMC_NE4/SAI2_SD_A/EVENTOUT                                                                                               , 
+      ,         ,        , C7    , G7      ,     128, PG13                 , I/O , FT_fs ,      , I2C1_SDA/USART1_CK/FMC_A24/EVENTOUT                                                                                                                        , 
+      ,         ,        , C6    , G6      ,     129, PG14                 , I/O , FT_fs ,      , I2C1_SCL/FMC_A25/EVENTOUT                                                                                                                                  , 
+      ,         ,        , F7    , A7      ,     130, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      , A6      ,        , G7    , B6      ,     131, VDDIO2               , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        , K1    , C6      ,     132, PG15                 , I/O , FT_s  ,      , LPTIM1_OUT/I2C1_SMBA/DCMI_D13/EVENTOUT                                                                                                                     , 
+    55, C6      ,      89, A8    , A6      ,     133, PB3(JTDO-TRACESWO)   , I/O , FT_la ,      , JTDO/TRACESWO/TIM2_CH2/SPI1_SCK/SPI3_SCK/USART1_RTS_DE/OTG_FS_CRS_SYNC/LCD_SEG7/SAI1_SCK_B/EVENTOUT                                                        , COMP2_INM
+    56, C7      ,      90, A7    , A5      ,     134, PB4(NJTRST)          , I/O , FT_fla,      , NJTRST/TIM3_CH1/I2C3_SDA/SPI1_MISO/SPI3_MISO/USART1_CTS/UART5_RTS_DE/TSC_G2_IO1/DCMI_D12/LCD_SEG8/SAI1_MCLK_B/TIM17_BKIN/EVENTOUT                          , COMP2_INP
+    57, B7      ,      91, C5    , B5      ,     135, PB5                  , I/O , FT_l  ,      , LPTIM1_IN1/TIM3_CH2/CAN2_RX/I2C1_SMBA/SPI1_MOSI/SPI3_MOSI/USART1_CK/UART5_CTS/TSC_G2_IO2/DCMI_D10/LCD_SEG9/COMP2_OUT/SAI1_SD_B/TIM16_BKIN/EVENTOUT         , 
+    58, A7      ,      92, B5    , C5      ,     136, PB6                  , I/O , FT_fa ,      , LPTIM1_ETR/TIM4_CH1/TIM8_BKIN2/I2C1_SCL/I2C4_SCL/DFSDM1_DATIN5/USART1_TX/CAN2_TX/TSC_G2_IO3/DCMI_D5/TIM8_BKIN2_COMP2/SAI1_FS_B/TIM16_CH1N/EVENTOUT         , COMP2_INP
+    59, D7      ,      93, B4    , D5      ,     137, PB7                  , I/O , FT_fla,      , LPTIM1_IN2/TIM4_CH2/TIM8_BKIN/I2C1_SDA/I2C4_SDA/DFSDM1_CKIN5/USART1_RX/UART4_CTS/TSC_G2_IO4/DCMI_VSYNC/LCD_SEG21/FMC_NL/TIM8_BKIN_COMP1/TIM17_CH1N/EVENTOUT, COMP2_INM/PVD_IN
+    60, E6      ,      94, A4    , E5      ,     138, PH3-BOOT0            , I/O , FT    ,      , EVENTOUT                                                                                                                                                   , 
+    61, B8      ,      95, A3    , C4      ,     139, PB8                  , I/O , FT_fl ,      , TIM4_CH3/I2C1_SCL/DFSDM1_DATIN6/CAN1_RX/DCMI_D6/LCD_SEG16/SDMMC1_D4/SAI1_MCLK_A/TIM16_CH1/EVENTOUT                                                         , 
+    62, A8      ,      96, B3    , D4      ,     140, PB9                  , I/O , FT_fl ,      , IR_OUT/TIM4_CH4/I2C1_SDA/SPI2_NSS/DFSDM1_CKIN6/CAN1_TX/DCMI_D7/LCD_COM3/SDMMC1_D5/SAI1_FS_A/TIM17_CH1/EVENTOUT                                             , 
+      ,         ,        ,       ,         ,        , VDD12                , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,      97, C3    , A4      ,     141, PE0                  , I/O , FT_l  ,      , TIM4_ETR/DCMI_D2/LCD_SEG36/FMC_NBL0/TIM16_CH1/EVENTOUT                                                                                                     , 
+      ,         ,      98, A2    , B4      ,     142, PE1                  , I/O , FT_l  ,      , DCMI_D3/LCD_SEG37/FMC_NBL1/TIM17_CH1/EVENTOUT                                                                                                              , 
+      ,         ,        ,       ,         ,        , VDD12                , S   ,       ,      ,                                                                                                                                                            , 
+    63, A9      ,      99, D3    , B3      ,     143, VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+    64, A10     ,     100, C4    , A3      ,     144, VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , C2      ,        , VSS                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , C1      ,        , VDD                  , S   ,       ,      ,                                                                                                                                                            , 
+      ,         ,        ,       , A2      ,        , PH2                  , I/O , FT    ,      , QUADSPI_BK2_IO0/EVENTOUT                                                                                                                                   , 
+      ,         ,        ,       , B2      ,        , PI7                  , I/O , FT    ,      , TIM8_CH3/DCMI_D7/EVENTOUT                                                                                                                                  , 
+      ,         ,        ,       , B1      ,        , PI9                  , I/O , FT    ,      , CAN1_RX/EVENTOUT                                                                                                                                           , 
+      ,         ,        ,       , A1      ,        , PI10                 , I/O , FT    ,      , EVENTOUT                                                                                                                                                   , 

--- a/scripts/pinutils.py
+++ b/scripts/pinutils.py
@@ -189,9 +189,9 @@ def scan_pin_file(pins, filename, nameoffset, functionoffset, altfunctionoffset)
   f = open(os.path.dirname(os.path.realpath(__file__))+'/../boards/pins/'+filename)
   lines = f.readlines()
   f.close()
-  headings = lines[0].split(",")
+  headings = [x.strip() for x in lines[0].split(",")]
   for line in lines:
-    pindata = line.split(",")
+    pindata = [x.strip() for x in line.split(",")]
     pinname = pindata[nameoffset].strip()
 
     extrafunction = ""


### PR DESCRIPTION
- this field stripping allows to use formatted .csv files
- vertically aligned with `mechatroner.rainbow-csv` or same like extension
