### PR TITLE
ESP32 IDF5: fix WiFi debug build

### DIFF
--- a/libs/network/esp32/jswrap_esp32_network.c
+++ b/libs/network/esp32/jswrap_esp32_network.c
@@ -564,7 +564,11 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
     g_isAPStarted = false;
     stopWifiIfIdle();
   } else
+#if ESP_IDF_VERSION_MAJOR>=5
+    jsDebug(DBG_INFO, "Wifi: event_handler -> NOT HANDLED EVENT: %d\n", event_id );
+#else
     jsDebug(DBG_INFO, "Wifi: event_handler -> NOT HANDLED EVENT: %d\n", event->event_id );
+#endif
 #if ESP_IDF_VERSION_MAJOR<5
   return ESP_OK;
 #endif


### PR DESCRIPTION
The ESP32 IDF5 Wi-Fi event callback receives the event number in the event_id argument. Its unhandled-event debug message instead referenced event->event_id, which belongs to the callback used with older ESP-IDF versions.

Normal release builds did not expose the problem because jsDebug() and its arguments are removed when debug output is disabled. A debug-enabled ESP32_IDF5 build compiled the expression and failed because event is not defined in the IDF5 callback.

**Fix**
Select the event expression appropriate to the ESP-IDF callback:

IDF5 and later use event_id;
earlier IDF versions retain event->event_id.
This changes only the unhandled-event diagnostic. It does not change Wi-Fi event handling in a normal release build.

**Validation**
Using ESP-IDF 5.5.3 and BOARD=ESP32_IDF5:

clean debug-enabled release build with DEBUG=1 RELEASE=1: pass;
clean standard release build with RELEASE=1: pass;
release firmware flashed to the classic ESP32 V1 bench: pass;
boot and USB-UART REPL connection: pass;
reported commit: 75210faca;
basic Espruino digitalWrite()/digitalRead() loopback test: 4/4 pass.