### PR TITLE
ESP32 IDF5: restore GPIO output after peripheral use

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -416,7 +416,7 @@ void jshPinSetValue(
   if (pinInfo[pin].port & JSH_PIN_NEGATED) value=!value;
   gpio_num_t gpioNum = pinToESP32Pin(pin);
 #if ESP_IDF_VERSION_MAJOR>=5
-  gpio_iomux_out(gpioNum, SIG_GPIO_OUT_IDX, 0); // reset pin to be GPIO in case it was used as rmt or something else
+  esp_rom_gpio_connect_out_signal(gpioNum, SIG_GPIO_OUT_IDX, false, false); // reset pin to be GPIO in case it was used as rmt or something else
 #else
   gpio_matrix_out(gpioNum,SIG_GPIO_OUT_IDX,0,0);  // reset pin to be GPIO in case it was used as rmt or something else
 #endif


### PR DESCRIPTION
### Issue

`jshPinSetValue()` must reconnect the ordinary GPIO output signal before
driving a pin that may previously have been assigned to PWM, RMT, UART or
another peripheral.

The IDF5 path called `gpio_iomux_out()` with `SIG_GPIO_OUT_IDX`. In ESP-IDF 5,
the second argument to `gpio_iomux_out()` is an IO-MUX function number, not a
GPIO-matrix signal index. It therefore did not perform the same operation as
the earlier `gpio_matrix_out()` call.

This could leave `digitalWrite()` unable to take control of a pin after
peripheral output use.

### Fix

Use `esp_rom_gpio_connect_out_signal()` to reconnect `SIG_GPIO_OUT_IDX` to the
pin under IDF5.

This is the ESP-IDF 5 form of the GPIO-matrix operation used by the earlier
build path. On the classic ESP32 it resolves to `gpio_matrix_out`.

The correction changes one line in `jshPinSetValue()`.

### Validation

The correction was built using ESP-IDF 5.5.3 with:

`BOARD=ESP32_IDF5 RELEASE=1`

The same patch was included in the final classic ESP32 IDF5 validation image
and tested on an ESP32 DevKitC V4.

The tests assigned peripheral output functions to pins and then returned those
pins to ordinary GPIO use:

- PWM output was followed by `digitalWrite()` and then returned to PWM;
- an external MCP3008 independently observed low, high and intermediate output
  levels; all 11 assertions passed;
- after DAC use, the output pin again passed ordinary
  `digitalWrite()`/`digitalRead()` checks;
- `digitalPulse()` and `setWatch()` correctly observed the connected GPIO edge
  sequence after peripheral use;
- the broader GPIO regression passed `digitalWrite()`/`digitalRead()` 4/4,
  `digitalPulse()` 3/3, `shiftOut()` 3/3 and watch handling 4/4.

The corrected source was also built and tested using the existing
`BOARD=ESP32` configuration. The GPIO and peripheral-output checks passed,
providing compatibility evidence for the existing classic ESP32 build.

The rebased commit has the same stable patch ID as the exact patch exercised
in the combined validation image:
`526d2baa4dd2e9af6538652ceba522b24c31f7c0`.