### PR TITLE
fix errors in NRF_GPIO_PIN_WRITE_FAST and NRF_GPIO_PIN_READ_FAST on NRF52840 / port P1

### DIFF
--- a/targets/nrf5x/nrf5x_utils.h
+++ b/targets/nrf5x/nrf5x_utils.h
@@ -35,8 +35,8 @@ void nrf_configure_uicr_flags(void);
 #ifdef NRF_P1
 #define NRF_GPIO_PIN_SET_FAST(PIN) {if((PIN)<P0_PIN_NUM) NRF_P0->OUTSET=1<<(PIN); else NRF_P1->OUTSET=1<<((PIN)-P0_PIN_NUM);}
 #define NRF_GPIO_PIN_CLEAR_FAST(PIN) {if((PIN)<P0_PIN_NUM) NRF_P0->OUTCLR=1<<(PIN); else NRF_P1->OUTCLR=1<<((PIN)-P0_PIN_NUM);}
-#define NRF_GPIO_PIN_WRITE_FAST(PIN,V) {if((PIN)<P0_PIN_NUM) { if (V) NRF_P0->OUTSET=1<<(PIN); else NRF_P0->OUTCLR=1<<(PIN); } else { if (V) NRF_P1->OUTSET=1<<(PIN); else NRF_P1->OUTCLR=1<<(PIN); }}
-#define NRF_GPIO_PIN_READ_FAST(PIN) (((PIN)<P0_PIN_NUM) ? (NRF_P0->IN >> (PIN))&1 : (NRF_P0->IN >> (PIN)) &1 )
+#define NRF_GPIO_PIN_WRITE_FAST(PIN,V) {if((PIN)<P0_PIN_NUM) { if (V) NRF_P0->OUTSET=1<<(PIN); else NRF_P0->OUTCLR=1<<(PIN); } else { if (V) NRF_P1->OUTSET=1<<((PIN)-P0_PIN_NUM); else NRF_P1->OUTCLR=1<<((PIN)-P0_PIN_NUM); }}
+#define NRF_GPIO_PIN_READ_FAST(PIN) (((PIN)<P0_PIN_NUM) ? (NRF_P0->IN >> (PIN))&1 : (NRF_P1->IN >> ((PIN)-P0_PIN_NUM))&1 )
 #define NRF_GPIO_PIN_CNF(PIN,value) {((PIN<P0_PIN_NUM) ? NRF_P0 : NRF_P1)->PIN_CNF[PIN & 31]=value;}
 #else
 #define NRF_GPIO_PIN_SET_FAST(PIN) NRF_P0->OUTSET=1<<(PIN);

--- a/targets/nrf5x_dfu/hardware.h
+++ b/targets/nrf5x_dfu/hardware.h
@@ -23,8 +23,8 @@
 #ifdef NRF_P1
 #define NRF_GPIO_PIN_SET_FAST(PIN) {if((PIN)<P0_PIN_NUM) NRF_P0->OUTSET=1<<(PIN); else NRF_P1->OUTSET=1<<((PIN)-P0_PIN_NUM);}
 #define NRF_GPIO_PIN_CLEAR_FAST(PIN) {if((PIN)<P0_PIN_NUM) NRF_P0->OUTCLR=1<<(PIN); else NRF_P1->OUTCLR=1<<((PIN)-P0_PIN_NUM);}
-#define NRF_GPIO_PIN_WRITE_FAST(PIN,V) {if((PIN)<P0_PIN_NUM) { if (V) NRF_P0->OUTSET=1<<(PIN); else NRF_P0->OUTCLR=1<<(PIN); } else { if (V) NRF_P1->OUTSET=1<<(PIN); else NRF_P1->OUTCLR=1<<(PIN); }}
-#define NRF_GPIO_PIN_READ_FAST(PIN) (((PIN)<P0_PIN_NUM) ? (NRF_P0->IN >> (PIN))&1 : (NRF_P0->IN >> (PIN)) &1 )
+#define NRF_GPIO_PIN_WRITE_FAST(PIN,V) {if((PIN)<P0_PIN_NUM) { if (V) NRF_P0->OUTSET=1<<(PIN); else NRF_P0->OUTCLR=1<<(PIN); } else { if (V) NRF_P1->OUTSET=1<<((PIN)-P0_PIN_NUM); else NRF_P1->OUTCLR=1<<((PIN)-P0_PIN_NUM); }}
+#define NRF_GPIO_PIN_READ_FAST(PIN) (((PIN)<P0_PIN_NUM) ? (NRF_P0->IN >> (PIN))&1 : (NRF_P1->IN >> ((PIN)-P0_PIN_NUM))&1 )
 #define NRF_GPIO_PIN_CNF(PIN,value) {((PIN<P0_PIN_NUM) ? NRF_P0 : NRF_P1)->PIN_CNF[PIN & 31]=value;}
 
 #else


### PR DESCRIPTION
The #define macros NRF_GPIO_PIN_WRITE_FAST and NRF_GPIO_PIN_READ_FAST are not correct on port P1/ if pin number is >= 32. This affects e.g. an external flash chip on NRF52840 connected to pins on port P1.

This occurs for both NRF_GPIO_PIN_WRITE_FAST and NRF_GPIO_PIN_READ_FAST in both targets/nrf5x/nrf5x_utils.h‎ and targets/nrf5x_dfu/hardware.h. The cause is that the write macro omitted the correction for making the P1 port number zero-based and the read macro read from the wrong port and additionally omitted the port number correction.

This PR corrects the port and adds the calculations.