### PR TITLE
ESP32 IDF5: restore analogue input

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -439,30 +439,20 @@ bool CALLED_FROM_INTERRUPT jshPinGetValue( // can be called at interrupt time
 
 
 JsVarFloat jshPinAnalog(Pin pin) {
-#if ESP_IDF_VERSION_MAJOR >= 5
-  jsError("jshPinAnalog(Pin pin) is not implemented yet");
-  return NAN;
-#else
   if (pinInfo[pin].analog == JSH_ANALOG_NONE)
     return NAN;
   JsVarFloat v = (JsVarFloat) readADC(pin) / 4096;
   if (pinInfo[pin].port & JSH_PIN_NEGATED) v=1-v;
   return v;
-#endif
 }
 
 
 int jshPinAnalogFast(Pin pin) {
-#if ESP_IDF_VERSION_MAJOR >= 5
-  jsError("jshPinAnalogFast(Pin pin) is not implemented yet");
-  return NAN;
-#else
   if (pinInfo[pin].analog == JSH_ANALOG_NONE)
     return 0;
   int v = readADC(pin) << 4;
   if (pinInfo[pin].port & JSH_PIN_NEGATED) v=65535-v;
   return v;
-#endif
 }
 
 


### PR DESCRIPTION
### Issue

The ESP32 hardware layer explicitly disabled both analogue-input functions
when compiling with ESP-IDF 5 or later. `analogRead()` therefore reported that
`jshPinAnalog()` was not implemented and returned `NaN`, even though the
classic ESP32 ADC backend and its initialisation path are present in the IDF5
build.

The same guard also disabled the fast analogue-input path used internally by
Espruino.

### Fix

Remove the IDF5-only stubs from `jshPinAnalog()` and `jshPinAnalogFast()` so
that IDF5 uses the existing ESP32 `readADC()` implementation, including the
normal pin validation, scaling and inverted-pin handling.

The correction removes ten preprocessor/stub lines and changes no ADC
conversion logic.

### Validation

The correction was built using ESP-IDF 5.5.3 with:

`BOARD=ESP32_IDF5 RELEASE=1`

The same patch was included in the final classic ESP32 IDF5 validation image
and tested on an ESP32 DevKitC V4.

Using an output pin connected to an ADC-capable input, Espruino `analogRead()`
produced:

- driven low: `0`;
- driven high: approximately `0.9998`;
- four assertions passed out of four.

The corrected source was also built and tested using the existing
`BOARD=ESP32` configuration. The analogue-input test passed, providing
compatibility evidence for the existing classic ESP32 build.

The rebased commit has the same stable patch ID as the exact patch exercised
in the combined validation image:
`187035eeb9c5769a5e6ec24d0867a616c0a02693`.