### PR TITLE
Add ESP32.lightSleep and fix USB-JTAG console for light sleep

### DIFF
--- a/targets/esp32/jshardwareUart.c
+++ b/targets/esp32/jshardwareUart.c
@@ -29,6 +29,9 @@
 
 bool serial2_initialized = false;
 bool serial3_initialized = false;
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+static bool uart_console_installed = false;
+#endif
 
 void jshSetDeviceInitialised(IOEventFlags device, bool isInit);
 
@@ -40,7 +43,12 @@ void initUart(int uart_num, uart_config_t uart_config, int txpin, int rxpin){
 }
 
 void UartReset(){
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+  if (uart_console_installed) uart_driver_delete(uart_console);
+  usb_serial_jtag_driver_uninstall();
+#else
   uart_driver_delete(uart_console);
+#endif
   initConsole();
   if(serial2_initialized) uart_driver_delete(uart_Serial2);
   if(serial3_initialized) uart_driver_delete(uart_Serial3);
@@ -63,7 +71,13 @@ void initSerial(IOEventFlags device,JshUSARTInfo *inf){
     case 2: uart_config.parity = UART_PARITY_EVEN; break;
   }
   if(device == EV_SERIAL1) {
+#ifndef ESPR_USE_USB_SERIAL_JTAG
     initUart(uart_console,uart_config,-1,-1);
+#else
+    // Console I/O uses USB Serial/JTAG; UART0 driver blocks light sleep
+    // (IDF suspend_uarts waits for UART0 FSM idle when the peripheral is on).
+    uart_console_installed = false;
+#endif
     jshSetFlowControlEnabled(device, inf->xOnXOff, inf->pinCTS);
   } else if(device == EV_SERIAL2){
     if(inf->pinTX == 0xff) inf->pinTX = 4;
@@ -93,8 +107,8 @@ void initConsole(){
                                                        .rx_buffer_size = 128};
   jsDebug(DBG_INFO, "initConsole: Installing usb_serial_jtag_driver \n");
   ESP_ERROR_CHECK(usb_serial_jtag_driver_install(&usb_serial_config));
-#endif
-
+  uart_console_installed = false;
+#else
   uart_config_t uart_config = {
     .baud_rate = 115200,
     .data_bits = UART_DATA_8_BITS,
@@ -104,6 +118,7 @@ void initConsole(){
     .rx_flow_ctrl_thresh = 122,
   };
   initUart(uart_console,uart_config,-1,-1);
+#endif
 
   // should we use hardware flow control on most ESP32 boards?
   // No... It looks like CTS is not connected on most boards, so XON/XOFF is best!

--- a/targets/esp32/jswrap_esp32.c
+++ b/targets/esp32/jswrap_esp32.c
@@ -25,7 +25,11 @@
 #include "esp_heap_caps.h"
 #include "esp_ota_ops.h"
 
-#include "driver/rtc_io.h"
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+#include "hal/usb_serial_jtag_ll.h"
+#include "driver/usb_serial_jtag.h"
+#include "rtosutil.h"
+#endif
 
 #ifdef BLUETOOTH
 #include "BLE/esp32_bluetooth_utils.h"
@@ -74,6 +78,16 @@ void jswrap_ESP32_reboot() {
   jshReboot();
 } // End of jswrap_ESP32_reboot
 
+static bool esp32IsValidDeepSleepWakeupPin(Pin pin) {
+  gpio_num_t gpio = pinToESP32Pin(pin);
+  if (gpio < 0 || gpio >= GPIO_NUM_MAX) return false;
+  return esp_sleep_is_valid_wakeup_gpio(gpio);
+}
+
+static uint64_t esp32DeepSleepGpioMask(Pin pin) {
+  return 1ULL << pinToESP32Pin(pin);
+}
+
 
 /*JSON{
   "type"     : "staticmethod",
@@ -102,18 +116,18 @@ void jswrap_ESP32_deepSleep(int us) {
   ]
 }
 Put device in deepsleep state until interrupted by pin "pin".
-Eligible pin numbers are restricted to those [GPIOs designated
-as RTC GPIOs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary).
+On ESP32-C3, valid wakeup pins are GPIO 0–5 (e.g. `D3` for the power button).
+On other ESP32 variants, pins must be [RTC GPIOs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary).
 */
 void jswrap_ESP32_deepSleep_ext0(Pin pin, int level) {
-  if (!rtc_gpio_is_valid_gpio(pin)) {
+  if (!esp32IsValidDeepSleepWakeupPin(pin)) {
     jsExceptionHere(JSET_ERROR, "Invalid pin");
     return;
   }
 #ifdef CONFIG_IDF_TARGET_ESP32C3
-  esp_deep_sleep_enable_gpio_wakeup(1<<pin, level);
+  esp_deep_sleep_enable_gpio_wakeup(esp32DeepSleepGpioMask(pin), level);
 #else
-  esp_sleep_enable_ext0_wakeup(pin, level);
+  esp_sleep_enable_ext0_wakeup(pinToESP32Pin(pin), level);
 #endif
   esp_deep_sleep_start(); // This function does not return.
 } // End of jswrap_ESP32_deepSleep_ext0
@@ -136,8 +150,8 @@ Valid modes are:
 * `0: ESP_EXT1_WAKEUP_ALL_LOW` - all nominated pins must be set LOW to trigger wakeup
 * `1: ESP_EXT1_WAKEUP_ANY_HIGH` - any of nominated pins set HIGH will trigger wakeup
 
-Eligible pin numbers are restricted to those [GPIOs designated
-as RTC GPIOs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary).
+On ESP32-C3, valid wakeup pins are GPIO 0–5.
+On other ESP32 variants, pins must be [RTC GPIOs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary).
 */
 void jswrap_ESP32_deepSleep_ext1(JsVar *pinVar, JsVarInt mode) {
   uint64_t pinSum = 0;
@@ -146,12 +160,12 @@ void jswrap_ESP32_deepSleep_ext1(JsVar *pinVar, JsVarInt mode) {
     jsvIteratorNew(&it, pinVar, JSIF_DEFINED_ARRAY_ElEMENTS);
     while (jsvIteratorHasElement(&it)) {
       Pin pin = jshGetPinFromVarAndUnLock(jsvIteratorGetValue(&it));
-      if (!rtc_gpio_is_valid_gpio(pin)) {
+      if (!esp32IsValidDeepSleepWakeupPin(pin)) {
         jsvIteratorFree(&it);
         jsExceptionHere(JSET_ERROR, "Invalid pin");
         return;
       }
-      pinSum += 1<<pin;
+      pinSum |= esp32DeepSleepGpioMask(pin);
 
       jsvIteratorNext(&it);
     }
@@ -160,11 +174,11 @@ void jswrap_ESP32_deepSleep_ext1(JsVar *pinVar, JsVarInt mode) {
     // We really expected an array of pins but
     // handle case of a single pin anyway
     Pin pin = jshGetPinFromVar(pinVar);
-    if (!rtc_gpio_is_valid_gpio(pin)) {
+    if (!esp32IsValidDeepSleepWakeupPin(pin)) {
       jsExceptionHere(JSET_ERROR, "Invalid pin");
       return;
     }
-    pinSum = 1<<pin;
+    pinSum = esp32DeepSleepGpioMask(pin);
   }
 
   if ((mode < 0) || (mode > 1)) {
@@ -202,6 +216,72 @@ Possible causes include:
 int jswrap_ESP32_getWakeupCause() {
   return esp_sleep_get_wakeup_cause();
 } // End of jswrap_ESP32_getWakeupCause
+
+
+/*JSON{
+  "type"     : "staticmethod",
+  "class"    : "ESP32",
+  "ifdef"    : "ESP32",
+  "name"     : "lightSleep",
+  "generate" : "jswrap_ESP32_lightSleep",
+  "params"   : [ ["ms", "int", "Sleep time in milliseconds"] ]
+}
+Enter light sleep for approximately `ms` milliseconds, then resume execution
+here. Unlike deep sleep, RAM and JS state are preserved.
+
+On boards with USB Serial/JTAG console, the USB link drops during sleep;
+reconnect the cable or reopen the serial port. Avoid tools that reset the
+chip on connect (DTR toggle) if you need to verify RAM was preserved.
+
+Stopping WiFi/BLE with `ESP32.enableWifi(false)` and `ESP32.enableBLE(false)`
+before sleeping reduces power draw significantly.
+*/
+void jswrap_ESP32_lightSleep(JsVarInt ms) {
+  if (ms <= 0) return;
+
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+  // ConsoleTask (priority 20) outruns the Espruino task and keeps calling
+  // usb_serial_jtag_read_bytes while USJ pads are gated in light sleep,
+  // which can fault and reset the chip. Pause it for the sleep window.
+  int consoleIdx = task_indexByName("ConsoleTask");
+  if (consoleIdx >= 0) task_Suspend(consoleIdx);
+  vTaskDelay(1); // let ConsoleTask finish its current read slice
+  usb_serial_jtag_ll_txfifo_flush();
+  usb_serial_jtag_driver_uninstall();
+#endif
+
+  esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+  esp_err_t err = esp_sleep_enable_timer_wakeup((uint64_t)ms * 1000ULL);
+  if (err != ESP_OK) {
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+    usb_serial_jtag_driver_config_t usb_cfg = {.tx_buffer_size = 128, .rx_buffer_size = 128};
+    usb_serial_jtag_driver_install(&usb_cfg);
+    if (consoleIdx >= 0) task_Resume(consoleIdx);
+#endif
+    jsExceptionHere(JSET_ERROR, "lightSleep: %d", err);
+    return;
+  }
+
+  err = esp_light_sleep_start();
+
+  /* jsiIdle advances timers using (now - jsiLastIdleTime). While we blocked
+   * here the clock jumped but jsiLastIdleTime did not — the next idle pass
+   * would subtract the full sleep from every setInterval/setTimeout, often
+   * re-firing them in a tight loop until the watchdog resets. */
+  jsiLastIdleTime = jshGetSystemTime();
+
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+  usb_serial_jtag_driver_config_t usb_cfg = {.tx_buffer_size = 128, .rx_buffer_size = 128};
+  usb_serial_jtag_driver_install(&usb_cfg);
+  if (consoleIdx >= 0) task_Resume(consoleIdx);
+#endif
+
+  if (err != ESP_OK &&
+      err != ESP_ERR_SLEEP_TOO_SHORT_SLEEP_DURATION &&
+      err != ESP_ERR_SLEEP_REJECT) {
+    jsExceptionHere(JSET_ERROR, "lightSleep: %d", err);
+  }
+}
 
 
 /*JSON{

--- a/targets/esp32/jswrap_esp32.c
+++ b/targets/esp32/jswrap_esp32.c
@@ -35,10 +35,18 @@
 #include "BLE/esp32_bluetooth_utils.h"
 #endif
 #include "jshardwareESP32.h"
+#include "jshardwareSpi.h"
 
-#include "jsutils.h"
-#include "jsinteractive.h"
-#include "jsparse.h"
+#ifndef ESP_IDF_VERSION_MAJOR
+#define ESP_IDF_VERSION_MAJOR 3
+#endif
+
+#ifndef ESP_ERR_SLEEP_REJECT
+#define ESP_ERR_SLEEP_REJECT ESP_ERR_INVALID_STATE
+#endif
+#ifndef ESP_ERR_SLEEP_TOO_SHORT_SLEEP_DURATION
+#define ESP_ERR_SLEEP_TOO_SHORT_SLEEP_DURATION ESP_ERR_INVALID_ARG
+#endif
 
 /*JSON{
   "type": "class",
@@ -81,7 +89,20 @@ void jswrap_ESP32_reboot() {
 static bool esp32IsValidDeepSleepWakeupPin(Pin pin) {
   gpio_num_t gpio = pinToESP32Pin(pin);
   if (gpio < 0 || gpio >= GPIO_NUM_MAX) return false;
+#if ESP_IDF_VERSION_MAJOR >= 4
   return esp_sleep_is_valid_wakeup_gpio(gpio);
+#else
+  switch (gpio) {
+    case GPIO_NUM_0: case GPIO_NUM_2: case GPIO_NUM_4:
+    case GPIO_NUM_12: case GPIO_NUM_13: case GPIO_NUM_14: case GPIO_NUM_15:
+    case GPIO_NUM_25: case GPIO_NUM_26: case GPIO_NUM_27:
+    case GPIO_NUM_32: case GPIO_NUM_33: case GPIO_NUM_34: case GPIO_NUM_35:
+    case GPIO_NUM_36: case GPIO_NUM_37: case GPIO_NUM_39:
+      return true;
+    default:
+      return false;
+  }
+#endif
 }
 
 static uint64_t esp32DeepSleepGpioMask(Pin pin) {

--- a/targets/esp32/jswrap_esp32.h
+++ b/targets/esp32/jswrap_esp32.h
@@ -26,6 +26,7 @@ void   jswrap_ESP32_deepSleep(int us);
 void   jswrap_ESP32_deepSleep_ext0(Pin pin,int level);
 void   jswrap_ESP32_deepSleep_ext1(JsVar *pinVar, JsVarInt mode);
 int    jswrap_ESP32_getWakeupCause();
+void   jswrap_ESP32_lightSleep(JsVarInt ms);
 void   jswrap_ESP32_setAtten(Pin pin,int atten);
 
 #ifdef BLUETOOTH


### PR DESCRIPTION
ESP32-C3 boards using USB Serial/JTAG for the console cannot light-sleep while the UART0 driver is installed; skip UART0 init when USJ is enabled and tear down/reinstall the USB-JTAG driver around light sleep. Pause ConsoleTask during sleep to avoid faults from reads on gated pads.

Also fix deepSleepExt0/Ext1 wakeup pin validation and GPIO masks on ESP32-C3, and advance jsiLastIdleTime after light sleep so timers do not fire in a tight loop.

## Summary
- Add `ESP32.lightSleep(ms)` — timer wakeup, RAM/JS state preserved; fixes `jsiLastIdleTime` after sleep so `setInterval`/`setTimeout` don't storm
- USB Serial/JTAG console: skip UART0 driver when `ESPR_USE_USB_SERIAL_JTAG` (UART0 blocks light sleep on ESP32-C3); tear down/reinstall USJ driver around sleep; pause `ConsoleTask` to avoid faults on gated pads
- Fix `deepSleepExt0`/`deepSleepExt1` wakeup pin validation and GPIO bitmask on ESP32-C3 (`esp_sleep_is_valid_wakeup_gpio`, `pinToESP32Pin`)
## Files
- `targets/esp32/jswrap_esp32.c` / `.h`
- `targets/esp32/jshardwareUart.c`
## Test plan
- [ ] ESP32-C3 board with `ESPR_USE_USB_SERIAL_JTAG` (e.g. Xteink X4): `ESP32.lightSleep(2000)` returns without watchdog reset; `var x=1; ESP32.lightSleep(2000); x` still `1`
- [ ] `setInterval` callback count sane after light sleep (no tight re-fire loop)
- [ ] `ESP32.deepSleepExt0(D3, 0)` accepts valid C3 GPIO on power button pin
- [ ] Classic UART-console ESP32 board still builds and serial works