### PR TITLE
ESP32 IDF5: reserve 70KB native heap

### DIFF
--- a/boards/ESP32_IDF5.py
+++ b/boards/ESP32_IDF5.py
@@ -52,7 +52,7 @@ info = {
  'espruino_page_link'       : 'ESP32',
  'default_console'          : "EV_SERIAL1",
  'default_console_baudrate' : "115200",
- 'variables'                : 0, # See note above
+ 'variables'                : 16383, # See note above
  'io_buffer_size'           : 4096, # How big is the input buffer (in bytes). Default on nRF52 is 1024
  'binary_name'              : 'espruino_%v_esp32.bin',
  'build' : {
@@ -72,9 +72,8 @@ info = {
    'makefile' : [
      'DEFINES+=-DESP_PLATFORM -DESP32=1',
      'DEFINES+=-DESP_STACK_SIZE=25000',
-#     'DEFINES+=-DJSVAR_CACHE_SIZE=20',
-#     'DEFINES+=-DJSVAR_MALLOC', # Allocate space for variables at jsvInit time
-     'DEFINES+=-DRESIZABLE_JSVARS=1',
+     'DEFINES+=-DESP_HEAP_SIZE=70000', # enough for HTTPS and IDF5 networking tasks
+     'DEFINES+=-DJSVAR_MALLOC', # Allocate space for variables at jsvInit time
      'DEFINES+=-DUSE_FONT_6X8',
      'ESP32_FLASH_MAX=1572864'
    ]


### PR DESCRIPTION
fixes memory allocation to enable space for wifi and other idf5 fixes  see #2746

## Summary

Adjust the `ESP32_IDF5` board definition to retain 70 KB of native ESP-IDF
heap while using a fixed startup JsVar allocation.

This PR is intentionally limited to `boards/ESP32_IDF5.py` and does not include any Wi-Fi/ping implementation changes.

## Change

- set `variables` to `16383`;
- enable `JSVAR_MALLOC`;
- remove `RESIZABLE_JSVARS`;
- set `ESP_HEAP_SIZE` to `70000`.

## Reason

The previous `ESP32_IDF5` configuration allowed the initial JsVar allocation
to consume nearly all available memory, leaving insufficient native ESP-IDF
heap headroom when Wi-Fi and Bluetooth were active together.

A controlled comparison showed:

| Configuration | BLE + HTTPS runs | Native heap low-water mark |
|---|---:|---:|
| 40 KB reserve | 3 of 3 completed | 1,900–3,840 bytes |
| 70 KB reserve | 3 of 3 completed | 30,736–30,900 bytes |

The 70 KB configuration therefore provided approximately 30 KB more native
heap headroom. Its cost was 2,143 fewer available JsVars, corresponding to
approximately 30,002 bytes at 14 bytes per JsVar.

## Validation

- clean release build completed with `BOARD=ESP32_IDF5`;
- ESP-IDF version: 5.5.3;
- controlled BLE-connected HTTPS workload completed three times with both
  the 40 KB comparator and proposed 70 KB configuration;
- Wi-Fi and BLE remained operational throughout the 70 KB tests;
- no resets, allocation failures or connection losses were observed.
