### PR TITLE
ESP32: improve ADC reliability and support JSHPINSTATE_ADC_IN

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -326,6 +326,10 @@ void jshPinSetState(
     pull_mode= GPIO_PULLUP_ONLY;
     if (negated) jsError( "jshPinSetState: can't do Open Drain on negated pin");
     break;
+  case JSHPINSTATE_ADC_IN:
+    mode = GPIO_MODE_INPUT;
+    pull_mode = GPIO_FLOATING;
+    break;
   default:
     jsError( "jshPinSetState: Unexpected state: %d", state);
   return;

--- a/targets/esp32/jshardwareAnalog.c
+++ b/targets/esp32/jshardwareAnalog.c
@@ -31,6 +31,17 @@
 #define adc_channel_max 8
 
 adc_atten_t adc_channel[8];
+static bool adc_channel_setup[adc_channel_max];
+static adc_atten_t adc_channel_configured_atten[adc_channel_max];
+
+static void adcEnsureChannelConfigured(adc1_channel_t channel, int idx) {
+  if (idx < 0) return;
+  if (!adc_channel_setup[idx] || adc_channel_configured_atten[idx] != adc_channel[idx]) {
+    adc1_config_channel_atten(channel, adc_channel[idx]);
+    adc_channel_setup[idx] = true;
+    adc_channel_configured_atten[idx] = adc_channel[idx];
+  }
+}
 
 adc1_channel_t pinToAdcChannel(Pin pin){
   adc1_channel_t channel;
@@ -113,6 +124,7 @@ void initADC(int ADCgroup){
 #else
       adc_channel[i] = ADC_ATTEN_11db;
 #endif
+      adc_channel_setup[i] = false;
      }
     break;
   case 2:
@@ -128,22 +140,20 @@ void initADC(int ADCgroup){
 }
 
 void rangeADC(Pin pin,int range){
-  int idx,atten;
-  idx = pinToAdcChannelIdx(pin);
-  printf("idx:%d\n",idx);
+  int idx = pinToAdcChannelIdx(pin);
   if(idx >= 0){
     adc_channel[idx] = rangeToAdcAtten(range);
-    printf("Atten:%d \n",adc_channel[idx]);
+    adc_channel_setup[idx] = false;
   }
 }
 
 int readADC(Pin pin){
-  adc1_channel_t channel; int value;
+  adc1_channel_t channel;
   channel = pinToAdcChannel(pin);
   if(channel >= 0) {
-    adc1_config_channel_atten(channel,adc_channel[pinToAdcChannelIdx(pin)]);
+    int idx = pinToAdcChannelIdx(pin);
+    adcEnsureChannelConfigured(channel, idx);
 #if ESP_IDF_VERSION_MAJOR>=4
-	  // ESP_IDF 4.x - int adc1_get_voltage(adc1_channel_t channel)    //Deprecated. Use adc1_get_raw() instead
 	  int value=adc1_get_raw(channel);
 #if CONFIG_IDF_TARGET_ESP32C3
     // we need to call it twice to get a decent value on the C3 for some reason!
@@ -151,7 +161,7 @@ int readADC(Pin pin){
     value=adc1_get_raw(channel);
 #endif
 #else
-	  value = adc1_get_voltage(channel);
+	  int value = adc1_get_voltage(channel);
 #endif
     return value;
   } else return -1;


### PR DESCRIPTION
Configure ADC channel attenuation once per channel (reconfigure only when range changes) instead of on every readADC call, and remove debug printf from rangeADC. Add JSHPINSTATE_ADC_IN handling in jshPinSetState so board definitions can use pinstate ADC_IN for analog inputs without triggering "Unexpected state" errors.

## Summary

- Add `JSHPINSTATE_ADC_IN` handling in `jshPinSetState()` so board definitions can use `pinstate: ADC_IN` without hitting "Unexpected state" errors (GPIO input, floating pull).
- Improve ESP32 ADC reliability by configuring channel attenuation once per channel via `adcEnsureChannelConfigured()`, reconfiguring only when `rangeADC()` changes attenuation, instead of calling `adc1_config_channel_atten()` on every `readADC()`.
- Remove debug `printf` calls left in `rangeADC()`.

These changes are generic ESP32 improvements (tested in the context of ESP32-C3 resistor-ladder buttons and battery ADC). No board-specific code.

## Test plan

- [ ] Build `BOARD=ESP32C3_IDF4 RELEASE=1` (or any ESP32 IDF4 board with ADC)
- [ ] Flash and connect via Web IDE (USB serial)
- [ ] `analogRead(D1)` / `E.getAnalogVRef()` — values stable across repeated reads
- [ ] Board with `pinstate: ADC_IN` in `.py` (e.g. resistor-ladder buttons) — no "Unexpected state" on boot
- [ ] `ESP32.setAnalog()` / changing attenuation — readings update correctly after range change
- [ ] Classic ESP32 (non-C3) — ADC still works (no regression)

## Related

- Enables reliable ADC for boards using analog buttons / battery monitoring
- Complements #2715 (CUSTOM_GETBATTERY) and #2716 (ESP32 lightSleep)
