### PR TITLE
Document E.getBattery when CUSTOM_GETBATTERY is defined

### DIFF
--- a/src/jswrap_espruino.c
+++ b/src/jswrap_espruino.c
@@ -2557,7 +2557,7 @@ bool jswrap_espruino_sendUSBHID(JsVar *arr) {
 
 /*JSON{
   "type" : "staticmethod",
-  "#if" : "defined(PUCKJS) || defined(PIXLJS) || defined(BANGLEJS)",
+  "#if" : "defined(PUCKJS) || defined(PIXLJS) || defined(BANGLEJS) || defined(CUSTOM_GETBATTERY)",
   "class" : "E",
   "name" : "getBattery",
   "generate" : "jswrap_espruino_getBattery",


### PR DESCRIPTION
Boards can wire a custom battery reader via makefile DEFINES without adding board headers to core; include the API in generated docs too.
