### PR TITLE
ESP32: initialise the complete I2C configuration

### DIFF
--- a/targets/esp32/jshardwareI2c.c
+++ b/targets/esp32/jshardwareI2c.c
@@ -110,7 +110,7 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *info) {
           funcTypeStr, info->pinSDA, info->pinSCL);
   #endif
 
-  i2c_config_t conf;
+  i2c_config_t conf = {0};
   conf.mode = I2C_MODE_MASTER;
   conf.sda_io_num = pinToESP32Pin(info->pinSDA);
   conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
@@ -118,10 +118,8 @@ void jshI2CSetup(IOEventFlags device, JshI2CInfo *info) {
   conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
   conf.master.clk_speed = info->bitrate;
   
-  #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)     // added to resolve issue #2589 for IDF v4.x
-    conf.clk_flags = 0;     // will always select 2MZ XTAL clock - Although speed set as in conf.master.clk_speed
-    // conf.clk_flags = 1;  // or set driver to ignore XTAL clock and use 1MHz RTC clock (better for low power?)
-    // ref https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32s3/api-reference/peripherals/i2c.html#source-clock-configuration
+  #if ESP_IDF_VERSION_MAJOR >= 4
+    conf.clk_flags = 0; // select the default I2C clock source
   #endif
                     
   esp_err_t err=i2c_param_config(i2c_master_port, &conf);


### PR DESCRIPTION
### Issue

The ESP32 I2C setup path declared its local `i2c_config_t` without
initialising it. It then set `clk_flags` only when compiling for ESP32-C3 or
ESP32-S3. On the classic ESP32 IDF5 target, `clk_flags` and any other fields
not explicitly assigned therefore contained indeterminate stack data.

On the tested classic ESP32 IDF5 build, Espruino `I2C1.setup()` could fail
before any I2C transaction was attempted.

### Fix

Zero-initialise the complete `i2c_config_t`, then set `clk_flags` to select the
default I2C clock source for ESP-IDF 4 and later on every ESP32-family target.

This removes the target-specific gap and ensures that fields introduced by
newer ESP-IDF versions always start from defined values.

### Validation

The exact I2C patch in this standalone branch was built and tested as part of
the staged classic ESP32 IDF5 candidate using ESP-IDF 5.5.3 and
`BOARD=ESP32_IDF5`:

- clean standard release build: pass;
- firmware flash, boot and USB-UART REPL connection: pass;
- reported staged commit: `26d927e64`;
- `I2C1.setup({scl:D22,sda:D21,bitrate:100000})`: pass;
- MCP23008 at address `0x20`, using `I2C.writeTo()` and `I2C.readFrom()` for
  register readback plus GPIO feedback: 6/6 pass;
- secondary MCP23008 at address `0x21`, including register changes, restoration
  and isolation from the first device: 8/8 pass;
- MCP23008 interrupt status/capture and interrupt clearing over I2C: pass.

