### PR TITLE
nRF5x: add support for using second I2C peripheral

### DIFF
--- a/targets/nrf5x/app_config.h
+++ b/targets/nrf5x/app_config.h
@@ -74,8 +74,12 @@
 
 #if ESPR_I2C_COUNT>0
 #define TWI_ENABLED 1
+#define TWI0_ENABLED 1
+#define TWI0_USE_EASY_DMA 0
+#if ESPR_I2C_COUNT>1
 #define TWI1_ENABLED 1
 #define TWI1_USE_EASY_DMA 0
+#endif
 #else
 #define TWI_ENABLED 0
 #endif // ESPR_I2C_COUNT

--- a/targets/nrf5x/jshardware.c
+++ b/targets/nrf5x/jshardware.c
@@ -398,8 +398,12 @@ void spi0EvtHandler(nrf_drv_spi_evt_t const * p_event
 }
 #endif
 #if TWI_ENABLED
+static const nrf_drv_twi_t TWI0 = NRF_DRV_TWI_INSTANCE(0);
+bool twi0Initialised = false;
+#if ESPR_I2C_COUNT > 1
 static const nrf_drv_twi_t TWI1 = NRF_DRV_TWI_INSTANCE(1);
 bool twi1Initialised = false;
+#endif
 #endif
 #ifdef I2C_SLAVE
 static const nrf_drv_twis_t TWIS1 = NRF_DRV_TWIS_INSTANCE(1);
@@ -625,7 +629,10 @@ void spiFlashSleep() {
 
 #if TWI_ENABLED
 const nrf_drv_twi_t *jshGetTWI(IOEventFlags device) {
-  if (device == EV_I2C1) return &TWI1;
+  if (device == EV_I2C1) return &TWI0;
+#if ESPR_I2C_COUNT > 1
+  if (device == EV_I2C2) return &TWI1;
+#endif
   return 0;
 }
 #endif
@@ -731,9 +738,14 @@ static NO_INLINE void jshPinSetFunction_int(JshPinFunction func, uint32_t pin) {
                  break;
 #endif
 #if TWI_ENABLED
-  case JSH_I2C1: if (fInfo==JSH_I2C_SDA) NRF_TWI1->PSELSDA = pin;
+  case JSH_I2C1: if (fInfo==JSH_I2C_SDA) NRF_TWI0->PSELSDA = pin;
+                 else NRF_TWI0->PSELSCL = pin;
+                 break;
+#if ESPR_I2C_COUNT>1
+  case JSH_I2C2: if (fInfo==JSH_I2C_SDA) NRF_TWI1->PSELSDA = pin;
                  else NRF_TWI1->PSELSCL = pin;
                  break;
+#endif
 #endif
   default: assert(0);
   }
@@ -1774,7 +1786,10 @@ bool jshIsDeviceInitialised(IOEventFlags device) {
   if (device==EV_SPI1) return spi0Initialised;
 #endif
 #if TWI_ENABLED
-  if (device==EV_I2C1) return twi1Initialised;
+  if (device==EV_I2C1) return twi0Initialised;
+#if ESPR_I2C_COUNT>1
+  if (device==EV_I2C2) return twi1Initialised;
+#endif
 #endif
 #if ESPR_USART_COUNT>0
   if (DEVICE_IS_USART(device)) return uart[device-EV_SERIAL1].isInitialised;
@@ -2298,8 +2313,19 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
     p_twi_config.frequency =
                       ((inf->bitrate<175000) ? NRF_TWI_FREQ_100K : ((inf->bitrate<325000) ? NRF_TWI_FREQ_250K : NRF_TWI_FREQ_400K));
     p_twi_config.interrupt_priority = APP_IRQ_PRIORITY_LOW;
-    if (twi1Initialised) nrf_drv_twi_uninit(twi);
-    twi1Initialised = true;
+    bool *twiInitialised = &twi0Initialised;
+    switch (device) {
+      case EV_I2C1:
+        twiInitialised = &twi0Initialised;
+        break;
+#if ESPR_I2C_COUNT > 1
+      case EV_I2C2:
+        twiInitialised = &twi1Initialised;
+        break;
+#endif
+    }
+    if (*twiInitialised) nrf_drv_twi_uninit(twi);
+    *twiInitialised = true;
     err_code = nrf_drv_twi_init(twi, &p_twi_config, NULL, NULL);
     if (err_code != NRF_SUCCESS)
       jsExceptionHere(JSET_INTERNALERROR, "I2C Initialisation Error %d", err_code);
@@ -2307,12 +2333,23 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
       nrf_drv_twi_enable(twi);
   }
 #endif
-  // nrf_drv_spi_init will set pins, but this ensures we know so can reset state later
+  // nrf_drv_twi_init will set pins, but this ensures we know so can reset state later
+  JshPinFunction pinFuncDevice = 0;
+  switch (device) {
+    case EV_I2C1:
+      pinFuncDevice |= JSH_I2C1;
+      break;
+#if ESPR_I2C_COUNT > 1
+    case EV_I2C2:
+      pinFuncDevice |= JSH_I2C2;
+      break;
+#endif
+  }
   if (jshIsPinValid(inf->pinSCL)) {
-    jshPinSetFunction(inf->pinSCL, JSH_I2C1|JSH_I2C_SCL);
+    jshPinSetFunction(inf->pinSCL, pinFuncDevice|JSH_I2C_SCL);
   }
   if (jshIsPinValid(inf->pinSDA)) {
-    jshPinSetFunction(inf->pinSDA, JSH_I2C1|JSH_I2C_SDA);
+    jshPinSetFunction(inf->pinSDA, pinFuncDevice|JSH_I2C_SDA);
   }
 }
 #endif

--- a/targets/nrf5x/jshardware.c
+++ b/targets/nrf5x/jshardware.c
@@ -406,7 +406,7 @@ bool twi1Initialised = false;
 #endif
 #endif
 #ifdef I2C_SLAVE
-static const nrf_drv_twis_t TWIS1 = NRF_DRV_TWIS_INSTANCE(1);
+static const nrf_drv_twis_t TWIS0 = NRF_DRV_TWIS_INSTANCE(0);
 static uint8_t twisRxBuf[32]; // receive buffer for I2C slave data
 static uint8_t twisAddr;
 #endif
@@ -638,7 +638,7 @@ const nrf_drv_twi_t *jshGetTWI(IOEventFlags device) {
 #endif
 #ifdef I2C_SLAVE
 const nrf_drv_twis_t *jshGetTWIS(IOEventFlags device) {
-  if (device == EV_I2C1) return &TWIS1;
+  if (device == EV_I2C1) return &TWIS0;
   return 0;
 }
 #endif
@@ -1053,9 +1053,9 @@ void jshKill() {
   spiFlashSleep(); // power down SPI flash to save a few uA
 #endif
 #ifdef I2C_SLAVE
-  if (nrf_drv_twis_is_enabled(TWIS1_INSTANCE_INDEX)) {
-    nrf_drv_twis_disable(&TWIS1);
-    nrf_drv_twis_uninit(&TWIS1);
+  if (nrf_drv_twis_is_enabled(TWIS0_INSTANCE_INDEX)) {
+    nrf_drv_twis_disable(&TWIS0);
+    nrf_drv_twis_uninit(&TWIS0);
   }
 #endif
 }
@@ -2222,9 +2222,9 @@ static void twis_event_handler(nrf_drv_twis_evt_t const * const p_event)
             size_t bufLen;
             char *bufPtr = jsvGetDataPointer(buf, &bufLen);
             if (bufPtr && bufLen>twisAddr)
-              nrf_drv_twis_tx_prepare(&TWIS1, bufPtr + twisAddr, bufLen - twisAddr);
+              nrf_drv_twis_tx_prepare(&TWIS0, bufPtr + twisAddr, bufLen - twisAddr);
             else
-              nrf_drv_twis_tx_prepare(&TWIS1, twisRxBuf, 0);
+              nrf_drv_twis_tx_prepare(&TWIS0, twisRxBuf, 0);
             jsvUnLock2(i2c,buf);
           }
         }
@@ -2235,7 +2235,7 @@ static void twis_event_handler(nrf_drv_twis_evt_t const * const p_event)
         break;
     case TWIS_EVT_WRITE_REQ:
         if (p_event->data.buf_req)
-          nrf_drv_twis_rx_prepare(&TWIS1, twisRxBuf, sizeof(twisRxBuf));
+          nrf_drv_twis_rx_prepare(&TWIS0, twisRxBuf, sizeof(twisRxBuf));
         break;
     case TWIS_EVT_WRITE_DONE:
         if (p_event->data.rx_amount>0) {
@@ -2269,7 +2269,7 @@ static void twis_event_handler(nrf_drv_twis_evt_t const * const p_event)
 }
 #endif
 
-#if TWI_ENABLED || defined(I2C_SLAVE)
+#if TWI_ENABLED
 /** Set up I2C, if pins are -1 they will be guessed */
 void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
   if (!jshIsPinValid(inf->pinSCL) || !jshIsPinValid(inf->pinSDA)) {
@@ -2277,10 +2277,24 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
     return;
   }
   uint32_t err_code;
+  bool *twiInitialised = &twi0Initialised;
+  JshPinFunction pinFuncDevice = 0;
+  switch (device) {
+    case EV_I2C1:
+      twiInitialised = &twi0Initialised;
+      pinFuncDevice |= JSH_I2C1;
+      break;
+#if ESPR_I2C_COUNT > 1
+    case EV_I2C2:
+      twiInitialised = &twi1Initialised;
+      pinFuncDevice |= JSH_I2C2;
+      break;
+#endif
+  }
 #ifdef I2C_SLAVE
-  if ((device == EV_I2C1) && nrf_drv_twis_is_enabled(TWIS1_INSTANCE_INDEX)) {
-    nrf_drv_twis_disable(&TWIS1);
-    nrf_drv_twis_uninit(&TWIS1);
+  if ((device == EV_I2C1) && nrf_drv_twis_is_enabled(TWIS0_INSTANCE_INDEX)) {
+    nrf_drv_twis_disable(&TWIS0);
+    nrf_drv_twis_uninit(&TWIS0);
   }
   if (inf->slaveAddr >=0) {
     const nrf_drv_twis_t *twis = jshGetTWIS(device);
@@ -2301,7 +2315,6 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
       nrf_drv_twis_enable(twis);
   } else
 #endif
-#if TWI_ENABLED
   {
     const nrf_drv_twi_t *twi = jshGetTWI(device);
     if (!twi) return;
@@ -2313,17 +2326,6 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
     p_twi_config.frequency =
                       ((inf->bitrate<175000) ? NRF_TWI_FREQ_100K : ((inf->bitrate<325000) ? NRF_TWI_FREQ_250K : NRF_TWI_FREQ_400K));
     p_twi_config.interrupt_priority = APP_IRQ_PRIORITY_LOW;
-    bool *twiInitialised = &twi0Initialised;
-    switch (device) {
-      case EV_I2C1:
-        twiInitialised = &twi0Initialised;
-        break;
-#if ESPR_I2C_COUNT > 1
-      case EV_I2C2:
-        twiInitialised = &twi1Initialised;
-        break;
-#endif
-    }
     if (*twiInitialised) nrf_drv_twi_uninit(twi);
     *twiInitialised = true;
     err_code = nrf_drv_twi_init(twi, &p_twi_config, NULL, NULL);
@@ -2332,19 +2334,7 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
     else
       nrf_drv_twi_enable(twi);
   }
-#endif
   // nrf_drv_twi_init will set pins, but this ensures we know so can reset state later
-  JshPinFunction pinFuncDevice = 0;
-  switch (device) {
-    case EV_I2C1:
-      pinFuncDevice |= JSH_I2C1;
-      break;
-#if ESPR_I2C_COUNT > 1
-    case EV_I2C2:
-      pinFuncDevice |= JSH_I2C2;
-      break;
-#endif
-  }
   if (jshIsPinValid(inf->pinSCL)) {
     jshPinSetFunction(inf->pinSCL, pinFuncDevice|JSH_I2C_SCL);
   }

--- a/targets/nrf5x/jshardware.c
+++ b/targets/nrf5x/jshardware.c
@@ -2278,19 +2278,19 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *inf) {
   }
   uint32_t err_code;
   bool *twiInitialised = &twi0Initialised;
-  JshPinFunction pinFuncDevice = 0;
+  JshPinFunction pinFuncDevice = JSH_I2C1;
+#if ESPR_I2C_COUNT > 1  
   switch (device) {
     case EV_I2C1:
       twiInitialised = &twi0Initialised;
-      pinFuncDevice |= JSH_I2C1;
+      pinFuncDevice = JSH_I2C1;
       break;
-#if ESPR_I2C_COUNT > 1
     case EV_I2C2:
       twiInitialised = &twi1Initialised;
-      pinFuncDevice |= JSH_I2C2;
+      pinFuncDevice = JSH_I2C2;
       break;
-#endif
   }
+#endif  
 #ifdef I2C_SLAVE
   if ((device == EV_I2C1) && nrf_drv_twis_is_enabled(TWIS0_INSTANCE_INDEX)) {
     nrf_drv_twis_disable(&TWIS0);


### PR DESCRIPTION
This allows using the second I2C peripheral on nRF52840.

While there's `I2C1` and `I2C2`, only `I2C1` actually did something; calling `I2C2.setup()` just returned early without an error message.
I noticed this on a Seeed Xiao BLE, but this should apply to at least JoltJS as well.
(I wanted to use the accelerometer built into the XiaoBLE and connect an I2C display on another pair of pins. Software I2C was too slow and switching `I2C1` between pins didn't seem like a good idea.)

Should work but I'm not sure about the way I did the I2C device specific stuff in `jshI2CSetup()`.
Seems sort of silly (and error prone) to have that switch statement in three different places, but then again I didn't want to change the  signature of `jshGetTWI()` since it's used in other places as well and the other two switch statements are probably sufficiently separated by a `#if TWI_ENABLED` block.

Or should `I2C2` actually work and I've just missed something? 🙈

btw: My Bangle.js 2 still works nicely (well, except for the barometer / temperature sensor that refuses to talk to me) and I'm really looking forward to the Bangle.js 3 which will probably be an insta-buy from me :)