### PR TITLE
ESP32 IDF5: restore PWM and DAC output

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -480,7 +480,7 @@ JshPinFunction jshPinAnalogOutput(Pin pin,
   if (!isfinite(freq)) freq=0;
   if(pin == 25 || pin == 26){
   if(flags & (JSAOF_ALLOW_SOFTWARE | JSAOF_FORCE_SOFTWARE)) jsError("pin does not support software PWM");
-    writeDAC(pin,(uint8_t)(value * 256));
+    writeDAC(pin,(uint8_t)(value * 255));
   }
   else{
   if(flags & JSAOF_ALLOW_SOFTWARE){

--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -473,9 +473,6 @@ JshPinFunction jshPinAnalogOutput(Pin pin,
     JsVarFloat value,
     JsVarFloat freq,
     JshAnalogOutputFlags flags) { // if freq<=0, the default is used
-#if ESP_IDF_VERSION_MAJOR >= 5
-    jsError("writeDAC() is not implemented yes");
-#else
   UNUSED(flags);
   if (pinInfo[pin].port & JSH_PIN_NEGATED) value=1-value;
   if (value<0) value=0;
@@ -498,7 +495,6 @@ JshPinFunction jshPinAnalogOutput(Pin pin,
     }
     else writePWM(pin,( uint16_t)(value * PWMTimerRange),(int) freq);
   }
-#endif
   return 0;
 }
 
@@ -507,9 +503,6 @@ JshPinFunction jshPinAnalogOutput(Pin pin,
  *
  */
 void jshSetOutputValue(JshPinFunction func, int value) {
-#if ESP_IDF_VERSION_MAJOR >= 5
-    jsError("writeDAC() is not implemented yes");
-#else
   int pin;
   if (JSH_PINFUNCTION_IS_DAC(func)) {
     uint8_t val = (uint8_t)(value >> 8);
@@ -524,7 +517,6 @@ void jshSetOutputValue(JshPinFunction func, int value) {
     value=value >> (16 - PWMTimerBit);
     setPWM( (Pin)pin, (uint16_t)value);
   }
-#endif
 }
 
 void jshEnableWatchDog(JsVarFloat timeout) {

--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -334,6 +334,7 @@ void jshPinSetState(
   Pin pin,                 //!< The pin to have its state changed.
     JshPinState state        //!< The new desired state of the pin.
   ) {
+  if (pin == 25 || pin == 26) disableDAC(pin);
   /* Make sure we kill software PWM if we set the pin state
    * after we've started it */
   if (BITFIELD_GET(jshPinSoftPWM, pin)) {
@@ -413,6 +414,7 @@ void jshPinSetValue(
     Pin pin,   //!< The pin to have its value changed.
     bool value //!< The new value of the pin.
   ) {
+  if (pin == 25 || pin == 26) disableDAC(pin);
   if (pinInfo[pin].port & JSH_PIN_NEGATED) value=!value;
   gpio_num_t gpioNum = pinToESP32Pin(pin);
 #if ESP_IDF_VERSION_MAJOR>=5

--- a/targets/esp32/jshardwareAnalog.c
+++ b/targets/esp32/jshardwareAnalog.c
@@ -176,7 +176,10 @@ void writeDAC(Pin pin,uint8_t value){
 #if CONFIG_IDF_TARGET_ESP32
   channel = pinToDacChannel(pin);
 #if ESP_IDF_VERSION_MAJOR>=4
-  if(channel >= 0) dac_output_voltage(channel, value);
+  if(channel >= 0) {
+    dac_output_enable(channel);
+    dac_output_voltage(channel, value);
+  }
 #else
   if(channel >= 0) dac_out_voltage(channel, value);
 #endif
@@ -188,6 +191,5 @@ void writeDAC(Pin pin,uint8_t value){
 	#error Not an ESP32 or ESP32-S3
 #endif
 }
-
 
 

--- a/targets/esp32/jshardwareAnalog.c
+++ b/targets/esp32/jshardwareAnalog.c
@@ -18,6 +18,7 @@
 #include "driver/adc.h"
 #if CONFIG_IDF_TARGET_ESP32
 	#include "driver/dac.h"
+	#include "driver/rtc_io.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
 	typedef enum { DAC_CHAN_0=0 , DAC_CHAN_1=1 } dac_channel_t;
 #elif CONFIG_IDF_TARGET_ESP32S3
@@ -192,4 +193,14 @@ void writeDAC(Pin pin,uint8_t value){
 #endif
 }
 
-
+void disableDAC(Pin pin){
+#if CONFIG_IDF_TARGET_ESP32
+  dac_channel_t channel = pinToDacChannel(pin);
+  if(channel >= 0) {
+    dac_output_disable(channel);
+    rtc_gpio_deinit((gpio_num_t)pin);
+  }
+#else
+  UNUSED(pin);
+#endif
+}

--- a/targets/esp32/jshardwareAnalog.h
+++ b/targets/esp32/jshardwareAnalog.h
@@ -23,3 +23,4 @@ int readADC(Pin pin);
 void rangeADC(Pin pin,int range);
 
 void writeDAC(Pin pin,uint8_t value);
+void disableDAC(Pin pin);


### PR DESCRIPTION
### Issue

The ESP32 hardware layer explicitly disabled `jshPinAnalogOutput()` and
`jshSetOutputValue()` for ESP-IDF 5. Espruino `analogWrite()` therefore
reported that analogue output was not implemented instead of using the
existing ESP32 PWM or DAC backends.

Three DAC details also prevented correct and reusable output:

- the IDF4/IDF5 path wrote a voltage before enabling the selected DAC channel;
- multiplying Espruino's inclusive value `1` by 256 wrapped to zero when cast
  to `uint8_t`;
- disabling the DAC channel alone did not release the pin from the RTC IO mux,
  so later `digitalWrite()` or `digitalPulse()` could not reliably take
  control.

### Fix

- Remove the IDF5-only stubs so `analogWrite()` and subsequent value updates
  use the existing PWM/DAC implementations.
- Enable a valid DAC channel before writing its voltage.
- Scale the inclusive `0..1` value to `0..255`, preserving full scale.
- When a DAC pin is returned to ordinary GPIO use, disable its DAC channel and
  call `rtc_gpio_deinit()` to return it to the digital IO mux.

The three commits keep path restoration, endpoint correction and pin teardown
individually reviewable.

### Relationship to the GPIO-matrix PR

This PR should be reviewed after the GPIO-matrix restoration PR:

`ESP32 IDF5: restore GPIO output after peripheral use`

The DAC teardown in this PR releases the DAC channel and RTC IO mux. The
GPIO-matrix PR performs the complementary reconnection of the ordinary GPIO
output signal.

### Validation

The exact three-commit branch was built using ESP-IDF 5.5.3 with:

`BOARD=ESP32_IDF5 RELEASE=1`

Build result:

- generated Espruino version: `2v29.69`;
- application size: `0x169d10`;
- 28% of the application partition remained free;
- firmware binary SHA-256:
  `3f9b3c2e7d1b5f62305a858c954c7e06638b0effc6d2856f3bb0fa7401128cc3`.

The same three patches, together with the GPIO-matrix correction, were included
in the final classic ESP32 IDF5 validation image and tested on an ESP32
DevKitC V4:

- PWM requests of 0.25, 0.5 and 0.75 produced ordered analogue feedback; 5/5
  assertions passed;
- an external MCP3008 independently confirmed useful low, midpoint and high
  PWM levels as part of an 11/11 test;
- `analogWrite(D25,0)` and `analogWrite(D25,1)` produced low and high feedback
  respectively on connected pin D26; 2/2 assertions passed;
- after DAC use, the D25/D26 pair again passed ordinary GPIO read/write,
  `digitalPulse()` and `setWatch()` checks.

Calling `dac_output_disable()` without `rtc_gpio_deinit()` had failed the GPIO
reuse check. Adding the RTC IO release produced the passing result.

The corrections were also included in a legacy `BOARD=ESP32 RELEASE=1` build.
ADC, PWM, DAC and GPIO-after-DAC checks passed, providing compatibility
evidence for the existing classic ESP32 build.

The three stable patch IDs match the exact commits exercised in the combined
validation image:

- path restoration:
  `54bb1737ff101f1e68d0d5a193efcd1b5ac8ecd6`;
- DAC enable and full scale:
  `6c21b8bf66393a617654f2ed89f5917b65f93e34`;
- DAC teardown and RTC mux release:
  `0ae3312db6e0c9c58fab8915d11822d00664bd37`.