### PR TITLE
Throw SyntaxError for duplicate parameter names in arrow functions

### DIFF
--- a/src/jsparse.c
+++ b/src/jsparse.c
@@ -1580,6 +1580,16 @@ NO_INLINE JsVar *jspeAddNamedFunctionParameter(JsVar *funcVar, JsVar *name) {
     char buf[JSLEX_MAX_TOKEN_LENGTH+1];
     buf[0] = '\xFF';
     jsvGetString(name, &buf[1], JSLEX_MAX_TOKEN_LENGTH);
+    // this is currently only reached while parsing arrow function parameters -
+    // regular 'function' arguments are handled separately by jspeFunctionArguments,
+    // where repeated names are legal in non-strict mode. Arrow functions must
+    // never allow duplicate parameter names, so check for that here.
+    JsVar *existingParam = jsvFindChildFromString(funcVar, buf);
+    if (existingParam) {
+      jsvUnLock(existingParam);
+      jsExceptionHere(JSET_SYNTAXERROR, "Duplicate parameter name not allowed in this context");
+      return funcVar;
+    }
     JsVar *param = jsvAddNamedChild(funcVar, 0, buf);
     param = jsvMakeFunctionParameter(param);
     jsvUnLock(param);


### PR DESCRIPTION
Fixes #2544.

Arrow functions currently accept duplicate parameter names without complaining, e.g. `(a, a) => a` just parses and runs, silently keeping only the first `a` (calling it with two arguments returns the first one, not the second). Every other engine (V8/Node, QuickJS, Hermes, Deno) throws a SyntaxError here, since unlike sloppy-mode `function` declarations, arrow functions are never allowed to repeat a parameter name.

The reason is that `jspeAddNamedFunctionParameter()` in jsparse.c (used when building up an arrow function's parameter list) just calls `jsvAddNamedChild()` for every parameter name it sees, with nothing checking whether that name was already added. So `(a, a) => {}` happily adds two separate children both named `a` to the function var.

I traced where this function is actually called from and it turns out it's only ever used for arrow function parameters (single-param `a => ...` and the parenthesised list before `=>`) - regular `function(a, b)` parameters go through a completely separate path, `jspeFunctionArguments()`, which is right to allow duplicates in non-strict mode. So the fix is just to check for an existing parameter of the same name inside `jspeAddNamedFunctionParameter()` before adding it, and throw a SyntaxError if found - no need to touch the plain-function path at all.

Built the Linux target and confirmed the before/after behaviour directly:
- `(a, a) => 1` now throws `SyntaxError: Duplicate parameter name not allowed in this context` (previously ran with no error)
- normal arrow functions (`a => a+1`, `(a, b) => a+b`, `x => x*2`, differently-cased params like `(a, A) => a+A`) are unaffected
- `(function(a, a) { return a; })` (plain function, sloppy-mode duplicate) still works exactly as before, since it doesn't go through this code path
- ran the full `tests/` suite before and after the change - same 383/400 pass, same set of pre-existing failures (all unrelated networking tests plus a couple of tests that are named `_FAIL` on purpose)
