### PR TITLE
Add true rounded corners to E.showMenu

### DIFF
--- a/libs/js/banglejs/E_showPrompt_Q3.js
+++ b/libs/js/banglejs/E_showPrompt_Q3.js
@@ -35,7 +35,7 @@
       btnPos.push({x1:x-2, x2:x+BW-2,
                    y1:y, y2:y+BH});
       var btnText = g.findFont(btn, {w:bw-4,h:BH-4,wrap:1});
-      var r = 10;
+      var r = 11;
       var isHL = (idx===highlightedButton);
       g.setColor(isHL ? g.theme.fgH : g.theme.fg2);
       g.fillRect({x:x, y:y, w:bw, h:bh, r:r});


### PR DESCRIPTION
This PR just makes the corners in buttons truly rounded - before it was a poly with harsh edges. Hopefully this helps subtly make the interface feel a little more fresh and modern - without changing anything major. I know we've had some issues with changes like this @gfwilliams, so I've avoided changing anything that isn't related to the rounded corners at all, and most people probably won't notice/comment on it anyway. Overall, this PR is designed to be as minimal as possible, only using `g.fillRect()` calls, and hopefully helps to make the prompt interface feel a little fresher. 

### Screenshots:

<img width="176" height="176" alt="download (3)" src="https://github.com/user-attachments/assets/1731b31e-9671-4b71-bef9-ec998b2c8978" />

<img width="176" height="176" alt="download (2)" src="https://github.com/user-attachments/assets/05e5d209-cd16-4178-9833-a2cae0d662f9" />
