### PR TITLE
ESP32: support undefined pin state during cleanup

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -344,6 +344,9 @@ void jshPinSetState(
   gpio_pull_mode_t pull_mode=GPIO_FLOATING;
   bool negated = pinInfo[pin].port & JSH_PIN_NEGATED;
   switch(state) {
+  case JSHPINSTATE_UNDEFINED:
+    mode = GPIO_MODE_DISABLE;
+    break;
   case JSHPINSTATE_GPIO_OUT:
     mode = GPIO_MODE_INPUT_OUTPUT;
     break;


### PR DESCRIPTION
### Issue

Espruino uses `JSHPINSTATE_UNDEFINED` when a peripheral releases its pins.

The ESP32 implementation of `jshPinSetState()` did not handle that state.
Cleanup operations such as `Serial.unsetup()` therefore fell through to the
default case and reported:

`jshPinSetState: Unexpected state: 0`

The message was caused by a missing valid cleanup-state mapping, not by an
invalid JavaScript API request.

### Fix

Map `JSHPINSTATE_UNDEFINED` to ESP-IDF `GPIO_MODE_DISABLE`.

This releases the pin without selecting an input or output function and avoids
treating normal peripheral cleanup as an error.

The correction adds one three-line switch case.

### Validation

The correction was built using ESP-IDF 5.5.3 with:

`BOARD=ESP32_IDF5 RELEASE=1`

The same patch was included in the final classic ESP32 IDF5 validation image
and tested on an ESP32 DevKitC V4:

- raw `Serial.setup()`/`Serial.unsetup()` output contained no
  `jshPinSetState: Unexpected state: 0` diagnostic;
- `Serial.isConnected()` returned `false`, `true`, then `false` before setup,
  after setup and after `unsetup()` respectively;
- UART data transfer, reconfiguration, listener and cleanup tests completed
  without the previous pin-state diagnostic.

Current ESP32 master emitted the diagnostic during the same cleanup path.

The corrected source was also built and tested using the existing
`BOARD=ESP32 RELEASE=1` configuration. `Serial.unsetup()` completed without
the diagnostic, providing compatibility evidence for the existing classic
ESP32 build.

The rebased commit has the same stable patch ID as the exact patch exercised
in the combined validation image:
`1bac1b958d41f35d9400863513ed8da37a6996a3`.