### PR TITLE
Fix for unlink not updating cluster count for file deletion.

### DIFF
--- a/libs/filesystem/fat_sd/ff.c
+++ b/libs/filesystem/fat_sd/ff.c
@@ -3485,9 +3485,10 @@ FRESULT f_unlink (
 			} else {
 				if (dir[DIR_Attr] & AM_RDO)
 					res = FR_DENIED;		/* Cannot remove R/O object */
+				else
+					dclst = ld_clust(dj.fs, dir);	/* Get cluster chain for files and directories */
 			}
 			if (res == FR_OK && (dir[DIR_Attr] & AM_DIR)) {	/* Is it a sub-dir? */
-				dclst = ld_clust(dj.fs, dir);
 				if (!dclst) {
 					res = FR_INT_ERR;
 				} else {					/* Make sure the sub-directory is empty */


### PR DESCRIPTION
Not sure if this issue exists on other devices, but on the Pip-Boy, if a file is deleted, the free cluster count is not properly updated. I believe this is because the cluster count is only updated if a directory is deleted, and does not update if a file is deleted. So I moved the cluster update code appropriately so it updates for both.