### PR TITLE
ESP32: fix legacy WiFi debug build after IDF5 merge

### DIFF
--- a/libs/network/esp32/jswrap_esp32_network.c
+++ b/libs/network/esp32/jswrap_esp32_network.c
@@ -405,7 +405,11 @@ static void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t e
 static esp_err_t event_handler(void *ctx, system_event_t *event) {
   UNUSED(ctx);
 #endif
+#if ESP_IDF_VERSION_MAJOR>=5
   jsDebug(DBG_INFO, "Event: %s (%d)\n", event_base == WIFI_EVENT ? wifiEventToString(event_id) : "OTHER", event_id);
+#else
+  jsDebug(DBG_INFO, "Wifi: Event(%d):SYSTEM_EVENT_%s\n", event->event_id, wifiEventToString(event->event_id));
+#endif
 #if ESP_IDF_VERSION_MAJOR>=5
   if (event_base == WIFI_EVENT && event_id >= WIFI_EVENT_MAX) {
     jsDebug(DBG_INFO, "Internal event ");


### PR DESCRIPTION
## Issue

As part of the IDF5 change, the shared ESP32 WiFi event handler needs separate 
callback arguments for ESP-IDF 5 and legacy ESP-IDF builds, when built with DEBUG.  Somehow this got lost in the merge and results in build errors.  Normal release builds do not expose this so ACTION checks look ok.    

<img width="1138" height="504" alt="Screenshot from 2026-09-04 09-59-39" src="https://github.com/user-attachments/assets/ee07dd3e-07b6-495f-b9a7-abba1a2b15de" />

## Suggest fix is in this PR
Guard based upon IDF. 

## Testing

Built the classic ESP32 port with debug logging explicitly enabled:

```bash
source scripts/provision.sh ESP32
make BOARD=ESP32 clean
DEBUG=1 make BOARD=ESP32 RELEASE=1
```
